### PR TITLE
Add solver barrier for VEP and fix is_viscoplastic

### DIFF
--- a/src/underworld3/constitutive_models.py
+++ b/src/underworld3/constitutive_models.py
@@ -579,6 +579,16 @@ class Constitutive_Model(uw_object):
 
         return
 
+    @property
+    def requires_stress_history(self):
+        """Whether this model needs DFDt stress history tracking.
+
+        Models that return True require a solver with stress history
+        management (e.g. VE_Stokes). Assigning such a model to a plain
+        Stokes solver will raise an error.
+        """
+        return False
+
     def _build_c_tensor(self):
         """Return the identity tensor of appropriate rank (e.g. for projections)"""
 
@@ -1589,6 +1599,11 @@ class ViscoElasticPlasticFlowModel(ViscousFlowModel):
         )
 
     @property
+    def requires_stress_history(self):
+        """VEP models always require stress history tracking."""
+        return True
+
+    @property
     def is_elastic(self):
         """True if elastic behavior is active (finite dt_elastic and shear_modulus)."""
         # If any of these is not defined, elasticity is switched off
@@ -1604,7 +1619,7 @@ class ViscoElasticPlasticFlowModel(ViscousFlowModel):
     @property
     def is_viscoplastic(self):
         """True if plastic yielding is active (finite yield_stress)."""
-        if self.Parameters.yield_stress == sympy.oo:
+        if self.Parameters.yield_stress.sym is sympy.oo:
             return False
 
         return True

--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -950,6 +950,16 @@ class SolverBaseClass(uw_object):
                 "constitutive_model must be a valid class or instance of a valid class"
             )
 
+        # Check that the solver can support this constitutive model's requirements.
+        # Models with stress history (VEP) need a solver that manages DFDt — e.g. VE_Stokes.
+        # Using them on a plain Stokes solver silently drops the history terms.
+        if self._constitutive_model.requires_stress_history and self.Unknowns.DFDt is None:
+            raise TypeError(
+                f"{type(self._constitutive_model).__name__} requires stress history tracking "
+                f"(DFDt). Use uw.systems.VE_Stokes instead of uw.systems.Stokes, or provide "
+                f"a DFDt object when constructing the solver."
+            )
+
         # May not work due to flux being incomplete
         if self.Unknowns.DFDt is not None:
             self.Unknowns.DFDt.psi_fn = self._constitutive_model.flux.T

--- a/tests/test_1050_VEstokesCart.py
+++ b/tests/test_1050_VEstokesCart.py
@@ -52,7 +52,7 @@ def test_stokes_boxmesh(mesh):
     )
     p = uw.discretisation.MeshVariable(r"mathbf{p}", mesh, 1, vtype=uw.VarType.SCALAR, degree=1)
 
-    stokes = uw.systems.Stokes(mesh, velocityField=u, pressureField=p)
+    stokes = uw.systems.VE_Stokes(mesh, velocityField=u, pressureField=p, order=1)
     stokes.constitutive_model = uw.constitutive_models.ViscoElasticPlasticFlowModel
     stokes.constitutive_model.Parameters.shear_viscosity_0 = 1
     stokes.constitutive_model.Parameters.shear_modulus = 1
@@ -101,7 +101,7 @@ def test_stokes_boxmesh(mesh):
         stokes.add_dirichlet_bc((sympy.oo, 0.0, sympy.oo), "Front")
         stokes.add_dirichlet_bc((sympy.oo, 0.0, sympy.oo), "Back")
 
-    stokes.solve()
+    stokes.solve(timestep=0.1)
 
     print(f"Mesh dimensions {mesh.dim}", flush=True)
     stokes.dm.ds.view()
@@ -229,7 +229,7 @@ def test_stokes_boxmesh_bc_failure(mesh):
     )
     p = uw.discretisation.MeshVariable(r"mathbf{p}", mesh, 1, vtype=uw.VarType.SCALAR, degree=1)
 
-    stokes = uw.systems.Stokes(mesh, velocityField=u, pressureField=p)
+    stokes = uw.systems.VE_Stokes(mesh, velocityField=u, pressureField=p, order=1)
     stokes.constitutive_model = uw.constitutive_models.ViscoElasticPlasticFlowModel
     stokes.constitutive_model.Parameters.shear_viscosity_0 = 1
     stokes.constitutive_model.Parameters.shear_modulus = 1
@@ -275,7 +275,7 @@ def test_stokes_boxmesh_bc_failure(mesh):
         stokes.add_dirichlet_bc((sympy.oo, 0.0, sympy.oo), "Front")
         stokes.add_dirichlet_bc((sympy.oo, 0.0, sympy.oo), "Back")
 
-    stokes.solve()
+    stokes.solve(timestep=0.1)
 
     print(f"Mesh dimensions {mesh.dim}", flush=True)
     stokes.dm.ds.view()


### PR DESCRIPTION
## Summary

Two small safety fixes for the VEP constitutive model, additive to PR #89.

### 1. Solver barrier for stress history models

Assigning `ViscoElasticPlasticFlowModel` to a plain `uw.systems.Stokes` solver silently drops all stress history terms — the solver runs without error but produces purely viscous results. This was a known failure mode (e.g. `test_1050_VEstokesCart.py` and `Ex_Sheared_Layer_Test.py` both used plain Stokes with VEP).

Now raises `TypeError` with a clear message directing users to `VE_Stokes`.

### 2. Fix `is_viscoplastic` comparison

`is_viscoplastic` compared `self.Parameters.yield_stress == sympy.oo` but `yield_stress` is a `UWexpression`, so the comparison always returned `False`. Now uses `.sym is sympy.oo`.

## Test plan

- [x] VEP on plain Stokes raises TypeError
- [x] VEP on VE_Stokes works normally
- [x] `is_viscoplastic` returns False when yield_stress is infinite
- [x] ViscousFlowModel on plain Stokes still works

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)