### PR TITLE
Remove sympy.simplify() from solver templates and internal paths

### DIFF
--- a/src/underworld3/constitutive_models.py
+++ b/src/underworld3/constitutive_models.py
@@ -2184,7 +2184,7 @@ class TransverseIsotropicFlowModel(ViscousFlowModel):
 
                         lambda_mat[i, j, k, l] = val
 
-        lambda_mat = sympy.simplify(uw.maths.tensor.rank4_to_mandel(lambda_mat, d))
+        lambda_mat = uw.maths.tensor.rank4_to_mandel(lambda_mat, d)
 
         self._c = uw.maths.tensor.mandel_to_rank4(lambda_mat, d)
 

--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -3730,7 +3730,7 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
         if self.saddle_preconditioner is not None:
             self._pp_G0 = self.saddle_preconditioner
         else:
-            self._pp_G0 = sympy.simplify(1 / self.constitutive_model.K)
+            self._pp_G0 = 1 / self.constitutive_model.K
 
         fns_jacobian.append(self._pp_G0)
 

--- a/src/underworld3/swarm.py
+++ b/src/underworld3/swarm.py
@@ -2147,7 +2147,7 @@ class IndexSwarmVariable(SwarmVariable):
         if len(funcsList) != self.indices:
             raise RuntimeError("Error input for createMask() - wrong length of input")
 
-        symo = sympy.simplify(0)
+        symo = sympy.S.Zero
         for i in range(self.indices):
             symo += funcsList[i] * self._MaskArray[i]
 

--- a/src/underworld3/systems/solver_template.py
+++ b/src/underworld3/systems/solver_template.py
@@ -162,7 +162,7 @@ class SNES_MyEquation(SNES_Scalar):
 
         F1_val = expression(
             r"\mathbf{F}_1\left( u, \nabla u \right)",
-            sympy.simplify(flux),
+            flux,
             "MyEquation pointwise flux term: $F_1(u, \\nabla u)$",
         )
 

--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -224,7 +224,7 @@ class SNES_Poisson(SNES_Scalar):
 
     F1 = Template(
         r"\mathbf{F}_1\left( \mathbf{u} \right)",
-        lambda self: sympy.simplify(self.constitutive_model.flux.T),
+        lambda self: self.constitutive_model.flux.T,
         r"""Diffusive flux term for the Poisson equation (pointwise).
 
         The $\mathbf{F}_1$ vector represents the flux $k \nabla u$
@@ -705,7 +705,7 @@ class SNES_Stokes(SNES_Stokes_SaddlePt):
 
     F1 = Template(
         r"\mathbf{F}_1\left( \mathbf{u} \right)",
-        lambda self: sympy.simplify(
+        lambda self: (
             self.stress + self.penalty * self.div_u * sympy.eye(self.mesh.dim)
         ),
         r"""Velocity equation flux/stress term (pointwise).
@@ -718,7 +718,7 @@ class SNES_Stokes(SNES_Stokes_SaddlePt):
 
     PF0 = Template(
         r"\mathbf{h}_0\left( \mathbf{p} \right)",
-        lambda self: sympy.simplify(sympy.Matrix((self.constraints))),
+        lambda self: sympy.Matrix((self.constraints)),
         r"""Pressure equation constraint term (continuity).
 
         The $h_0$ term enforces the incompressibility constraint
@@ -2478,7 +2478,7 @@ class SNES_Diffusion(SNES_Scalar):
         """Pointwise source term including time derivative."""
         f0 = expression(
             r"f_0 \left( \mathbf{u} \right)",
-            -self.f + sympy.simplify(self.DuDt.bdf()) / self.delta_t,
+            -self.f + self.DuDt.bdf() / self.delta_t,
             "Diffusion pointwise force term: f_0(u)",
         )
 
@@ -2918,7 +2918,7 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
 
         f0 = expression(
             r"\mathbf{F}_1\left( \mathbf{p} \right)",
-            sympy.simplify(sympy.Matrix((self.constraints))),
+            sympy.Matrix((self.constraints)),
             "NStokes pointwise flux term: f_0(p)",
         )
 


### PR DESCRIPTION
## Summary

- Remove `sympy.simplify()` from all solver template lambdas and internal code paths
- Fixes TypeError crash when SymPy simplification walks into `UWexpression.__new__` with unhashable arguments
- User-facing simplify flags (visualisation, evaluate, expressions) preserved

## Changes

5 files, 9 call sites:
- `solvers.py`: Stokes F1/PF0, Poisson F1, Diffusion F0, NavierStokes PF0
- `solver_template.py`: generic F1 template
- `constitutive_models.py`: TransverseIsotropic stiffness tensor setup
- `petsc_generic_snes_solvers.pyx`: Schur preconditioner computation
- `swarm.py`: `sympy.simplify(0)` replaced with `sympy.S.Zero`

## Rationale

`sympy.simplify()` is expensive and fragile with custom symbol types. The calls in solver templates were purely cosmetic — the JIT compiler and PETSc do not require simplified expressions. Users who want cleaner display can call `sympy.simplify()` themselves.

## Test plan

- [x] Tier A level 1: 33 passed
- [x] Tier A+B level 2: 174 passed, 0 failures

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)