### PR TITLE
Fix f-string and remove forced crash in 15-Thermal-convection-with-units.py (release candidate)

### DIFF
--- a/docs/beginner/tutorials/15-Thermal-convection-with-units.py
+++ b/docs/beginner/tutorials/15-Thermal-convection-with-units.py
@@ -302,7 +302,7 @@ adv_diff.solve(timestep=delta_t , zero_init_guess=True)
 # Null space ?
 
 for step in range(0, max_steps):
-    print(f"Timestep: {timestep}, dt: {delta_t.to("Myr")}, time: {elapsed_time}")
+    print(f"Timestep: {timestep}, dt: {delta_t.to('Myr')}, time: {elapsed_time}")
     
     stokes.solve(zero_init_guess=True)
     delta_t = 2 * adv_diff.estimate_dt()
@@ -314,7 +314,7 @@ for step in range(0, max_steps):
 
 
 # %%
-0/0
+#0/0 
 
 # %%
 # visualise it


### PR DESCRIPTION
- Corrected f-string syntax in timestep print statement to prevent SyntaxError.
- Commented out intentional 0/0 crash so the tutorial runs to completion.
- Changes based on uw3-release-candidate branch as requested.
