### PR TITLE
Fix CI abort: skip PyVista Plotter test on headless runners

### DIFF
--- a/src/underworld3/materials.py
+++ b/src/underworld3/materials.py
@@ -297,7 +297,7 @@ class MaterialRegistry:
         Parameters
         ----------
         callback : callable
-            Function called as callback(event_type, \*args)
+            Function called as ``callback(event_type, *args)``
         """
         self._callbacks.append(callback)
 

--- a/src/underworld3/model.py
+++ b/src/underworld3/model.py
@@ -124,7 +124,7 @@ class Model(PintNativeModelMixin, BaseModel):
         ----------
         name : str, optional
             Human-readable name for this model instance
-        \*\*kwargs : dict
+        **kwargs : dict
             Additional arguments for Pydantic BaseModel
         """
         # Handle name generation before calling super().__init__
@@ -540,7 +540,7 @@ class Model(PintNativeModelMixin, BaseModel):
             Parameter path (e.g., 'material.viscosity', 'solver.tolerance')
         ptype : ParameterType, optional
             Parameter type for validation (not used yet)
-        \*\*kwargs : dict
+        **kwargs : dict
             Additional arguments
         """
         # TODO: Implement when parameter system is ready
@@ -592,7 +592,7 @@ class Model(PintNativeModelMixin, BaseModel):
             [0-1] space while user-facing values remain in physical units.
             Set to False for expert mode (dimensional units only, no scaling).
             Disabling this may cause numerical conditioning issues.
-        \*\*quantities : dict
+        **quantities : dict
             Named reference quantities using Pint units or UWQuantity objects,
             e.g. ``domain_depth=uw.quantity(2900, "km")``.
 

--- a/tests/test_0800_optional_modules.py
+++ b/tests/test_0800_optional_modules.py
@@ -49,6 +49,15 @@ HAS_PYPROJ = check_module_available("pyproj")
 HAS_GDAL = check_module_available("osgeo.gdal")
 HAS_GEOPANDAS = check_module_available("geopandas")
 HAS_PYVISTA = check_module_available("pyvista")
+
+# Check if a display server is available for rendering.
+# On headless CI (no DISPLAY, no WAYLAND), pyvista.Plotter() calls
+# VTK's OpenGL probe which aborts the entire process — not catchable
+# with try/except. We must skip rendering tests before they run.
+import os
+HAS_DISPLAY = bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY")
+                    or os.environ.get("PYVISTA_OFF_SCREEN"))
+HAS_PYVISTA_RENDERING = HAS_PYVISTA and HAS_DISPLAY
 HAS_TRAME = check_module_available("trame")
 
 # Composite feature flags
@@ -96,6 +105,11 @@ requires_cartopy = pytest.mark.skipif(
 requires_pyvista = pytest.mark.skipif(
     not HAS_PYVISTA,
     reason="Requires pyvista. Install with: pixi install -e runtime"
+)
+
+requires_pyvista_rendering = pytest.mark.skipif(
+    not HAS_PYVISTA_RENDERING,
+    reason="Requires pyvista and a display server (DISPLAY or PYVISTA_OFF_SCREEN)"
 )
 
 requires_amr = pytest.mark.skipif(
@@ -233,12 +247,12 @@ class TestVisualizationFeatures:
             sphere = pv.Sphere()
             assert sphere is not None
 
-    @requires_pyvista
+    @requires_pyvista_rendering
     def test_pyvista_plotter_available(self):
         """Test pyvista plotter when available."""
         import pyvista as pv
 
-        # Just verify we can create a plotter (off-screen)
+        pv.OFF_SCREEN = True
         plotter = pv.Plotter(off_screen=True)
         assert plotter is not None
         plotter.close()


### PR DESCRIPTION
## Summary

- `test_pyvista_plotter_available` creates a `pv.Plotter(off_screen=True)` which calls VTK's OpenGL probe — this **aborts the entire process** on headless GitHub Actions runners (no `DISPLAY`). The abort kills the `test_08*` pytest session (334 tests), masking all results from that batch.
- Added `HAS_DISPLAY` check using `DISPLAY`, `WAYLAND_DISPLAY`, or `PYVISTA_OFF_SCREEN` environment variables. Plotter tests skip when no display is available.
- Fixed `\*\*kwargs` escape sequences in `model.py` and `materials.py` docstrings (Python 3.12+ SyntaxWarning).

## Test plan

- [x] `test_0800_optional_modules.py` passes locally (10 passed, 4 skipped)
- [x] Plotter test correctly skipped when no display available
- [x] Docstring escape warnings eliminated
- [ ] CI should now pass all 334 tests in the `test_08*` batch (instead of aborting)

Underworld development team with AI support from Claude Code