### PR TITLE
Fix essential BCs on wrapped imported DMPlex meshes

### DIFF
--- a/examples/stokes_imported_box_essential_bc.py
+++ b/examples/stokes_imported_box_essential_bc.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+
+# %%
+# Demonstrate essential BC registration on a wrapped imported DMPlex.
+#
+# Before the fix, this script crashes in stokes.solve() because the imported
+# mesh exposes generic Gmsh labels (Face Sets / Cell Sets) rather than named
+# boundary labels such as Bottom / Top / Left / Right.
+# After the fix, the same solve succeeds because essential BCs are registered
+# on the consolidated UW_Boundaries label.
+
+# %%
+from enum import Enum
+from pathlib import Path
+import tempfile
+
+import gmsh
+import numpy as np
+from petsc4py import PETSc
+import sympy as sp
+
+import underworld3 as uw
+from underworld3.systems import Stokes
+
+
+# %%
+CELLSIZE = 0.25
+MESH_PATH = Path(tempfile.gettempdir()) / "uw3_imported_box_essential_bc.msh"
+
+
+class boundaries_2D(Enum):
+    Bottom = 11
+    Top = 12
+    Right = 13
+    Left = 14
+    Elements = 666
+    Null_Boundary = 666
+    All_Boundaries = 1001
+
+
+class boundary_normals_2D(Enum):
+    Bottom = sp.Matrix([0, 1])
+    Top = sp.Matrix([0, 1])
+    Right = sp.Matrix([1, 0])
+    Left = sp.Matrix([1, 0])
+
+
+# %%
+def build_box_mesh(mesh_path: Path, cellsize: float) -> None:
+    gmsh.initialize()
+    gmsh.option.setNumber("General.Verbosity", 0)
+    gmsh.model.add("uw3_imported_box_essential_bc")
+
+    p1 = gmsh.model.geo.add_point(0.0, 0.0, 0.0, cellsize)
+    p2 = gmsh.model.geo.add_point(1.0, 0.0, 0.0, cellsize)
+    p3 = gmsh.model.geo.add_point(1.0, 1.0, 0.0, cellsize)
+    p4 = gmsh.model.geo.add_point(0.0, 1.0, 0.0, cellsize)
+
+    l1 = gmsh.model.geo.add_line(p1, p2)
+    l2 = gmsh.model.geo.add_line(p2, p3)
+    l3 = gmsh.model.geo.add_line(p3, p4)
+    l4 = gmsh.model.geo.add_line(p4, p1)
+
+    cl = gmsh.model.geo.add_curve_loop([l1, l2, l3, l4])
+    surface = gmsh.model.geo.add_plane_surface([cl])
+    gmsh.model.geo.synchronize()
+
+    gmsh.model.add_physical_group(1, [l1], boundaries_2D.Bottom.value, name=boundaries_2D.Bottom.name)
+    gmsh.model.add_physical_group(1, [l3], boundaries_2D.Top.value, name=boundaries_2D.Top.name)
+    gmsh.model.add_physical_group(1, [l2], boundaries_2D.Right.value, name=boundaries_2D.Right.name)
+    gmsh.model.add_physical_group(1, [l4], boundaries_2D.Left.value, name=boundaries_2D.Left.name)
+    gmsh.model.add_physical_group(2, [surface], boundaries_2D.Elements.value, name=boundaries_2D.Elements.name)
+
+    gmsh.model.mesh.generate(2)
+    gmsh.write(str(mesh_path))
+    gmsh.finalize()
+
+
+# %%
+build_box_mesh(MESH_PATH, CELLSIZE)
+plex = PETSc.DMPlex().createFromFile(str(MESH_PATH), interpolate=True, comm=PETSc.COMM_WORLD)
+
+print("raw labels:", [plex.getLabelName(i) for i in range(plex.getNumLabels())], flush=True)
+
+mesh = uw.discretisation.Mesh(
+    plex,
+    degree=1,
+    qdegree=4,
+    boundaries=boundaries_2D,
+    boundary_normals=boundary_normals_2D,
+    markVertices=True,
+    useMultipleTags=True,
+    useRegions=True,
+    coordinate_system_type=uw.coordinates.CoordinateSystemType.CARTESIAN,
+)
+
+print("has Bottom label?", bool(mesh.dm.getLabel("Bottom")), flush=True)
+print("has UW_Boundaries?", bool(mesh.dm.getLabel("UW_Boundaries")), flush=True)
+
+
+# %%
+x, y = mesh.X
+v_exact = sp.Matrix([y, 0])
+
+v = uw.discretisation.MeshVariable("U", mesh, 2, degree=2, vtype=uw.VarType.VECTOR)
+p = uw.discretisation.MeshVariable("P", mesh, 1, degree=1, continuous=True, vtype=uw.VarType.SCALAR)
+
+stokes = Stokes(mesh, velocityField=v, pressureField=p)
+stokes.constitutive_model = uw.constitutive_models.ViscousFlowModel
+stokes.constitutive_model.Parameters.viscosity = 1.0
+stokes.saddle_preconditioner = 1.0
+stokes.bodyforce = sp.Matrix([0, 0])
+
+for name in ("Bottom", "Top", "Left", "Right"):
+    stokes.add_essential_bc(v_exact, name)
+
+stokes.tolerance = 1.0e-10
+stokes.petsc_options["snes_type"] = "ksponly"
+stokes.petsc_options["ksp_type"] = "preonly"
+stokes.petsc_options["pc_type"] = "lu"
+
+print("about to solve", flush=True)
+stokes.solve(verbose=False, debug=False)
+
+
+# %%
+vel_err = uw.maths.Integral(
+    mesh, fn=((v.sym[0] - v_exact[0]) ** 2 + (v.sym[1] - v_exact[1]) ** 2)
+).evaluate()
+vel_ref = uw.maths.Integral(mesh, fn=(v_exact[0] ** 2 + v_exact[1] ** 2)).evaluate()
+print("relative velocity L2 error", float(np.sqrt(vel_err / vel_ref)), flush=True)

