### PR TITLE
Copy .petsc-version to new worktrees

### DIFF
--- a/uw
+++ b/uw
@@ -1164,6 +1164,14 @@ worktree_create() {
         echo -e "    ${GREEN}✓${NC} petsc-custom/petsc → main repo (shared)"
     fi
 
+    # .petsc-version — copy (not symlink) so each worktree can pin its own
+    # PETSc version independently.  Initialised from the main repo's current
+    # version; the worktree can later run ./uw petsc switch to diverge.
+    if [ -f "$main_repo/petsc-custom/.petsc-version" ]; then
+        cp "$main_repo/petsc-custom/.petsc-version" "$wt_path/petsc-custom/.petsc-version"
+        echo -e "    ${GREEN}✓${NC} .petsc-version copied ($(cat "$main_repo/petsc-custom/.petsc-version"))"
+    fi
+
     # .pixi-env — copy so ./uw knows which environment to use
     if [ -f "$main_repo/.pixi-env" ]; then
         cp "$main_repo/.pixi-env" "$wt_path/.pixi-env"

--- a/uw
+++ b/uw
@@ -1164,9 +1164,11 @@ worktree_create() {
         echo -e "    ${GREEN}✓${NC} petsc-custom/petsc → main repo (shared)"
     fi
 
-    # .petsc-version — copy (not symlink) so each worktree can pin its own
-    # PETSc version independently.  Initialised from the main repo's current
-    # version; the worktree can later run ./uw petsc switch to diverge.
+    # .petsc-version — copy (not symlink) so each worktree can select a
+    # different already-built PETSC_ARCH (e.g. petsc-324-uw-openmpi vs
+    # petsc-325-uw-openmpi).  Built arch directories coexist in the
+    # shared PETSc source tree; .petsc-version just picks which one
+    # the activation script uses for PETSC_ARCH.
     if [ -f "$main_repo/petsc-custom/.petsc-version" ]; then
         cp "$main_repo/petsc-custom/.petsc-version" "$wt_path/petsc-custom/.petsc-version"
         echo -e "    ${GREEN}✓${NC} .petsc-version copied ($(cat "$main_repo/petsc-custom/.petsc-version"))"


### PR DESCRIPTION
## Summary

- `./uw worktree create` symlinks `petsc-custom/petsc/` (the build directory) but didn't copy `petsc-custom/.petsc-version` (the version pin)
- The pixi activation script (`activate-petsc-arch.sh`) reads `.petsc-version` to derive `PETSC_ARCH` -- without it, worktrees fall back to the default and `./uw build` links against the wrong PETSc
- Fix: copy the file (not symlink) so each worktree can independently pin a different PETSc version

## Test plan

- [x] Verified the file is missing in existing worktrees
- [ ] Create a new worktree and confirm `.petsc-version` is present

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)