### PR TITLE
Fix stale solver state after mesh._deform_mesh (re-opened #122)

### DIFF
--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -550,7 +550,16 @@ class SolverBaseClass(uw_object):
         # If JIT cache key matches, the compiled code is identical — only
         # constant values (dt_elastic, scalar viscosity, BDF coeffs) differ.
         # Refresh PetscDS constants and skip all rebuilding.
-        if self.dm is not None and hasattr(self, '_last_jit_cache_key'):
+        #
+        # BUGFIX(#122): must also respect _needs_dm_rebuild. A mesh deform
+        # leaves equations (and therefore the JIT cache key) unchanged, but
+        # the cached DM still carries the pre-deform coordinate layout.
+        # Without this guard, Fast Path 1 fires and the solver solves on
+        # stale coords, computing F(v_prev) ≈ 0 and "converging" in zero
+        # iterations without updating the solution. Fast Path 2 already
+        # checks this flag; Fast Path 1 was missing the same guard.
+        if self.dm is not None and hasattr(self, '_last_jit_cache_key') \
+                and not self._needs_dm_rebuild:
             self._setup_pointwise_functions(verbose, debug=debug, debug_name=debug_name)
 
             if hasattr(self, '_current_jit_cache_key') and \

--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -1792,6 +1792,18 @@ class Mesh(Stateful, uw_object):
         for cb in old_callbacks:
             self._coords.add_callback(cb)
 
+        # BUGFIX(#122): mark registered solvers for rebuild. Since PR #127
+        # ("Trust JIT cache: skip DM rebuild on constant-only parameter
+        # changes") a solver with is_setup=True trusts its cached PETSc DM
+        # / SNES assembly and skips rebuild on the next solve(). After a
+        # coordinate change the cached DM still carries pre-deform
+        # coordinates, so F(v_prev) ≈ 0 and the solver converges in 0
+        # iterations without updating the solution. mesh.adapt() already
+        # does this; _deform_mesh must match.
+        for solver in self._equation_systems_register:
+            if solver is not None and hasattr(solver, "is_setup"):
+                solver.is_setup = False
+
         # Propagate coordinate changes to registered submeshes
         for submesh in self._registered_submeshes:
             submesh.sync_coordinates_from_parent()

--- a/tests/test_0820_deform_mesh_solver_rebuild_regression.py
+++ b/tests/test_0820_deform_mesh_solver_rebuild_regression.py
@@ -1,0 +1,87 @@
+"""Regression test for the re-opened portion of issue #122.
+
+Before the fix, a second call to mesh._deform_mesh() followed by
+stokes.solve(zero_init_guess=False) returned the pre-deform velocity
+field unchanged. The solver's Fast Path 1 (introduced with PR #127)
+short-circuited on a matching JIT cache key without checking the
+_needs_dm_rebuild flag, so the cached DM (pre-deform coords) was reused
+and F(v_prev) ≈ 0 → zero SNES iterations → no update.
+
+Two-part fix:
+  1. _deform_mesh now marks registered solvers is_setup=False, matching
+     the behaviour of mesh.adapt().
+  2. Fast Path 1 now respects _needs_dm_rebuild (matching Fast Path 2).
+
+Either fix alone is insufficient; both must be present.
+"""
+
+import pytest
+import numpy as np
+import sympy
+
+import underworld3 as uw
+
+
+pytestmark = pytest.mark.level_1
+
+
+def test_stokes_velocity_updates_after_second_deform():
+    """Second mesh deform + re-solve must produce a velocity consistent with
+    the new boundary amplitude, not the previous solution.
+    """
+    mesh = uw.meshing.StructuredQuadBox(
+        elementRes=(50, 50), minCoords=(-0.5, -1.0), maxCoords=(0.5, 0.0)
+    )
+    v = uw.discretisation.MeshVariable("V", mesh, mesh.dim, degree=1, continuous=True)
+    p = uw.discretisation.MeshVariable("P", mesh, 1, degree=0, continuous=False)
+
+    def deform_with_amplitude(amp, var_name):
+        """Solve Poisson for a cosine boundary and apply the result as a
+        vertical displacement to the mesh."""
+        disp_fn = amp * sympy.cos(2.0 * sympy.pi * mesh.X[0] / 1.0)
+        Dz = uw.discretisation.MeshVariable(var_name, mesh, 1, degree=1)
+        diff = uw.systems.Poisson(mesh, Dz)
+        diff.constitutive_model = uw.constitutive_models.DiffusionModel
+        diff.constitutive_model.Parameters.diffusivity = 1.0
+        diff.add_essential_bc((disp_fn,), "Top")
+        diff.add_essential_bc((0.0,), "Bottom")
+        diff.solve()
+        disp = np.zeros((mesh.X.coords.shape[0], mesh.dim))
+        disp[:, -1] = uw.function.evaluate(Dz.sym[0], mesh.X.coords)[:, 0, 0]
+        mesh._deform_mesh(mesh.X.coords + disp)
+
+    stokes = uw.systems.Stokes(mesh, velocityField=v, pressureField=p)
+    stokes.constitutive_model = uw.constitutive_models.ViscousFlowModel
+    stokes.bodyforce = sympy.Matrix([0, -1.0])
+    stokes.constitutive_model.Parameters.shear_viscosity_0 = 4e-5
+    stokes.saddle_preconditioner = 1.0 / stokes.constitutive_model.Parameters.shear_viscosity_0
+    stokes.add_essential_bc((0.0, None), "Left")
+    stokes.add_essential_bc((0.0, None), "Right")
+    stokes.add_essential_bc((0.0, 0.0), "Bottom")
+    stokes.tolerance = 1.0e-6
+    stokes.petsc_options["ksp_rtol"] = 1.0e-6
+    stokes.petsc_options["ksp_atol"] = 1.0e-6
+
+    # --- first deform (amp 0.02) ---
+    deform_with_amplitude(0.02, "Dz_a")
+    stokes.solve(zero_init_guess=False)
+    vel_first = uw.function.evaluate(v, mesh.X.coords)[:, 0, :].copy()
+    vmax_first = abs(vel_first).max()
+    assert vmax_first > 1.0, (
+        f"first solve should produce nontrivial velocity (got {vmax_first:.3f})"
+    )
+
+    # --- second deform (additional amp 0.05 → total boundary amp ~0.07) ---
+    deform_with_amplitude(0.05, "Dz_b")
+    stokes.solve(zero_init_guess=False)
+    vel_second = uw.function.evaluate(v, mesh.X.coords)[:, 0, :].copy()
+    vmax_second = abs(vel_second).max()
+
+    # Pre-fix: vmax_second == vmax_first (solver reused stale DM).
+    # Post-fix: velocity scales with boundary amplitude (~3.3-3.5× here).
+    ratio = vmax_second / vmax_first
+    assert ratio > 1.5, (
+        f"velocity did not respond to second deform — ratio {ratio:.2f} "
+        f"(vmax_first={vmax_first:.3f}, vmax_second={vmax_second:.3f}). "
+        "Symptom of the #122 re-opened bug: solver cached pre-deform DM."
+    )


### PR DESCRIPTION
## Summary
- \`_deform_mesh\` now marks registered solvers \`is_setup = False\`, matching \`mesh.adapt()\`.
- Solver \`_build()\` Fast Path 1 now respects \`_needs_dm_rebuild\` (matching Fast Path 2).
- Adds \`tests/test_0820_deform_mesh_solver_rebuild_regression.py\` — level_1 regression from NengLu's reproducer.

Fixes the re-opened portion of #122.

## Root cause
Two holes combined to produce the regression:

**1. \`_deform_mesh\` never invalidated attached solvers.** Before PR #127 (\"Trust JIT cache: skip DM rebuild on constant-only parameter changes\", merged 2026-04-21) this was harmless — the solver always rebuilt its DM on \`solve()\`. PR #127 made the cached DM persistent, so any coord change now has to be signalled explicitly. \`mesh.adapt()\` and submesh re-extraction already do this; \`_deform_mesh\` was the one code path that didn't.

**2. \`_build()\` Fast Path 1 short-circuited on a matching JIT cache key without checking \`_needs_dm_rebuild\`.** Fast Path 2 already checks this flag; Fast Path 1 was missing the guard (\`petsc_generic_snes_solvers.pyx:553\`). A pure mesh deform leaves the equations (and therefore the JIT key) unchanged, so even after fix (1) sets \`is_setup = False\`, Fast Path 1 would still fire and keep the stale DM.

Symptom: \`F(v_prev)\` computed on the cached (pre-deform) DM is ≈ 0, so SNES \"converges\" in zero iterations without updating the solution. \`vel.max()\` stayed at the first-deform value across subsequent deforms.

## Test plan
- [x] NengLu's reproducer from #122:
  - Pre-fix: \`vel.max = 39.50\` after both deforms (ratio 1.00×).
  - Post-fix: \`vel.max = 131.91\` after second deform (ratio 3.34×, matches NengLu's analytical expectation).
- [x] Mesh-side fix alone: insufficient (Fast Path 1 still fires).
- [x] Solver-side fix alone: insufficient (\`_needs_dm_rebuild\` stays False because nothing sets it).
- [x] Both fixes together: reproducer passes.
- [x] New \`tests/test_0820_deform_mesh_solver_rebuild_regression.py\` passes in 15s.
- [x] \`pytest -m \"level_1 and tier_a\"\` on \`amr-dev\`: **56 passed, 3 skipped, 0 failed**. No regressions.

## Notes
NengLu originally reported the re-opened bug as \"the latest other merge introduced a related problem\" on 2026-04-22. The timing matches PR #127 (merged 2026-04-21 12:25 UTC).

Depends on no other open PRs. Orthogonal to #139 (AMR swarm cache invalidation).

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)