### PR TITLE
Fix mesh.X.coords stale after mesh deformation

### DIFF
--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -1283,6 +1283,20 @@ class Mesh(Stateful, uw_object):
         self.dm.setCoordinatesLocal(coord_vec)
         self.nuke_coords_and_rebuild()
 
+        # Rebuild the _coords array view.  nuke_coords_and_rebuild may
+        # replace the coordinate vector internally (createCoordinateSpace),
+        # leaving self._coords as a stale numpy view of the old buffer.
+        import underworld3.utilities
+        old_callbacks = getattr(self._coords, "_callbacks", [])
+        self._coords = underworld3.utilities.NDArray_With_Callback(
+            numpy.ndarray.view(
+                self.dm.getCoordinatesLocal().array.reshape(-1, self.cdim)
+            ),
+            owner=self,
+        )
+        for cb in old_callbacks:
+            self._coords.add_callback(cb)
+
         return
 
     def _legacy_access(self, *writeable_vars: "MeshVariable"):


### PR DESCRIPTION
## Summary

- `mesh.X.coords` returned pre-deformation coordinates after `_deform_mesh()` because `self._coords` held a numpy view of the old coordinate buffer
- `nuke_coords_and_rebuild` (called by `_deform_mesh`) replaces the DM's coordinate vector via `createCoordinateSpace`, but `self._coords` was never updated to view the new buffer
- Fix: rebuild the `NDArray_With_Callback` wrapper from the current DM coordinate vector after `nuke_coords_and_rebuild`, preserving the deformation callback

## Reproducer (from @NengLu)

```python
mesh = uw.meshing.StructuredQuadBox(elementRes=(50, 50), ...)
# ... solve for displacement, compute new coords ...
mesh._deform_mesh(mesh.X.coords + displacement)

# Before fix: mesh.X.coords shows original (undeformed) coordinates
# After fix: mesh.X.coords matches mesh.dm.getCoordinatesLocal()
```

## Test plan

- [x] NengLu's reproducer: `mesh.X.coords` matches `mesh.dm.getCoordinatesLocal()` after deformation
- [ ] @NengLu to verify in their workflow

Closes #122

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)