### PR TITLE
Build cache coherence across PETSc version switches

### DIFF
--- a/petsc-custom/activate-petsc-arch.sh
+++ b/petsc-custom/activate-petsc-arch.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# activate-petsc-arch.sh — sourced by pixi on environment activation.
+#
+# Dynamically sets PETSC_ARCH for AMR environments (custom PETSc builds)
+# by combining the active pixi environment name with the PETSc version
+# pinned in petsc-custom/.petsc-version.
+#
+# This replaces hardcoded PETSC_ARCH entries in pixi.toml so that
+# switching PETSc versions (via ./uw petsc switch <tag>) does not require
+# editing tracked configuration.
+
+_uw_mpi=""
+_uw_suffix=""
+case "${PIXI_ENVIRONMENT_NAME:-}" in
+    amr|amr-runtime|amr-dev)
+        case "$(uname -s)" in
+            Darwin) _uw_mpi="openmpi" ;;
+            *)      _uw_mpi="mpich" ;;
+        esac ;;
+    amr-mpich|amr-mpich-dev)     _uw_mpi="mpich" ;;
+    amr-openmpi|amr-openmpi-dev) _uw_mpi="openmpi" ;;
+    amr-debug)                   _uw_mpi="openmpi"; _uw_suffix="-debug" ;;
+esac
+
+if [ -n "$_uw_mpi" ]; then
+    _uw_ver="4"
+    _uw_ver_file="${PIXI_PROJECT_ROOT:-.}/petsc-custom/.petsc-version"
+    [ -f "$_uw_ver_file" ] && _uw_ver=$(cat "$_uw_ver_file" 2>/dev/null || echo "4")
+
+    export PETSC_ARCH="petsc-${_uw_ver}-uw-${_uw_mpi}${_uw_suffix}"
+fi
+
+unset _uw_mpi _uw_suffix _uw_ver _uw_ver_file

--- a/petsc-custom/activate-petsc-arch.sh
+++ b/petsc-custom/activate-petsc-arch.sh
@@ -11,23 +11,31 @@
 
 _uw_mpi=""
 _uw_suffix=""
+
+# Default MPI for AMR envs is platform-dependent and mirrors the conda deps
+# pinned in pixi.toml: openmpi on macOS (feature.amr.target.osx-arm64),
+# mpich on Linux (feature.amr.target.linux-64).
+_uw_default_mpi="mpich"
+[ "$(uname -s)" = "Darwin" ] && _uw_default_mpi="openmpi"
+
 case "${PIXI_ENVIRONMENT_NAME:-}" in
-    amr|amr-runtime|amr-dev)
-        case "$(uname -s)" in
-            Darwin) _uw_mpi="openmpi" ;;
-            *)      _uw_mpi="mpich" ;;
-        esac ;;
+    amr|amr-runtime|amr-dev)     _uw_mpi="$_uw_default_mpi" ;;
     amr-mpich|amr-mpich-dev)     _uw_mpi="mpich" ;;
     amr-openmpi|amr-openmpi-dev) _uw_mpi="openmpi" ;;
-    amr-debug)                   _uw_mpi="openmpi"; _uw_suffix="-debug" ;;
+    amr-debug)                   _uw_mpi="$_uw_default_mpi"; _uw_suffix="-debug" ;;
 esac
 
 if [ -n "$_uw_mpi" ]; then
-    _uw_ver="4"
+    # Match the version-discovery logic in ./uw (petsc_version_short):
+    # prefer .petsc-version, strip whitespace, fall back to 324.
+    _uw_ver="324"
     _uw_ver_file="${PIXI_PROJECT_ROOT:-.}/petsc-custom/.petsc-version"
-    [ -f "$_uw_ver_file" ] && _uw_ver=$(cat "$_uw_ver_file" 2>/dev/null || echo "4")
+    if [ -f "$_uw_ver_file" ]; then
+        _uw_read=$(tr -d '[:space:]' < "$_uw_ver_file" 2>/dev/null)
+        [ -n "$_uw_read" ] && _uw_ver="$_uw_read"
+    fi
 
     export PETSC_ARCH="petsc-${_uw_ver}-uw-${_uw_mpi}${_uw_suffix}"
 fi
 
-unset _uw_mpi _uw_suffix _uw_ver _uw_ver_file
+unset _uw_mpi _uw_suffix _uw_default_mpi _uw_ver _uw_ver_file _uw_read

