### PR TITLE
Add mesh.nullspace_rotations and stokes.petsc_use_nullspace

### DIFF
--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -3564,17 +3564,20 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
         ``petsc_velocity_nullspace_basis`` separately.
         """
         return (self._petsc_use_pressure_nullspace
-                and len(self._petsc_velocity_nullspace_basis) > 0)
+                or len(self._petsc_velocity_nullspace_basis) > 0)
 
     @petsc_use_nullspace.setter
     def petsc_use_nullspace(self, value):
         value = bool(value)
         self._petsc_use_pressure_nullspace = value
-        if value and hasattr(self.mesh, 'nullspace_rotations'):
-            modes = self.mesh.nullspace_rotations
-            if modes:
-                self.petsc_velocity_nullspace_basis = modes
-        elif not value:
+        if value:
+            # Sync velocity nullspace basis to mesh rotations (even if empty)
+            # to avoid stale modes carrying over between meshes/runs
+            if hasattr(self.mesh, 'nullspace_rotations'):
+                self.petsc_velocity_nullspace_basis = self.mesh.nullspace_rotations or ()
+            else:
+                self._petsc_velocity_nullspace_basis = ()
+        else:
             self._petsc_velocity_nullspace_basis = ()
         self._reset_stokes_nullspace()
         self.is_setup = False

--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -3554,6 +3554,32 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
         self._saddle_preconditioner = function
 
     @property
+    def petsc_use_nullspace(self):
+        """Enable full nullspace handling: constant pressure + mesh rotation modes.
+
+        Convenience property that enables the pressure nullspace and
+        auto-populates velocity nullspace modes from ``mesh.nullspace_rotations``.
+
+        For finer control, use ``petsc_use_pressure_nullspace`` and
+        ``petsc_velocity_nullspace_basis`` separately.
+        """
+        return (self._petsc_use_pressure_nullspace
+                and len(self._petsc_velocity_nullspace_basis) > 0)
+
+    @petsc_use_nullspace.setter
+    def petsc_use_nullspace(self, value):
+        value = bool(value)
+        self._petsc_use_pressure_nullspace = value
+        if value and hasattr(self.mesh, 'nullspace_rotations'):
+            modes = self.mesh.nullspace_rotations
+            if modes:
+                self.petsc_velocity_nullspace_basis = modes
+        elif not value:
+            self._petsc_velocity_nullspace_basis = ()
+        self._reset_stokes_nullspace()
+        self.is_setup = False
+
+    @property
     def petsc_use_pressure_nullspace(self):
         """
         Enable PETSc handling of the constant-pressure nullspace.

--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -664,6 +664,11 @@ class Mesh(Stateful, uw_object):
         self._lvec = None
         self.petsc_fe = None
 
+        # Rigid-body rotation null modes for this geometry.
+        # Mesh factories override this for closed surfaces (annulus, sphere).
+        # Each entry is a SymPy Matrix velocity field in mesh coordinates.
+        self._nullspace_rotations = []
+
         self.degree = degree
         self.qdegree = qdegree
 
