### PR TITLE
Fix VE_Stokes first-solve parallel deadlock (#130)

### DIFF
--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -1653,10 +1653,10 @@ class Mesh(Stateful, uw_object):
         # Invalidate projected boundary normals (rebuilt lazily on access)
         self._projected_normals = None
 
-        # TODO(BUG): issue #130 — refill the coord cache for every already-
-        # registered variable. Variables created before this rebuild would
-        # otherwise have their cache entry (from __init__) wiped above and
-        # refill lazily from rank-local code paths (rbf_interpolate), which
+        # BUGFIX(#130): refill the coord cache for every already-registered
+        # variable. Variables created before this rebuild would otherwise
+        # have their cache entry (from __init__) wiped above and refill
+        # lazily from rank-local code paths (rbf_interpolate), which
         # deadlocks when the collectives inside _get_coords_for_basis are
         # reached by only a subset of ranks.
         for _var in list(self.vars.values()):
@@ -2733,6 +2733,12 @@ class Mesh(Stateful, uw_object):
 
         dmnew.restoreGlobalVec(coordsNewG)
         dmnew.restoreLocalVec(coordsNewL)
+        # Clean up the PETSc interpolation objects built above. Without this
+        # they accumulate until Python GC runs — noticeable in long adapt
+        # loops that re-fill the coord cache per variable.
+        matInterp.destroy()
+        if vecScale is not None:
+            vecScale.destroy()
         dmnew.destroy()
         dmfe.destroy()
 

--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -1653,6 +1653,15 @@ class Mesh(Stateful, uw_object):
         # Invalidate projected boundary normals (rebuilt lazily on access)
         self._projected_normals = None
 
+        # TODO(BUG): issue #130 — refill the coord cache for every already-
+        # registered variable. Variables created before this rebuild would
+        # otherwise have their cache entry (from __init__) wiped above and
+        # refill lazily from rank-local code paths (rbf_interpolate), which
+        # deadlocks when the collectives inside _get_coords_for_basis are
+        # reached by only a subset of ranks.
+        for _var in list(self.vars.values()):
+            self._get_coords_for_var(_var)
+
         if verbose and uw.mpi.rank == 0:
             print(
                 f"Mesh Spatial Discretisation Complete",

--- a/src/underworld3/discretisation/discretisation_mesh_variables.py
+++ b/src/underworld3/discretisation/discretisation_mesh_variables.py
@@ -388,8 +388,8 @@ class _BaseMeshVariable(Stateful, uw_object):
         self.mesh.vars[self.clean_name] = self
         self._setup_ds()
 
-        # TODO(BUG): issue #130 — pre-populate the mesh's coordinate cache
-        # for this variable's basis. mesh._get_coords_for_basis contains MPI
+        # BUGFIX(#130): pre-populate the mesh's coordinate cache for this
+        # variable's basis. mesh._get_coords_for_basis contains MPI
         # collectives (DMClone, createInterpolation, globalToLocal) that
         # deadlock when triggered lazily from rank-local code paths (e.g.
         # rbf_interpolate inside global_evaluate_nd's per-particle loop):

--- a/src/underworld3/discretisation/discretisation_mesh_variables.py
+++ b/src/underworld3/discretisation/discretisation_mesh_variables.py
@@ -388,6 +388,18 @@ class _BaseMeshVariable(Stateful, uw_object):
         self.mesh.vars[self.clean_name] = self
         self._setup_ds()
 
+        # TODO(BUG): issue #130 — pre-populate the mesh's coordinate cache
+        # for this variable's basis. mesh._get_coords_for_basis contains MPI
+        # collectives (DMClone, createInterpolation, globalToLocal) that
+        # deadlock when triggered lazily from rank-local code paths (e.g.
+        # rbf_interpolate inside global_evaluate_nd's per-particle loop):
+        # ranks with no exterior points skip the call, while ranks with
+        # exterior points enter the collective and wait forever. Variable
+        # construction is collective, so filling the cache here ensures all
+        # ranks populate it together and subsequent rank-local lookups are
+        # cache hits.
+        self.mesh._get_coords_for_var(self)
+
         # Setup public view of data - using NDArray_With_Callback
         self._array_cache = None  # Will be created lazily when first accessed
         self._data_cache = None  # Will be created lazily when first accessed

--- a/tests/parallel/test_0780_ve_stokes_first_solve_mpi.py
+++ b/tests/parallel/test_0780_ve_stokes_first_solve_mpi.py
@@ -1,0 +1,72 @@
+"""
+MPI regression test for VE_Stokes first-solve deadlock (issue #130).
+
+The bug: the first ``VE_Stokes.solve()`` call on a fresh in-memory mesh
+deadlocked at specific ``(np, mesh)`` partition geometries (e.g. np=4
+with a 16x8 StructuredQuadBox → 4x2 rank partition). Root cause was
+lazy invocation of ``mesh._get_coords_for_basis`` (DMClone +
+createInterpolation + globalToLocal collectives) from rank-local code
+paths in ``global_evaluate_nd``: ranks whose migrated particles were
+all interior skipped the RBF path and never entered the collective,
+while ranks with exterior particles did — deadlocking forever.
+
+The fix pre-populates each variable's coordinate cache at the end of
+``_BaseMeshVariable.__init__`` (a collective context), so subsequent
+rank-local lookups always hit the cache.
+
+This test runs the canonical failure case at np=4, 16x8 and fails fast
+via the pytest timeout rather than blocking indefinitely.
+"""
+
+import sympy
+import pytest
+import underworld3 as uw
+from underworld3.function import expression
+
+
+pytestmark = [
+    pytest.mark.level_2,
+    pytest.mark.tier_a,
+    pytest.mark.mpi(min_size=2),
+    pytest.mark.timeout(60),
+]
+
+
+@pytest.mark.mpi(min_size=2)
+def test_ve_stokes_first_solve_does_not_deadlock():
+    """
+    First VE_Stokes.solve() must complete under MPI on a partition-sensitive
+    mesh (16x8 -> 4x2 rank partition at np=4). Before the fix for issue #130,
+    this hung at the first solve indefinitely.
+    """
+    mesh = uw.meshing.StructuredQuadBox(elementRes=(16, 8))
+    v = uw.discretisation.MeshVariable("V", mesh, mesh.dim, degree=2)
+    p = uw.discretisation.MeshVariable("P", mesh, 1, degree=1)
+
+    stokes = uw.systems.VE_Stokes(
+        mesh, velocityField=v, pressureField=p, order=2
+    )
+    stokes.constitutive_model = (
+        uw.constitutive_models.ViscoElasticPlasticFlowModel
+    )
+    stokes.constitutive_model.Parameters.shear_viscosity_0 = 1.0
+    stokes.constitutive_model.Parameters.shear_modulus = 1.0
+    stokes.constitutive_model.Parameters.dt_elastic = 0.02
+
+    V_top = expression("V_top", 0.5, "Top BC")
+    stokes.add_dirichlet_bc((V_top, 0.0), "Top")
+    stokes.add_dirichlet_bc((0.0, 0.0), "Bottom")
+    stokes.add_dirichlet_bc((sympy.oo, 0.0), "Left")
+    stokes.add_dirichlet_bc((sympy.oo, 0.0), "Right")
+
+    stokes.solve(timestep=0.02)
+
+    # Velocity must carry the top BC. If the solve returned without diverging
+    # (pre-fix deadlock would hit the pytest timeout) but with zero velocity,
+    # something else went wrong.
+    import numpy as np
+    v_max = float(np.abs(v.data).max()) if v.data.size else 0.0
+    gathered = uw.mpi.comm.allgather(v_max)
+    assert max(gathered) > 1.0e-6, (
+        f"Velocity field is effectively zero after solve; max|v|={gathered}"
+    )

--- a/tests/parallel/test_0780_ve_stokes_first_solve_mpi.py
+++ b/tests/parallel/test_0780_ve_stokes_first_solve_mpi.py
@@ -27,12 +27,12 @@ from underworld3.function import expression
 pytestmark = [
     pytest.mark.level_2,
     pytest.mark.tier_a,
-    pytest.mark.mpi(min_size=2),
+    pytest.mark.mpi(min_size=4),
     pytest.mark.timeout(60),
 ]
 
 
-@pytest.mark.mpi(min_size=2)
+@pytest.mark.mpi(min_size=4)
 def test_ve_stokes_first_solve_does_not_deadlock():
     """
     First VE_Stokes.solve() must complete under MPI on a partition-sensitive


### PR DESCRIPTION
## Summary
- Pre-populates the mesh coordinate cache at the end of `_BaseMeshVariable.__init__` so `_get_coords_for_basis` PETSc collectives (`DMClone`, `createInterpolation`, `globalToLocal`) are always entered collectively.
- Defense-in-depth: also repopulates for all registered variables at the end of `nuke_coords_and_rebuild`, so mesh adaptation and DM rebuilds don't re-open the same deadlock window.
- Adds `tests/parallel/test_0780_ve_stokes_first_solve_mpi.py` exercising the canonical np=4, 16×8 failure case with a 60s timeout.

Fixes #130.

## Root cause
`global_evaluate_nd` migrates particles across ranks and evaluates the expression rank-locally. In default mode, interior points use `petsc_interpolate` and exterior points use `rbf_evaluate` → `MeshVariable.rbf_interpolate` → `self.coords_nd` → `mesh._get_coords_for_basis(degree, continuous)`.

`_get_coords_for_basis` contains PETSc collectives on the mesh's communicator. The coord cache was populated lazily on first access, so whichever rank hit the cache miss first entered the collective — but ranks whose migrated particles were all interior skipped `rbf_evaluate` entirely and never arrived. The collective never completed.

That explains the partition sensitivity reported in #130: on a 4×2 partition at 16×8, the migration distribution left some ranks without exterior particles; on a 2×2 partition at 16×16 every rank had some, so every rank reached the collective and it completed.

The fix moves cache population into `_BaseMeshVariable.__init__`, which is always collective (it modifies the mesh DM), ensuring all ranks fill the cache together and subsequent rank-local lookups are cache hits.

Stack traces from the investigation (rank 1 vs. ranks 0/2/3 on the np=4, 16×8 repro) are in the bugfix commit history and the issue thread.

## Test plan
- [x] Full (np, mesh) matrix from the issue
  - np=3 {16×8, 32×16}: was HANG 5/5 → 2.9s / 3.0s
  - np=4 16×8: was HANG 5/5 → 3.2s
  - np=4 {16×16, 32×16}, np=8 16×8: previously OK → still OK
  - np=12 16×8, np=16 16×8 (oversubscribed on 16 logical cores): complete
- [x] New parallel regression test at np=4, 16×8 — passes in 5.5s
- [x] `pytest -m "level_1 and tier_a"` — 56 passed, 3 skipped, no regressions

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)