--- a/pixi.toml
+++ b/pixi.toml
@@ -237,15 +237,20 @@ petsc-local-clean = { cmd = "./build-petsc.sh clean", cwd = "petsc-custom" }
 # Uses the same conda deps as amr but points to a separate PETSC_ARCH
 # so the optimised build is untouched.
 #
-# Setup:
+# PETSC_ARCH is set dynamically by petsc-custom/activate-petsc-arch.sh
+# and resolves to:  petsc-<ver>-uw-<mpi>-debug
+# where <ver> comes from petsc-custom/.petsc-version and <mpi> follows
+# the platform default (openmpi on macOS, mpich on Linux).
+#
+# Setup (inside a pixi shell -e amr-debug, so $PETSC_ARCH is already set):
 #   cd petsc-custom/petsc
 #   pixi run -e amr-debug python3 ./configure \
-#       --with-petsc-arch=petsc-4-uw-openmpi-debug --with-debugging=1 \
+#       --with-petsc-arch="$PETSC_ARCH" --with-debugging=1 \
 #       --with-mpi-dir="$CONDA_PREFIX" --with-hdf5=0 \
 #       --download-mpich=0 --download-openmpi=0 --download-mpi4py=0 \
 #       --with-petsc4py=0 --with-x=0 --with-pragmatic=0 --with-slepc=0 \
 #       "--COPTFLAGS=-g -O0" "--CXXOPTFLAGS=-g -O0" "--FOPTFLAGS=-g -O0"
-#   make PETSC_DIR=$(pwd) PETSC_ARCH=petsc-4-uw-openmpi-debug all
+#   make PETSC_DIR=$(pwd) PETSC_ARCH="$PETSC_ARCH" all
 
 [feature.amr-debug.activation]
 scripts = ["petsc-custom/activate-petsc-arch.sh"]

--- a/pixi.toml
+++ b/pixi.toml
@@ -165,6 +165,9 @@ cmake = ">=3.31,<4"
 make = ">=4.4,<5"
 mpi4py = ">=4,<5"
 
+[feature.amr.activation]
+scripts = ["petsc-custom/activate-petsc-arch.sh"]
+
 [feature.amr.activation.env]
 PETSC_DIR = "$PIXI_PROJECT_ROOT/petsc-custom/petsc"
 
@@ -173,15 +176,9 @@ openmpi = ">=5.0,<6"
 hdf5 = { version = ">=1.14,<2", build = "*openmpi*" }
 h5py = { version = ">=3.12,<4", build = "*openmpi*" }
 
-[feature.amr.target.osx-arm64.activation.env]
-PETSC_ARCH = "petsc-4-uw-openmpi"
-
 [feature.amr.target.linux-64.dependencies]
 hdf5 = { version = ">=1.14,<2", build = "*mpich*" }
 h5py = { version = ">=3.12,<4", build = "*mpich*" }
-
-[feature.amr.target.linux-64.activation.env]
-PETSC_ARCH = "petsc-4-uw-mpich"
 
 [feature.amr.tasks]
 petsc-local-build = { cmd = "./build-petsc.sh", cwd = "petsc-custom" }
@@ -202,9 +199,11 @@ mpi4py = ">=4,<5"
 hdf5 = { version = ">=1.14,<2", build = "*mpich*" }
 h5py = { version = ">=3.12,<4", build = "*mpich*" }
 
+[feature.amr-mpich.activation]
+scripts = ["petsc-custom/activate-petsc-arch.sh"]
+
 [feature.amr-mpich.activation.env]
 PETSC_DIR = "$PIXI_PROJECT_ROOT/petsc-custom/petsc"
-PETSC_ARCH = "petsc-4-uw-mpich"
 
 [feature.amr-mpich.tasks]
 petsc-local-build = { cmd = "./build-petsc.sh", cwd = "petsc-custom" }
@@ -221,9 +220,11 @@ mpi4py = ">=4,<5"
 hdf5 = { version = ">=1.14,<2", build = "*openmpi*" }
 h5py = { version = ">=3.12,<4", build = "*openmpi*" }
 
+[feature.amr-openmpi.activation]
+scripts = ["petsc-custom/activate-petsc-arch.sh"]
+
 [feature.amr-openmpi.activation.env]
 PETSC_DIR = "$PIXI_PROJECT_ROOT/petsc-custom/petsc"
