### PR TITLE
add missing packages to petsc during hpc build

### DIFF
--- a/petsc-custom/build-petsc.sh
+++ b/petsc-custom/build-petsc.sh
@@ -293,6 +293,7 @@ configure_petsc() {
                 --download-cmake=1 \
                 --download-bison=1 \
                 --with-petsc4py=1 \
+		--with-slepc4py=1 \
                 --with-make-np=40
             ;;
         gadi)
@@ -304,6 +305,7 @@ configure_petsc() {
                 --with-hdf5-dir="${HDF5_DIR}" \
                 --download-fblaslapack=1 \
                 --with-petsc4py=1 \
+		--with-slepc4py=1 \
                 --with-make-np=40 \
                 --with-shared-libraries=1 \
                 --with-cxx-dialect=C++11 \


### PR DESCRIPTION
Fix HPC PETSc configure by enabling `slepc4py` when using `petsc4py` with downloaded SLEPc.

The Gadi/HPC PETSc build used `--with-petsc4py=1` together with `--download-slepc=1`, but did not pass `--with-slepc4py=1`. This caused PETSc configure to fail with:

`You should also set --with-slepc4py when using both --with-petsc4py and --download-slepc`

This PR adds the missing `--with-slepc4py=1` flag to the relevant HPC configure path in `petsc-custom/build-petsc.sh`.

Tested on Gadi: PETSc build completed successfully and UW3 Level 1 tests passed.