@@ -1530,6 +1535,31 @@ class Mesh(Stateful, uw_object):
         >>> stokes.solve(time=current_time)   # sets petsc_t before SNES
         """
         return self._t
+
+    @property
+    def nullspace_rotations(self):
+        """Symbolic velocity fields for rigid-body rotation null modes.
+
+        Returns a list of SymPy Matrix expressions in mesh Cartesian
+        coordinates. Empty for meshes with no rotation nullspace (boxes,
+        wedge segments with walls). Set by mesh factory functions for
+        closed surfaces (annulus, spherical shell, etc.).
+
+        Each entry represents a rigid rotation: v = omega x r.
+
+        Returns
+        -------
+        list of sympy.Matrix
+            Velocity fields for each independent rotation mode.
+
+        Examples
+        --------
+        >>> annulus = uw.meshing.Annulus(...)
+        >>> annulus.nullspace_rotations  # [Matrix([-y, x])]
+        >>> shell = uw.meshing.SphericalShell(...)
+        >>> shell.nullspace_rotations   # 3 rotation matrices
+        """
+        return self._nullspace_rotations
 
     @property
     def r(self) -> Tuple[sympy.vector.BaseScalar]:

--- a/src/underworld3/meshing/annulus.py
+++ b/src/underworld3/meshing/annulus.py
@@ -538,6 +538,10 @@ def Annulus(
 
     new_mesh.boundary_normals = boundary_normals
 
+    # Full annulus: rigid rotation about z-axis
+    x, y = new_mesh.X
+    new_mesh._nullspace_rotations = [sympy.Matrix([-y, x])]
+
     return new_mesh
 
 
@@ -1110,6 +1114,10 @@ def AnnulusWithSpokes(
 
     new_mesh.boundary_normals = boundary_normals
 
+    # Full annulus with spokes: rigid rotation about z-axis
+    x, y = new_mesh.X
+    new_mesh._nullspace_rotations = [sympy.Matrix([-y, x])]
+
     return new_mesh
 
 
@@ -1392,6 +1400,10 @@ def AnnulusInternalBoundary(
 
     new_mesh.boundary_normals = boundary_normals
 
+    # Full annulus with internal boundary: rigid rotation about z-axis
+    x, y = new_mesh.X
+    new_mesh._nullspace_rotations = [sympy.Matrix([-y, x])]
+
     return new_mesh
 
 
@@ -1670,5 +1682,9 @@ def DiscInternalBoundaries(
         Centre = None
 
     new_mesh.boundary_normals = boundary_normals
+
+    # Full disc with internal boundaries: rigid rotation about z-axis
+    x, y = new_mesh.X
+    new_mesh._nullspace_rotations = [sympy.Matrix([-y, x])]
 
     return new_mesh

--- a/src/underworld3/meshing/segmented.py
+++ b/src/underworld3/meshing/segmented.py
@@ -676,6 +676,14 @@ def SegmentedSphericalShell(
 
     new_mesh.boundary_normals = boundary_normals
 
+    # Full segmented spherical shell: 3 rigid rotation modes
+    x, y, z = new_mesh.X
+    new_mesh._nullspace_rotations = [
+        sympy.Matrix([0, -z, y]),
+        sympy.Matrix([z, 0, -x]),
+        sympy.Matrix([-y, x, 0]),
+    ]
+
     return new_mesh
 
 
@@ -1087,5 +1095,13 @@ def SegmentedSphericalBall(
         Centre = None
 
     new_mesh.boundary_normals = boundary_normals
+
+    # Solid sphere: 3 rigid rotation modes
+    x, y, z = new_mesh.X
+    new_mesh._nullspace_rotations = [
+        sympy.Matrix([0, -z, y]),
+        sympy.Matrix([z, 0, -x]),
+        sympy.Matrix([-y, x, 0]),
+    ]
 
     return new_mesh

--- a/src/underworld3/meshing/spherical.py
+++ b/src/underworld3/meshing/spherical.py
@@ -269,6 +269,14 @@ def SphericalShell(
         Upper = 12
         Centre = 1
 
+    # Full spherical shell: 3 rigid rotation modes
+    x, y, z = new_mesh.X
+    new_mesh._nullspace_rotations = [
+        sympy.Matrix([0, -z, y]),   # rotation about x
+        sympy.Matrix([z, 0, -x]),   # rotation about y
+        sympy.Matrix([-y, x, 0]),   # rotation about z
+    ]
+
     return new_mesh
 
 
@@ -474,6 +482,14 @@ def SphericalShellInternalBoundary(
         Internal = 12
         Upper = 13
         Centre = 1
+
+    # Full spherical shell with internal boundary: 3 rigid rotation modes
+    x, y, z = new_mesh.X
+    new_mesh._nullspace_rotations = [
+        sympy.Matrix([0, -z, y]),
+        sympy.Matrix([z, 0, -x]),
+        sympy.Matrix([-y, x, 0]),
+    ]
 
     return new_mesh
 
@@ -1010,5 +1026,13 @@ def CubedSphere(
         Upper = new_mesh.CoordinateSystem.unit_e_0
 
     new_mesh.boundary_normals = boundary_normals
+
+    # Full cubed sphere: 3 rigid rotation modes
+    x, y, z = new_mesh.X
+    new_mesh._nullspace_rotations = [
+        sympy.Matrix([0, -z, y]),
+        sympy.Matrix([z, 0, -x]),
+        sympy.Matrix([-y, x, 0]),
+    ]
 
     return new_mesh


### PR DESCRIPTION
## Summary

- Add `mesh.nullspace_rotations` property: returns symbolic velocity fields for rigid-body rotation null modes. Empty for boxes/wedges, populated by mesh factories for closed surfaces (annulus: 1 mode, spherical shell: 3 modes).
- Add `stokes.petsc_use_nullspace` convenience property: enables pressure nullspace and auto-populates velocity nullspace basis from `mesh.nullspace_rotations` in one call.
- Mesh factories updated: Annulus, AnnulusWithSpokes, AnnulusInternalBoundary, DiscInternalBoundaries, SphericalShell, SphericalShellInternalBoundary, SegmentedSphericalShell, SegmentedSphericalBall, CubedSphere.

Rebased from `feature/mesh-nullspace` onto current `development`. Closes #102.

Original commits by @gthyagi.

## Test plan

- [ ] CI passes
- [ ] `annulus.nullspace_rotations` returns `[Matrix([-y, x])]`
- [ ] `shell.nullspace_rotations` returns 3 rotation matrices
- [ ] `stokes.petsc_use_nullspace = True` auto-populates velocity basis

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)