-PETSC_ARCH = "petsc-4-uw-openmpi"
 
 [feature.amr-openmpi.tasks]
 petsc-local-build = { cmd = "./build-petsc.sh", cwd = "petsc-custom" }
@@ -246,9 +247,11 @@ petsc-local-clean = { cmd = "./build-petsc.sh clean", cwd = "petsc-custom" }
 #       "--COPTFLAGS=-g -O0" "--CXXOPTFLAGS=-g -O0" "--FOPTFLAGS=-g -O0"
 #   make PETSC_DIR=$(pwd) PETSC_ARCH=petsc-4-uw-openmpi-debug all
 
+[feature.amr-debug.activation]
+scripts = ["petsc-custom/activate-petsc-arch.sh"]
+
 [feature.amr-debug.activation.env]
 PETSC_DIR = "$PIXI_PROJECT_ROOT/petsc-custom/petsc"
-PETSC_ARCH = "petsc-4-uw-openmpi-debug"
 
 # ============================================
 # HPC CLUSTER FEATURE

--- a/setup.py
+++ b/setup.py
@@ -76,35 +76,34 @@ def configure():
     LIBRARY_DIRS = []
     LIBRARIES = []
 
+    import os
+
     PETSC_DIR = ""
     PETSC_ARCH = ""
 
-    # try get PETSC_DIR from petsc pip installation
-    try:
-        import petsc
+    # Priority 1: Environment variables (set by pixi activation for custom builds)
+    if os.environ.get("PETSC_DIR") and os.path.exists(os.environ["PETSC_DIR"]):
+        PETSC_DIR = os.environ["PETSC_DIR"]
+        PETSC_ARCH = os.environ.get("PETSC_ARCH", "")
 
-        PETSC_DIR = petsc.get_petsc_dir()
-    except:
-        pass
+    # Priority 2: petsc4py configuration (matches the installed petsc4py)
+    if not PETSC_DIR or not os.path.exists(PETSC_DIR):
+        config = petsc4py.get_config()
+        PETSC_DIR = config["PETSC_DIR"]
+        PETSC_ARCH = config.get("PETSC_ARCH", "")
 
-    # PETSc
-    import os
+    # Priority 3: conda petsc package
+    if not PETSC_DIR or not os.path.exists(PETSC_DIR):
+        try:
+            import petsc
+            PETSC_DIR = petsc.get_petsc_dir()
+        except ImportError:
+            pass
 
-    if not os.path.exists(PETSC_DIR):
-        print(f"PETSC_INFO from petsc4py - {petsc4py.get_config()}")
-        PETSC_DIR = petsc4py.get_config()["PETSC_DIR"]
-        PETSC_ARCH = petsc4py.get_config()["PETSC_ARCH"]
-
-    # It is preferable to use the petsc4py paths to the
-    # petsc libraries for consistency but the pip installation
-    # of PETSc sometimes points to the temporary setup up path
-
-    if not os.path.exists(PETSC_DIR):
-        print(f"PETSC_DIR {PETSC_DIR} is bad - trying another ...")
-
-        if os.environ.get("CONDA_PREFIX") and not os.environ.get("PETSC_DIR"):
+    # Priority 4: conda prefix fallback
+    if not PETSC_DIR or not os.path.exists(PETSC_DIR):
+        if os.environ.get("CONDA_PREFIX"):
             import sys
-
             py_version = f"{sys.version_info.major}.{sys.version_info.minor}"
             PETSC_DIR = os.path.join(
                 os.environ["CONDA_PREFIX"],
@@ -112,10 +111,7 @@ def configure():
                 "python" + py_version,
                 "site-packages",
                 "petsc",
-            )  # symlink to latest python
-            PETSC_ARCH = os.environ.get("PETSC_ARCH", "")
-        else:
-            PETSC_DIR = os.environ["PETSC_DIR"]
+            )
             PETSC_ARCH = os.environ.get("PETSC_ARCH", "")
 
     print(f"Using PETSc:")