--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -396,6 +396,17 @@ class Mesh(Stateful, uw_object):
         self.boundaries = boundaries
         self.boundary_normals = boundary_normals
 
+        # Wrapped imported DMPlex meshes may only expose generic Gmsh labels
+        # such as "Face Sets". Rebuild named boundary labels from those sets so
+        # boundary APIs behave the same way as the standard Mesh(mesh_file) path.
+        if isinstance(plex_or_meshfile, PETSc.DMPlex) and self.boundaries is not None:
+            has_named_boundary_labels = any(self.dm.getLabel(b.name) for b in self.boundaries)
+            if not has_named_boundary_labels:
+                for stacked_label_name in ("Face Sets", "Edge Sets", "Vertex Sets"):
+                    if self.dm.getLabel(stacked_label_name):
+                        uw.adaptivity._dm_unstack_bcs(self.dm, self.boundaries, stacked_label_name)
+                        break
+
         # options.delValue("dm_plex_gmsh_mark_vertices")
         # options.delValue("dm_plex_gmsh_multiple_tags")
         # options.delValue("dm_plex_gmsh_use_regions")


### PR DESCRIPTION
## Summary

Fix essential BC handling for wrapped imported `PETSc.DMPlex` meshes by rebuilding named boundary labels from generic imported Gmsh boundary sets.

This bug does **not** affect the usual:

```python
mesh = uw.discretisation.Mesh(mesh_file, ...)
```

path, because `_from_gmsh(...)` already reconstructs named labels such as `Bottom`, `Top`, `Left`, and `Right`.

It **does** affect the lower-level path:

```python
plex = PETSc.DMPlex().createFromFile(mesh_file, interpolate=True, comm=...)
mesh = uw.discretisation.Mesh(plex, ...)
```

where the wrapped mesh may only expose generic labels such as `Face Sets` / `Cell Sets`.

## Problem

The Stokes essential BC path expects named boundary labels like `Bottom` to exist on the working DM. For wrapped imported `DMPlex` meshes, that assumption is false on clean `development`.

On exact upstream `development`, the reproducer prints:

```text
raw labels: ['celltype', 'depth', 'Cell Sets', 'Face Sets']
has Bottom label? False
has UW_Boundaries? True
about to solve
```

and then dies in `stokes.solve()`.

So the issue is specifically:

- imported raw `DMPlex` retains generic Gmsh labels
- named labels are not rebuilt during `Mesh(plex, ...)`
- essential BCs added by boundary name cannot attach correctly

## Fix

When `uw.discretisation.Mesh(...)` is constructed from an already-created `PETSc.DMPlex`, and named boundary labels are missing, unstack the imported generic boundary-set labels into named UW labels before `UW_Boundaries` is stacked.

In practice this means rebuilding labels such as:

- `Bottom`
- `Top`
- `Left`
- `Right`

from imported labels such as:

- `Face Sets`
- `Edge Sets`
- `Vertex Sets`

This keeps the wrapped-`DMPlex` path consistent with the standard file-import path instead of changing solver-side boundary semantics.

## Reproducer

Added:

- `examples/stokes_imported_box_essential_bc.py`

It is self-contained:

- builds a simple Gmsh box mesh with named physical groups
- imports it through raw `PETSc.DMPlex().createFromFile(...)`
- wraps that `DMPlex` with `uw.discretisation.Mesh(plex, ...)`
- applies a nonzero Couette essential BC `u = (y, 0)` on all four sides
- solves a trivial Stokes problem and reports the relative velocity L2 error

## Results

### Before this fix

Run the reproducer against clean `development`:

```bash
PYTHONPATH=/path/to/underworld3_essential_bc_baseline/src \
python -u examples/stokes_imported_box_essential_bc.py
```

Observed output:

```text
raw labels: ['celltype', 'depth', 'Cell Sets', 'Face Sets']
has Bottom label? False
has UW_Boundaries? True
about to solve
```

The process then crashes in `stokes.solve()`.

### After this fix

Run the same script against this branch:

```bash
PYTHONPATH=/path/to/underworld3/src \
python -u examples/stokes_imported_box_essential_bc.py
```

Observed output:

```text
raw labels: ['celltype', 'depth', 'Cell Sets', 'Face Sets']
has Bottom label? True
has UW_Boundaries? True
about to solve
relative velocity L2 error 4.538571271364606e-16
```

So the direct imported-`DMPlex` path now behaves correctly and matches the expected machine-precision solution for this simple imposed-velocity Stokes case.

## Scope

This PR only changes the wrapped imported-`DMPlex` mesh path and adds the reproducer.