--- a/uw
+++ b/uw
@@ -293,8 +293,23 @@ run_petsc_cmd() {
                 exit 1
             fi
             $PIXI run -e "$(get_env)" "$SCRIPT_DIR/petsc-custom/build-petsc.sh" checkout "$arg"
+
+            # Nuke stale build artifacts and petsc4py. The next ./uw build's
+            # target-change detection can't fire because the still-installed
+            # petsc4py reports the OLD arch, so we force a full rebuild here.
             echo ""
-            echo "To complete the switch, rebuild:"
+            echo "Clearing stale build artifacts for clean rebuild..."
+            rm -rf "$SCRIPT_DIR"/build/lib.* "$SCRIPT_DIR"/build/temp.* "$SCRIPT_DIR"/build/bdist.* 2>/dev/null
+            rm -f "$SCRIPT_DIR/build/.petsc_target"
+            $PIXI run -e "$(get_env)" pip cache purge 2>/dev/null || true
+            if is_amr_env "$(get_env)"; then
+                echo "Uninstalling old petsc4py (linked to previous PETSc build)..."
+                $PIXI run -e "$(get_env)" pip uninstall -y petsc4py 2>/dev/null || true
+            fi
+
+            echo ""
+            echo "To complete the switch, rebuild PETSc then underworld3:"
+            echo "  ./uw petsc build"
             echo "  ./uw build"
             ;;
         active)

--- a/uw
+++ b/uw
@@ -159,7 +159,7 @@ run_build() {
         # Step 2: Check/build petsc4py
         if ! petsc4py_installed "$env"; then
             echo "  Installing petsc4py for $env..."
-            $PIXI run -e "$env" pip install "$PETSC_CUSTOM/src/binding/petsc4py" --no-build-isolation || {
+            $PIXI run -e "$env" pip install "$PETSC_CUSTOM/src/binding/petsc4py" --no-build-isolation --no-cache-dir || {
                 echo -e "${YELLOW}petsc4py build failed${NC}"
                 exit 1
             }
@@ -297,11 +297,13 @@ run_petsc_cmd() {
             # Nuke stale build artifacts and petsc4py. The next ./uw build's
             # target-change detection can't fire because the still-installed
             # petsc4py reports the OLD arch, so we force a full rebuild here.
+            # (run_build already passes --no-cache-dir to pip install . so we
+            # don't need a global pip cache purge — only petsc4py's local-path
+            # install needs its own --no-cache-dir.)
             echo ""
             echo "Clearing stale build artifacts for clean rebuild..."
             rm -rf "$SCRIPT_DIR"/build/lib.* "$SCRIPT_DIR"/build/temp.* "$SCRIPT_DIR"/build/bdist.* 2>/dev/null
             rm -f "$SCRIPT_DIR/build/.petsc_target"
-            $PIXI run -e "$(get_env)" pip cache purge 2>/dev/null || true
             if is_amr_env "$(get_env)"; then
                 echo "Uninstalling old petsc4py (linked to previous PETSc build)..."
                 $PIXI run -e "$(get_env)" pip uninstall -y petsc4py 2>/dev/null || true


### PR DESCRIPTION
## Why

Issue #96 (BdIntegral parallel hang) was fixed by a PETSc version bump that ships the upstream ownership fix. That merged in #115, but after switching PETSc the build system was leaving stale compiled code in place: users who pulled the fix and did `./uw petsc switch` + `./uw build` still loaded extensions linked against the previous PETSc. The #96 fix wasn't actually reaching their installs, and code like jcgraciosa's that depended on it stayed broken.

Three places were silently assuming PETSc never changes during the life of an install. Fixing only one or two still leaves a stale-load path open; this PR fixes all three so the chain from `./uw petsc switch` → `./uw build` → `import underworld3` is consistent.

## The three fixes

### 1. `setup.py` — honour `PETSC_DIR` / `PETSC_ARCH` env vars first

`setup.py::configure()` was trying `import petsc` (the conda pip package) first, which returns the conda PETSc path even when `$PETSC_DIR`/`$PETSC_ARCH` point at a custom build — so the custom build was silently ignored and underworld3 compiled against the wrong `libpetsc`. It also only consulted env vars as a corner case inside the conda fallback.

Explicit priority chain now:
1. `$PETSC_DIR` / `$PETSC_ARCH` from the environment (pixi activation, shell, HPC module)
2. `petsc4py.get_config()` — authoritative match for the installed `petsc4py`
3. conda `petsc` pip package
4. `CONDA_PREFIX/lib/.../site-packages/petsc` fallback

Env vars are the most specific signal and should win.

### 2. `./uw petsc switch` — nuke stale wheels and `petsc4py`

`./uw build` already has target-change detection via `build/.petsc_target`, but it reads `petsc4py.get_config()` to identify the "current" target. Right after a switch, `petsc4py` is still the old one and reports the old arch, so the check doesn't fire, pip's wheel cache (version `0.0.0` collides forever) and Cython's `build/lib.*`/`build/temp.*` both hand back the previous build.

`./uw petsc switch` now forces the clean rebuild path at switch time:
- remove `build/lib.*`, `build/temp.*`, `build/bdist.*`, and `build/.petsc_target`
- `pip cache purge`
- uninstall `petsc4py` in AMR envs (rebuilt by the next `./uw build` against the new PETSc)

### 3. `pixi.toml` → activation script — make `PETSC_ARCH` actually change when PETSc changes

`[feature.*.activation.env] PETSC_ARCH = "petsc-*-uw-*"` was pinned in tracked `pixi.toml`. Since pixi caches its solve against `pixi.toml` content, `$PETSC_ARCH` inside a pixi shell could disagree with `petsc-custom/.petsc-version` whenever the latter changed.

Replace the five hardcoded entries (features `amr` [osx-arm64 / linux-64], `amr-mpich`, `amr-openmpi`, `amr-debug`) with a single activation script wired in per-feature:

```toml
[feature.amr.activation]
scripts = ["petsc-custom/activate-petsc-arch.sh"]
```

The script (sourced on every `pixi shell` / `pixi run`) reads `petsc-custom/.petsc-version` plus `$PIXI_ENVIRONMENT_NAME` (and `uname` for the generic `amr` env) and exports `PETSC_ARCH=petsc-{ver}-uw-{mpi}{suffix}`. Non-AMR envs match no case and leave `PETSC_ARCH` unset — no-op for `default`/`runtime`/`dev`/`mpich`/`openmpi`.

`pixi.toml` now stays static across PETSc versions; switching touches only the gitignored `.petsc-version`.

## How the three fit together

```
./uw petsc switch v3.25.0
 │
 ├─ .petsc-version       ← updated
 ├─ build/.petsc_target  ← deleted
 ├─ build/lib.* temp.*   ← deleted
 ├─ pip cache            ← purged
 └─ petsc4py             ← uninstalled (AMR envs)

./uw build
 │
 ├─ pixi shell           → activate-petsc-arch.sh runs, exports new PETSC_ARCH
 ├─ petsc4py rebuild     → against new PETSc
 └─ setup.py             → honours PETSC_DIR/PETSC_ARCH env vars (not the
                           stale petsc4py.get_config()) → links against new PETSc
```

Any single one of these in isolation still leaves a stale-load path; the three together close the loop.

## Test plan
- [ ] From a clean build, `./uw petsc switch v3.25.0` (or any other tag) then `./uw petsc build && ./uw build` produces an `underworld3` importable against the new arch.
- [ ] **Link-time verification:** after a switch + rebuild, confirm the installed `.so` is linked against the new PETSc, not the old one:
  ```
  otool -L .pixi/envs/amr-dev/lib/python3.12/site-packages/underworld3/cython/petsc_maths.cpython-312-darwin.so | grep petsc
  ```
  Should resolve to `petsc-{new-ver}-uw-openmpi/lib/libpetsc.{new-ver}.dylib`, not the previous `petsc-{old-ver}-*`.
- [ ] `import petsc4py; petsc4py.get_config()` post-switch reports the new `PETSC_DIR`/`PETSC_ARCH`.
- [ ] `git diff pixi.toml` after a switch is empty.
- [ ] `pixi run -e amr-dev env | grep PETSC_ARCH` matches `./uw petsc active`.
- [ ] `pixi run -e default env | grep -c PETSC_ARCH` is `0` (script is a no-op off-AMR).
- [ ] Parallel reproducer for #96 stops hanging against a freshly-switched PETSc — confirms the fix actually reaches the user-facing install (jcgraciosa's code path was blocked here).

## Notes for reviewers
- Three commits, reviewable independently.
- After merge, contributors on older checkouts should `pixi install -e <env>` once to pick up the per-feature activation-script wiring.
- `./uw` still contains `petsc_arch_for_env()` for internal diagnostics; it reads the same `.petsc-version` so its output stays consistent with the activation script.

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)