### PR TITLE
Add PETSc DMPlex checkpoint reload for mesh variables

### DIFF
--- a/docs/developer/design/petsc-dmplex-checkpoint-reload-plan.md
+++ b/docs/developer/design/petsc-dmplex-checkpoint-reload-plan.md
@@ -1,0 +1,426 @@
+# PETSc DMPlex Checkpoint Reload Plan
+
+## Objective
+
+Implement and validate an exact PETSc DMPlex checkpoint reload path for UW3
+mesh variables.
+
+The target workflow is:
+
+```python
+mesh = uw.discretisation.Mesh("restart.mesh.0.h5", ...)
+v_soln = uw.discretisation.MeshVariable("Velocity", mesh, ...)
+p_soln = uw.discretisation.MeshVariable("Pressure", mesh, ...)
+
+v_soln.load_from_checkpoint(
+    "restart.checkpoint.00000.h5",
+    data_name="Velocity",
+)
+p_soln.load_from_checkpoint(
+    "restart.checkpoint.00000.h5",
+    data_name="Pressure",
+)
+```
+
+This reload path must not use KDTree remapping. It must restore the saved FE
+vectors using PETSc DMPlex topology, section, and vector metadata.
+
+## Commit And Test Workflow
+
+Use small, meaningful commits while implementing this work.
+
+Do `git add` and `git commit` after each coherent feature, fix, or debugging
+checkpoint so progress is easy to inspect and bisect. Do not wait until the end
+to commit everything as one large change, and do not commit after every tiny
+edit.
+
+Create or update unit tests whenever they are needed to prove the behavior or
+prevent regressions. Prefer adding a failing regression test before the fix
+when the failure mode is already known.
+
+Commit at useful milestones, such as:
+
+- adding the first failing regression test
+- adding storage-version `3.0.0` write support
+- exposing or preserving the checkpoint topology SF
+- adding the first working `load_from_checkpoint(...)` helper
+- adding MPI same-rank test coverage
+- adding different-rank reload coverage or documenting its limitation
+- integrating the helper into benchmark-facing workflow tests
+
+Each commit message should describe the specific feature, fix, or debugging
+result included in that commit.
+
+## Problem Statement
+
+UW3 currently has two related but different output paths:
+
+- `mesh.write_timestep(...)`
+- `mesh.write_checkpoint(...)`
+
+`write_timestep()` is visualization / remap oriented. Its reload path,
+`MeshVariable.read_timestep(...)`, reads `/fields/<name>` and
+`/fields/coordinates`, builds a KDTree, and maps values onto the current mesh.
+That is flexible, but it is expensive and memory-heavy at high MPI counts.
+
+`write_checkpoint()` writes PETSc DMPlex restart metadata, including section
+and vector information. This is the correct format for exact restart, but UW3
+does not yet expose a clean, validated helper for loading mesh variables from
+this format.
+
+The benchmark scripts should not manually guess PETSc section/SF details. The
+fix belongs in UW3 checkpoint I/O.
+
+## PETSc Requirements
+
+PETSc's DMPlex HDF5 restart workflow requires these steps:
+
+1. Load topology with `DMPlexTopologyLoad(...)`.
+2. Keep the `PetscSF` returned by topology load.
+3. Load coordinates with `DMPlexCoordinatesLoad(...)`.
+4. Load labels with `DMPlexLabelsLoad(...)`.
+5. If the mesh is redistributed after load, compose the topology-load SF with
+   the redistribution SF.
+6. Load the saved section with `DMPlexSectionLoad(...)`.
+7. Load the saved vector with `DMPlexGlobalVectorLoad(...)`.
+8. Scatter the global vector into UW3's local mesh-variable storage.
+
+The critical object identity requirements are:
+
+- The topology DM name used during reload must match the saved topology group.
+- The section DM name must match the saved variable/subDM group.
+- The vector name must match the saved vector group.
+- The `PetscSF` passed to `DMPlexSectionLoad(...)` must describe the mapping
+  from the saved topology points to the current distributed topology points.
+
+## Required File Format Changes
+
+### 1. Write DMPlex HDF5 Storage Version 3.0.0
+
+Checkpoint mesh and field files should be written with PETSc DMPlex HDF5
+storage version `3.0.0`.
+
+Expected implementation direction:
+
+- Set the HDF5 viewer / PETSc option used by DMPlex output so the saved files
+  contain `dmplex_storage_version = "3.0.0"`.
+- Ensure this is used by `Mesh.write_checkpoint(...)`.
+- Prefer a local option scope or explicit viewer setting if available, rather
+  than mutating global PETSc options permanently.
+
+Expected outcome:
+
+- New checkpoint files report storage version `3.0.0`.
+- Files remain readable by PETSc `3.25.x`.
+- Existing `write_timestep()` behavior is not unintentionally changed.
+
+### 2. Preserve Or Expose The Correct Topology SF
+
+When loading a mesh from a PETSc DMPlex HDF5 file, UW3 currently calls the
+PETSc topology load path internally. The reload implementation must preserve
+or expose the exact `PetscSF` returned by `DMPlexTopologyLoad(...)`.
+
+Expected implementation direction:
+
+- Verify that `_from_plexh5(..., return_sf=True)` stores the topology-load SF
+  on the UW3 mesh object.
+- Confirm whether any subsequent `DM.distribute()` call changes the topology.
+- If redistribution happens, capture the redistribution SF and compose it with
+  the topology-load SF as PETSc documents.
+
+Expected outcome:
+
+- The mesh object has a reliable SF suitable for `DMPlexSectionLoad(...)`.
+- This SF is not guessed from `mesh.sf`, `mesh.sf0`, or `dm.getDefaultSF()`
+  unless those names are explicitly verified to mean the PETSc-required SF.
+
+### 3. Add A Supported MeshVariable Reload Helper
+
+Add a public helper on mesh variables, for example:
+
+```python
+mesh_var.load_from_checkpoint(
+    filename,
+    data_name=None,
+)
+```
+
+Expected behavior:
+
+- `filename` points to a `write_checkpoint()` checkpoint file.
+- `data_name` defaults to `mesh_var.clean_name`.
+- The helper loads section metadata and vector data exactly.
+- The helper updates both global and local PETSc vectors.
+- The helper works under MPI.
+- The helper does not use KDTree, coordinate remapping, or interpolation.
+
+Expected internal sequence:
+
+```python
+if mesh_var._lvec is None:
+    mesh_var._set_vec(available=True)
+
+indexset, subdm = mesh_var.mesh.dm.createSubDM(mesh_var.field_id)
+sectiondm = subdm.clone()
+
+mesh_var.mesh.dm.setName("uw_mesh")
+subdm.setName(data_name)
+sectiondm.setName(data_name)
+mesh_var._gvec.setName(data_name)
+
+gsf, lsf = mesh_var.mesh.dm.sectionLoad(
+    viewer,
+    sectiondm,
+    mesh_var.mesh.<checkpoint_topology_sf>,
+)
+
+subdm.setSection(sectiondm.getSection())
+mesh_var.mesh.dm.globalVectorLoad(viewer, subdm, gsf, mesh_var._gvec)
+subdm.globalToLocal(mesh_var._gvec, mesh_var._lvec, addv=False)
+```
+
+This sketch is not final API code. The important requirement is that UW3 owns
+the PETSc SF and section semantics.
+
+## Current Failure To Reproduce
+
+A temporary Mac test was run with:
+
+- spherical Thieulot benchmark
+- `8` MPI ranks
+- `uw_cellsize = 1/8`
+- PETSc `3.25.0`
+
+The baseline `read_timestep(...)` reload reproduced expected metrics:
+
+```text
+v_l2_norm               = 0.0059010703925659195
+p_l2_norm               = 0.26146895222007555
+sigma_rr_l2_norm_lower  = 0.1900342889700883
+```
+
+A manual PETSc metadata reload first failed because the runtime mesh DM name
+was `plex`, while the checkpoint file stored data under `uw_mesh`:
+
+```text
+Object (dataset) "order" not stored in group /topologies/plex/dms/Velocity
+```
+
+After setting the runtime mesh DM name to `uw_mesh`, the reload reached
+`DMPlexSectionLoad(...)` but failed with:
+
+```text
+Nonconforming object sizes
+SF roots 6421 < pEnd 47112
+```
+
+The same class of failure occurred with:
+
+- `mesh.sf`
+- `mesh.sf0`
+- `mesh.dm.getDefaultSF()`
+
+This strongly indicates that the correct PETSc topology-load SF is not being
+used or not being composed correctly after distribution.
+
+## Step-By-Step Implementation Plan
+
+### Step 1: Add Minimal Unit-Level Checkpoint Reload Test
+
+Create a small test that does not depend on the full spherical benchmark.
+
+Test shape:
+
+1. Create a small mesh under MPI.
+2. Create one continuous scalar variable.
+3. Fill it with deterministic values.
+4. Write `mesh.write_checkpoint(...)`.
+5. Reload mesh from the written checkpoint mesh file.
+6. Create the same mesh variable.
+7. Load the variable with the new checkpoint helper.
+8. Compare values against the original field.
+
+Expected outcome:
+
+- Test passes with `mpirun -np 1`.
+- Test passes with `mpirun -np 2`.
+- No KDTree path is used.
+
+### Step 2: Add Vector Variable Coverage
+
+Extend the test to include a vector variable.
+
+Expected outcome:
+
+- Component ordering is preserved.
+- Local and global vectors are valid after reload.
+- `mesh_var.data` matches expected values.
+
+### Step 3: Add Continuous And Discontinuous Coverage
+
+Test both:
+
+- continuous variables
+- discontinuous variables
+
+Expected outcome:
+
+- Continuous variables reload exactly.
+- Discontinuous variables reload exactly.
+- No coordinate ambiguity appears for discontinuous fields.
+
+### Step 4: Test Same-Rank Reload
+
+Run write and reload with the same MPI rank count.
+
+Examples:
+
+```bash
+mpirun -np 1 pytest tests/parallel/test_checkpoint_reload.py
+mpirun -np 2 pytest tests/parallel/test_checkpoint_reload.py
+mpirun -np 4 pytest tests/parallel/test_checkpoint_reload.py
+```
+
+Expected outcome:
+
+- Same-rank reload works for scalar and vector variables.
+- Global vector sizes and section sizes match.
+
+### Step 5: Test Different-Rank Reload
+
+Run write and reload with different MPI rank counts.
+
+Examples:
+
+```bash
+mpirun -np 1 python write_checkpoint_case.py
+mpirun -np 2 python reload_checkpoint_case.py
+
+mpirun -np 2 python write_checkpoint_case.py
+mpirun -np 4 python reload_checkpoint_case.py
+```
+
+Expected outcome:
+
+- Reload works when PETSc can redistribute correctly.
+- If PETSc cannot support a specific rank-change path, document the limitation
+  explicitly.
+
+### Step 6: Validate Storage Version 3.0.0
+
+After writing checkpoint files, inspect them:
+
+```bash
+h5dump -A restart.mesh.0.h5 | grep dmplex_storage_version
+h5dump -A restart.checkpoint.00000.h5 | grep dmplex_storage_version
+```
+
+Expected outcome:
+
+```text
+dmplex_storage_version = "3.0.0"
+```
+
+### Step 7: Validate Against Spherical Benchmark
+
+After the unit tests pass, validate with a small spherical benchmark case.
+
+Test setup:
+
+```bash
+mpirun -np 8 python ex_stokes_thieulot.py -uw_cellsize 1/8
+mpirun -np 8 python ex_stokes_thieulot.py -uw_cellsize 1/8 -uw_metrics_from_checkpoint_only true
+```
+
+Expected outcome:
+
+- Checkpoint helper reloads velocity and pressure.
+- Metrics match the known `read_timestep(...)` baseline.
+- No KDTree construction occurs during field reload.
+
+### Step 8: Validate At Larger Mesh Size
+
+Run progressively larger spherical cases:
+
+- `1/16`
+- `1/32`
+- `1/64`
+
+Expected outcome:
+
+- Memory usage during reload is lower than the KDTree path.
+- Reload time is stable.
+- Metrics match the existing baseline.
+
+### Step 9: Validate High-Rank Failure Case
+
+The motivating case is spherical `1/128` on `1000+` ranks.
+
+Expected outcome:
+
+- Reload does not exceed requested memory.
+- Velocity and pressure reload complete.
+- Boundary metric computation can proceed without KDTree memory blow-up.
+
+## Debugging Checklist
+
+When reload fails, inspect these items first:
+
+- `dmplex_storage_version` in mesh and checkpoint files.
+- PETSc version used to write and read the files.
+- Runtime mesh DM name.
+- Saved topology group name.
+- Saved section DM group name.
+- Saved vector name.
+- Size of saved `order` dataset.
+- Size of saved `atlasDof` and `atlasOff`.
+- Size of current mesh chart, especially `pEnd`.
+- Root count in the SF passed to `DMPlexSectionLoad(...)`.
+- Whether mesh distribution occurred after topology load.
+- Whether the topology-load SF was composed with the distribution SF.
+
+Useful HDF5 inspection commands:
+
+```bash
+h5ls -r restart.mesh.0.h5
+h5ls -r restart.checkpoint.00000.h5
+h5dump -A restart.mesh.0.h5
+h5dump -A restart.checkpoint.00000.h5
+```
+
+Useful PETSc-level checks:
+
+```python
+mesh.dm.getName()
+mesh.dm.getChart()
+mesh.sf0.getGraph()
+mesh.sf.getGraph()
+mesh.dm.getDefaultSF().getGraph()
+```
+
+## Acceptance Criteria
+
+The implementation is complete only when:
+
+- `write_checkpoint()` writes PETSc DMPlex HDF5 storage version `3.0.0`.
+- UW3 exposes a public checkpoint reload helper for mesh variables.
+- The helper uses PETSc section/vector metadata, not KDTree remapping.
+- Scalar and vector variables reload correctly.
+- Continuous and discontinuous variables reload correctly.
+- MPI reload works at least for same-rank runs.
+- Different-rank support is either working or clearly documented.
+- Spherical benchmark metrics match the previous baseline.
+- The benchmark scripts no longer need manual PETSc reload logic.
+
+## Expected Final Outcome
+
+After this work, benchmark postprocessing should be able to do:
+
+```python
+mesh = uw.discretisation.Mesh("restart.mesh.0.h5", ...)
+v_soln.load_from_checkpoint("restart.checkpoint.00000.h5", "Velocity")
+p_soln.load_from_checkpoint("restart.checkpoint.00000.h5", "Pressure")
+```
+
+This should provide exact FE restart behavior, avoid high-memory KDTree reload,
+and make large spherical benchmark postprocessing practical on high-rank jobs.

--- a/docs/developer/design/petsc-dmplex-checkpoint-reload-plan.md
+++ b/docs/developer/design/petsc-dmplex-checkpoint-reload-plan.md
@@ -1,30 +1,5 @@
 # PETSc DMPlex Checkpoint Reload Plan
 
-## Objective
-
-Implement and validate an exact PETSc DMPlex checkpoint reload path for UW3
-mesh variables.
-
-The target workflow is:
-
-```python
-mesh = uw.discretisation.Mesh("restart.mesh.0.h5", ...)
-v_soln = uw.discretisation.MeshVariable("Velocity", mesh, ...)
-p_soln = uw.discretisation.MeshVariable("Pressure", mesh, ...)
-
-v_soln.read_checkpoint(
-    "restart.checkpoint.00000.h5",
-    data_name="Velocity",
-)
-p_soln.read_checkpoint(
-    "restart.checkpoint.00000.h5",
-    data_name="Pressure",
-)
-```
-
-This reload path must not use KDTree remapping. It must restore the saved FE
-vectors using PETSc DMPlex topology, section, and vector metadata.
-
 ## Commit And Test Workflow
 
 Use small, meaningful commits while implementing this work.
@@ -34,393 +9,239 @@ checkpoint so progress is easy to inspect and bisect. Do not wait until the end
 to commit everything as one large change, and do not commit after every tiny
 edit.
 
-Create or update unit tests whenever they are needed to prove the behavior or
-prevent regressions. Prefer adding a failing regression test before the fix
-when the failure mode is already known.
+Create or update unit tests whenever they are needed to prove behavior or
+prevent regressions. Prefer adding a failing regression test before the fix when
+the failure mode is already known.
 
-Commit at useful milestones, such as:
+## Objective
 
-- adding the first failing regression test
-- adding storage-version `3.0.0` write support
-- exposing or preserving the checkpoint topology SF
-- adding the first working `read_checkpoint(...)` helper
-- adding MPI same-rank test coverage
-- adding different-rank reload coverage or documenting its limitation
-- integrating the helper into benchmark-facing workflow tests
+Provide an exact PETSc DMPlex checkpoint reload path for UW3 mesh variables.
+This path is intended for restart and large-scale postprocessing, not
+visualisation.
 
-Each commit message should describe the specific feature, fix, or debugging
-result included in that commit.
+Target workflow:
 
-## Problem Statement
+```python
+mesh.write_checkpoint(
+    "checkout",
+    outputPath=str(output_dir),
+    meshVars=[v_soln, p_soln],
+    index=0,
+)
+```
 
-UW3 currently has two related but different output paths:
+Default output:
 
-- `mesh.write_timestep(...)`
-- `mesh.write_checkpoint(...)`
+```text
+checkout.mesh.00000.h5
+checkout.Velocity.00000.h5
+checkout.Pressure.00000.h5
+```
 
-`write_timestep()` is visualization / remap oriented. Its reload path,
-`MeshVariable.read_timestep(...)`, reads `/fields/<name>` and
-`/fields/coordinates`, builds a KDTree, and maps values onto the current mesh.
-That is flexible, but it is expensive and memory-heavy at high MPI counts.
+Reload workflow:
 
-`write_checkpoint()` writes PETSc DMPlex restart metadata, including section
-and vector information. This is the correct format for exact restart, but UW3
-does not yet expose a clean, validated helper for loading mesh variables from
-this format.
+```python
+mesh = uw.discretisation.Mesh("checkout.mesh.00000.h5")
+v_soln = uw.discretisation.MeshVariable("Velocity", mesh, mesh.dim, degree=2)
+p_soln = uw.discretisation.MeshVariable("Pressure", mesh, 1, degree=1)
 
-The benchmark scripts should not manually guess PETSc section/SF details. The
-fix belongs in UW3 checkpoint I/O.
+v_soln.read_checkpoint("checkout.Velocity.00000.h5", data_name="Velocity")
+p_soln.read_checkpoint("checkout.Pressure.00000.h5", data_name="Pressure")
+```
+
+The reload path must not use `KDTree` remapping. It must restore FE data through
+PETSc DMPlex topology, section, vector, and `PetscSF` metadata.
+
+## Existing Output Methods
+
+UW3 has two related but different output paths.
+
+| Method | Purpose | Reload method | Strength | Limitation |
+| --- | --- | --- | --- | --- |
+| `mesh.write_timestep(...)` | Visualisation and flexible field remap | `MeshVariable.read_timestep(...)` | Writes XDMF and vertex-field data; can map data onto a different mesh | Uses coordinate/KDTree remapping; memory-heavy for large meshes and high MPI counts |
+| `mesh.write_checkpoint(...)` | Restart and exact postprocessing | `MeshVariable.read_checkpoint(...)` | Uses PETSc DMPlex section/vector metadata; avoids KDTree | Not a visualisation output; no XDMF or vertex-field datasets |
+
+The benchmark scripts should use `write_timestep()` when they need
+visualisation files, and `write_checkpoint()` when they need restart-safe,
+memory-efficient postprocessing.
+
+## Implemented Design
+
+### Checkpoint Writing
+
+`Mesh.write_checkpoint(...)` writes PETSc DMPlex HDF5 storage version `3.0.0`.
+
+The mesh file is named:
+
+```text
+<base>.mesh.<index>.h5
+```
+
+With the default `separate_variable_files=True`, each mesh variable is written
+to its own checkpoint file:
+
+```text
+<base>.<variable>.<index>.h5
+```
+
+With `separate_variable_files=False`, all variables are written into:
+
+```text
+<base>.checkpoint.<index>.h5
+```
+
+Per-variable files are the default because they avoid forcing downstream
+postprocessing to open and move through one very large combined checkpoint file.
+This is useful for large spherical benchmark cases where velocity and pressure
+files can already be large individually.
+
+### Mesh Reload
+
+When a PETSc DMPlex HDF5 mesh is loaded, UW3 keeps the topology-load `PetscSF`
+returned by `DMPlexTopologyLoad(...)`. If UW3 distributes the mesh after load,
+the topology-load SF is composed with the redistribution SF.
+
+This composed SF is stored on the mesh and is the mapping used by
+`MeshVariable.read_checkpoint(...)`.
+
+The mesh DM name is fixed to `uw_mesh` while writing and loading checkpoint
+files so PETSc can find the expected topology groups.
+
+### Variable Reload
+
+`MeshVariable.read_checkpoint(filename, data_name=None)`:
+
+- opens the checkpoint HDF5 file in PETSc HDF5 format
+- loads the saved DMPlex section for `data_name`
+- loads the saved local vector through PETSc's DMPlex local-vector path
+- copies values into the target UW3 variable using section offsets
+- syncs the UW3 local vector back to its global vector
+
+The implementation uses a small Cython wrapper around:
+
+- `DMPlexSectionLoad(...)`
+- `DMPlexLocalVectorLoad(...)`
+
+The wrapper requests only the local-data SF. This avoids failures seen when
+the global-data SF path was constructed before the local checkpoint data could
+be loaded.
 
 ## PETSc Requirements
 
-PETSc's DMPlex HDF5 restart workflow requires these steps:
+The relevant PETSc DMPlex HDF5 restart sequence is:
 
 1. Load topology with `DMPlexTopologyLoad(...)`.
 2. Keep the `PetscSF` returned by topology load.
 3. Load coordinates with `DMPlexCoordinatesLoad(...)`.
 4. Load labels with `DMPlexLabelsLoad(...)`.
-5. If the mesh is redistributed after load, compose the topology-load SF with
-   the redistribution SF.
+5. If the mesh is redistributed, compose the topology-load SF with the
+   redistribution SF.
 6. Load the saved section with `DMPlexSectionLoad(...)`.
-7. Load the saved vector with `DMPlexGlobalVectorLoad(...)`.
-8. Scatter the global vector into UW3's local mesh-variable storage.
+7. Load the saved vector with the DMPlex vector-load API.
+8. Scatter or copy the loaded values into UW3's mesh-variable storage.
 
-The critical object identity requirements are:
+The critical identity requirements are:
 
-- The topology DM name used during reload must match the saved topology group.
-- The section DM name must match the saved variable/subDM group.
-- The vector name must match the saved vector group.
-- The `PetscSF` passed to `DMPlexSectionLoad(...)` must describe the mapping
-  from the saved topology points to the current distributed topology points.
+- topology DM name must match the saved topology group
+- section DM name must match the saved variable group
+- vector name must match the saved vector group
+- the SF passed to section load must map saved topology points to current
+  distributed topology points
 
-## Required File Format Changes
+PETSc reference: [DMPlex manual](https://petsc.org/main/manual/dmplex/).
 
-### 1. Write DMPlex HDF5 Storage Version 3.0.0
+## Tests
 
-Checkpoint mesh and field files should be written with PETSc DMPlex HDF5
-storage version `3.0.0`.
+Current unit coverage is in `tests/test_0003_save_load.py`.
 
-Expected implementation direction:
+The checkpoint roundtrip test covers:
 
-- Set the HDF5 viewer / PETSc option used by DMPlex output so the saved files
-  contain `dmplex_storage_version = "3.0.0"`.
-- Ensure this is used by `Mesh.write_checkpoint(...)`.
-- Prefer a local option scope or explicit viewer setting if available, rather
-  than mutating global PETSc options permanently.
+- scalar variable reload
+- vector variable reload
+- discontinuous variable reload
+- combined checkpoint file reload with `separate_variable_files=False`
+- per-variable checkpoint file reload with the default
+  `separate_variable_files=True`
 
-Expected outcome:
-
-- New checkpoint files report storage version `3.0.0`.
-- Files remain readable by PETSc `3.25.x`.
-- Existing `write_timestep()` behavior is not unintentionally changed.
-
-### 2. Preserve Or Expose The Correct Topology SF
-
-When loading a mesh from a PETSc DMPlex HDF5 file, UW3 currently calls the
-PETSc topology load path internally. The reload implementation must preserve
-or expose the exact `PetscSF` returned by `DMPlexTopologyLoad(...)`.
-
-Expected implementation direction:
-
-- Verify that `_from_plexh5(..., return_sf=True)` stores the topology-load SF
-  on the UW3 mesh object.
-- Confirm whether any subsequent `DM.distribute()` call changes the topology.
-- If redistribution happens, capture the redistribution SF and compose it with
-  the topology-load SF as PETSc documents.
-
-Expected outcome:
-
-- The mesh object has a reliable SF suitable for `DMPlexSectionLoad(...)`.
-- This SF is not guessed from `mesh.sf`, `mesh.sf0`, or `dm.getDefaultSF()`
-  unless those names are explicitly verified to mean the PETSc-required SF.
-
-### 3. Add A Supported MeshVariable Reload Helper
-
-Add a public helper on mesh variables, for example:
-
-```python
-mesh_var.read_checkpoint(
-    filename,
-    data_name=None,
-)
-```
-
-Expected behavior:
-
-- `filename` points to a `write_checkpoint()` checkpoint file.
-- `data_name` defaults to `mesh_var.clean_name`.
-- The helper loads section metadata and vector data exactly.
-- The helper updates both global and local PETSc vectors.
-- The helper works under MPI.
-- The helper does not use KDTree, coordinate remapping, or interpolation.
-
-Expected internal sequence:
-
-```python
-if mesh_var._lvec is None:
-    mesh_var._set_vec(available=True)
-
-indexset, subdm = mesh_var.mesh.dm.createSubDM(mesh_var.field_id)
-sectiondm = subdm.clone()
-
-mesh_var.mesh.dm.setName("uw_mesh")
-subdm.setName(data_name)
-sectiondm.setName(data_name)
-mesh_var._gvec.setName(data_name)
-
-gsf, lsf = mesh_var.mesh.dm.sectionLoad(
-    viewer,
-    sectiondm,
-    mesh_var.mesh.<checkpoint_topology_sf>,
-)
-
-subdm.setSection(sectiondm.getSection())
-mesh_var.mesh.dm.globalVectorLoad(viewer, subdm, gsf, mesh_var._gvec)
-subdm.globalToLocal(mesh_var._gvec, mesh_var._lvec, addv=False)
-```
-
-This sketch is not final API code. The important requirement is that UW3 owns
-the PETSc SF and section semantics.
-
-## Current Failure To Reproduce
-
-A temporary Mac test was run with:
-
-- spherical Thieulot benchmark
-- `8` MPI ranks
-- `uw_cellsize = 1/8`
-- PETSc `3.25.0`
-
-The baseline `read_timestep(...)` reload reproduced expected metrics:
-
-```text
-v_l2_norm               = 0.0059010703925659195
-p_l2_norm               = 0.26146895222007555
-sigma_rr_l2_norm_lower  = 0.1900342889700883
-```
-
-A manual PETSc metadata reload first failed because the runtime mesh DM name
-was `plex`, while the checkpoint file stored data under `uw_mesh`:
-
-```text
-Object (dataset) "order" not stored in group /topologies/plex/dms/Velocity
-```
-
-After setting the runtime mesh DM name to `uw_mesh`, the reload reached
-`DMPlexSectionLoad(...)` but failed with:
-
-```text
-Nonconforming object sizes
-SF roots 6421 < pEnd 47112
-```
-
-The same class of failure occurred with:
-
-- `mesh.sf`
-- `mesh.sf0`
-- `mesh.dm.getDefaultSF()`
-
-This strongly indicates that the correct PETSc topology-load SF is not being
-used or not being composed correctly after distribution.
-
-## Step-By-Step Implementation Plan
-
-### Step 1: Add Minimal Unit-Level Checkpoint Reload Test
-
-Create a small test that does not depend on the full spherical benchmark.
-
-Test shape:
-
-1. Create a small mesh under MPI.
-2. Create one continuous scalar variable.
-3. Fill it with deterministic values.
-4. Write `mesh.write_checkpoint(...)`.
-5. Reload mesh from the written checkpoint mesh file.
-6. Create the same mesh variable.
-7. Load the variable with the new checkpoint helper.
-8. Compare values against the original field.
-
-Expected outcome:
-
-- Test passes with `mpirun -np 1`.
-- Test passes with `mpirun -np 2`.
-- No KDTree path is used.
-
-### Step 2: Add Vector Variable Coverage
-
-Extend the test to include a vector variable.
-
-Expected outcome:
-
-- Component ordering is preserved.
-- Local and global vectors are valid after reload.
-- `mesh_var.data` matches expected values.
-
-### Step 3: Add Continuous And Discontinuous Coverage
-
-Test both:
-
-- continuous variables
-- discontinuous variables
-
-Expected outcome:
-
-- Continuous variables reload exactly.
-- Discontinuous variables reload exactly.
-- No coordinate ambiguity appears for discontinuous fields.
-
-### Step 4: Test Same-Rank Reload
-
-Run write and reload with the same MPI rank count.
-
-Examples:
+Required validation before PR:
 
 ```bash
-mpirun -np 1 pytest tests/parallel/test_checkpoint_reload.py
-mpirun -np 2 pytest tests/parallel/test_checkpoint_reload.py
-mpirun -np 4 pytest tests/parallel/test_checkpoint_reload.py
+./uw python -m pytest tests/test_0003_save_load.py -q
+mpirun -np 2 ./uw python -m pytest tests/test_0003_save_load.py -q
 ```
 
-Expected outcome:
+## Spherical Benchmark Validation
 
-- Same-rank reload works for scalar and vector variables.
-- Global vector sizes and section sizes match.
+The motivating case is spherical benchmark postprocessing at high MPI counts.
+The old `write_timestep()` / `read_timestep()` path can build large KDTree
+mapping structures during reload. At `1/128` this used nearly the full 4.5 TB
+allocation on Gadi.
 
-### Step 5: Test Different-Rank Reload
+The checkpoint method avoids KDTree reload and preserves velocity/pressure
+metrics to roundoff. Boundary stress metrics require the benchmark to recover
+stress consistently after reload. In the spherical benchmark this is handled by
+projecting the six deviatoric-stress components and then forming `sigma_rr`.
 
-Run write and reload with different MPI rank counts.
+### Gadi Evidence
 
-Examples:
+| Resolution | Method | NCPUs | Walltime | Memory used | Status |
+| --- | --- | ---: | ---: | ---: | --- |
+| `1/64` | `write_timestep/read_timestep` | 144 | `00:03:43` | `211.27 GB` | completed |
+| `1/64` | `write_checkpoint/read_checkpoint` | 144 | `00:02:41` | `233.67 GB` | completed |
+| `1/128` | `write_timestep/read_timestep` | 1152 | `00:13:55` | `3.92 TB` | completed near memory limit |
+| `1/128` | `write_checkpoint/read_checkpoint` | 1152 | `00:03:57` | `1.83 TB` | completed |
 
-```bash
-mpirun -np 1 python write_checkpoint_case.py
-mpirun -np 2 python reload_checkpoint_case.py
+The `1/128` checkpoint reload reduced memory by about `2.09 TB` and walltime by
+about `3.5x` for the postprocessing run.
 
-mpirun -np 2 python write_checkpoint_case.py
-mpirun -np 4 python reload_checkpoint_case.py
-```
+### Metric Agreement
 
-Expected outcome:
+`1/128` spherical Thieulot benchmark:
 
-- Reload works when PETSc can redistribute correctly.
-- If PETSc cannot support a specific rank-change path, document the limitation
-  explicitly.
+| Metric | `write_timestep/read_timestep` | `write_checkpoint/read_checkpoint` |
+| --- | ---: | ---: |
+| `v_l2_norm` | `1.4319274480265082e-06` | `1.4319274480231255e-06` |
+| `p_l2_norm` | `5.985841567394967e-04` | `5.985841567395382e-04` |
+| `p_l2_norm_abs` | `1.0566381005355924e-03` | `1.0566381005356654e-03` |
+| `sigma_rr_l2_norm_lower` | `1.117914337768646e-03` | `1.1256362820288926e-03` |
+| `sigma_rr_l2_norm_upper` | `4.461443231341268e-05` | `3.811141458727819e-05` |
+| `u_dot_n_l2_norm_lower_abs` | `2.2509850571644799e-04` | `2.2509850571645164e-04` |
+| `u_dot_n_l2_norm_upper_abs` | `5.535239716141496e-05` | `5.535239716141875e-05` |
 
-### Step 6: Validate Storage Version 3.0.0
+Velocity, pressure, and normal-velocity metrics agree to roundoff. The
+`sigma_rr` values are close but not bitwise identical because the stress
+recovery path changed from the old reload workflow to explicit tau-component
+projection after checkpoint reload.
 
-After writing checkpoint files, inspect them:
+`1/64` spherical Thieulot benchmark:
 
-```bash
-h5dump -A restart.mesh.0.h5 | grep dmplex_storage_version
-h5dump -A restart.checkpoint.00000.h5 | grep dmplex_storage_version
-```
+| Metric | `write_timestep/read_timestep` | `write_checkpoint/read_checkpoint` |
+| --- | ---: | ---: |
+| `v_l2_norm` | `1.1662200663950889e-05` | `1.1662200663957042e-05` |
+| `p_l2_norm` | `2.7573367818459473e-03` | `2.7573367818460497e-03` |
+| `sigma_rr_l2_norm_lower` | `4.368560398155481e-03` | `4.381908965541248e-03` |
+| `sigma_rr_l2_norm_upper` | `1.6315543718450765e-04` | `1.6047310456195621e-04` |
 
-Expected outcome:
+## Remaining PR Readiness Items
 
-```text
-dmplex_storage_version = "3.0.0"
-```
-
-### Step 7: Validate Against Spherical Benchmark
-
-After the unit tests pass, validate with a small spherical benchmark case.
-
-Test setup:
-
-```bash
-mpirun -np 8 python ex_stokes_thieulot.py -uw_cellsize 1/8
-mpirun -np 8 python ex_stokes_thieulot.py -uw_cellsize 1/8 -uw_metrics_from_checkpoint_only true
-```
-
-Expected outcome:
-
-- Checkpoint helper reloads velocity and pressure.
-- Metrics match the known `read_timestep(...)` baseline.
-- No KDTree construction occurs during field reload.
-
-### Step 8: Validate At Larger Mesh Size
-
-Run progressively larger spherical cases:
-
-- `1/16`
-- `1/32`
-- `1/64`
-
-Expected outcome:
-
-- Memory usage during reload is lower than the KDTree path.
-- Reload time is stable.
-- Metrics match the existing baseline.
-
-### Step 9: Validate High-Rank Failure Case
-
-The motivating case is spherical `1/128` on `1000+` ranks.
-
-Expected outcome:
-
-- Reload does not exceed requested memory.
-- Velocity and pressure reload complete.
-- Boundary metric computation can proceed without KDTree memory blow-up.
-
-## Debugging Checklist
-
-When reload fails, inspect these items first:
-
-- `dmplex_storage_version` in mesh and checkpoint files.
-- PETSc version used to write and read the files.
-- Runtime mesh DM name.
-- Saved topology group name.
-- Saved section DM group name.
-- Saved vector name.
-- Size of saved `order` dataset.
-- Size of saved `atlasDof` and `atlasOff`.
-- Size of current mesh chart, especially `pEnd`.
-- Root count in the SF passed to `DMPlexSectionLoad(...)`.
-- Whether mesh distribution occurred after topology load.
-- Whether the topology-load SF was composed with the distribution SF.
-
-Useful HDF5 inspection commands:
-
-```bash
-h5ls -r restart.mesh.0.h5
-h5ls -r restart.checkpoint.00000.h5
-h5dump -A restart.mesh.0.h5
-h5dump -A restart.checkpoint.00000.h5
-```
-
-Useful PETSc-level checks:
-
-```python
-mesh.dm.getName()
-mesh.dm.getChart()
-mesh.sf0.getGraph()
-mesh.sf.getGraph()
-mesh.dm.getDefaultSF().getGraph()
-```
+- Run the unit checkpoint tests on the clean checkpoint-only branch.
+- Add or record one small local benchmark smoke test for reproducibility.
+- Decide whether different-rank checkpoint reload is required for the first PR
+  or should be documented as follow-up validation.
+- Keep the final checkpoint PR branch free of unrelated JIT and macOS compiler
+  commits.
 
 ## Acceptance Criteria
 
-The implementation is complete only when:
+The checkpoint reload implementation is ready for review when:
 
 - `write_checkpoint()` writes PETSc DMPlex HDF5 storage version `3.0.0`.
-- UW3 exposes a public checkpoint reload helper for mesh variables.
-- The helper uses PETSc section/vector metadata, not KDTree remapping.
-- Scalar and vector variables reload correctly.
-- Continuous and discontinuous variables reload correctly.
-- MPI reload works at least for same-rank runs.
-- Different-rank support is either working or clearly documented.
-- Spherical benchmark metrics match the previous baseline.
-- The benchmark scripts no longer need manual PETSc reload logic.
-
-## Expected Final Outcome
-
-After this work, benchmark postprocessing should be able to do:
-
-```python
-mesh = uw.discretisation.Mesh("restart.mesh.0.h5", ...)
-v_soln.read_checkpoint("restart.checkpoint.00000.h5", "Velocity")
-p_soln.read_checkpoint("restart.checkpoint.00000.h5", "Pressure")
-```
-
-This should provide exact FE restart behavior, avoid high-memory KDTree reload,
-and make large spherical benchmark postprocessing practical on high-rank jobs.
+- `write_checkpoint()` supports `outputPath`.
+- `write_checkpoint()` defaults to one checkpoint file per variable.
+- `write_checkpoint(..., separate_variable_files=False)` still supports a
+  combined variable checkpoint file.
+- `MeshVariable.read_checkpoint(...)` reloads through PETSc metadata, not
+  coordinate/KDTree remapping.
+- scalar, vector, and discontinuous variables roundtrip in tests.
+- same-rank MPI reload is validated.
+- benchmark evidence shows the large-memory KDTree reload issue is avoided.

--- a/docs/developer/design/petsc-dmplex-checkpoint-reload-plan.md
+++ b/docs/developer/design/petsc-dmplex-checkpoint-reload-plan.md
@@ -167,7 +167,8 @@ Required validation before PR:
 
 ```bash
 ./uw python -m pytest tests/test_0003_save_load.py -q
-mpirun -np 2 ./uw python -m pytest tests/test_0003_save_load.py -q
+mpirun -np 2 ./uw python -m pytest \
+    tests/test_0003_save_load.py::test_meshvariable_checkpoint_roundtrip -q
 ```
 
 ## Spherical Benchmark Validation

--- a/docs/developer/design/petsc-dmplex-checkpoint-reload-plan.md
+++ b/docs/developer/design/petsc-dmplex-checkpoint-reload-plan.md
@@ -12,11 +12,11 @@ mesh = uw.discretisation.Mesh("restart.mesh.0.h5", ...)
 v_soln = uw.discretisation.MeshVariable("Velocity", mesh, ...)
 p_soln = uw.discretisation.MeshVariable("Pressure", mesh, ...)
 
-v_soln.load_from_checkpoint(
+v_soln.read_checkpoint(
     "restart.checkpoint.00000.h5",
     data_name="Velocity",
 )
-p_soln.load_from_checkpoint(
+p_soln.read_checkpoint(
     "restart.checkpoint.00000.h5",
     data_name="Pressure",
 )
@@ -43,7 +43,7 @@ Commit at useful milestones, such as:
 - adding the first failing regression test
 - adding storage-version `3.0.0` write support
 - exposing or preserving the checkpoint topology SF
-- adding the first working `load_from_checkpoint(...)` helper
+- adding the first working `read_checkpoint(...)` helper
 - adding MPI same-rank test coverage
 - adding different-rank reload coverage or documenting its limitation
 - integrating the helper into benchmark-facing workflow tests
@@ -139,7 +139,7 @@ Expected outcome:
 Add a public helper on mesh variables, for example:
 
 ```python
-mesh_var.load_from_checkpoint(
+mesh_var.read_checkpoint(
     filename,
     data_name=None,
 )
@@ -418,8 +418,8 @@ After this work, benchmark postprocessing should be able to do:
 
 ```python
 mesh = uw.discretisation.Mesh("restart.mesh.0.h5", ...)
-v_soln.load_from_checkpoint("restart.checkpoint.00000.h5", "Velocity")
-p_soln.load_from_checkpoint("restart.checkpoint.00000.h5", "Pressure")
+v_soln.read_checkpoint("restart.checkpoint.00000.h5", "Velocity")
+p_soln.read_checkpoint("restart.checkpoint.00000.h5", "Pressure")
 ```
 
 This should provide exact FE restart behavior, avoid high-memory KDTree reload,

--- a/docs/developer/subsystems/checkpoint-output-and-reload-methods.md
+++ b/docs/developer/subsystems/checkpoint-output-and-reload-methods.md
@@ -1,0 +1,212 @@
+# Checkpoint Output And Reload Methods
+
+UW3 currently has two output/reload workflows for mesh and mesh-variable data.
+They serve different purposes and should not be treated as interchangeable.
+
+## Method A: `write_timestep()` / `read_timestep()`
+
+This is the visualisation and flexible remap workflow.
+
+Example:
+
+```python
+mesh.write_timestep(
+    "output",
+    index=0,
+    outputPath=str(output_dir),
+    meshVars=[velocity, pressure],
+)
+
+velocity.read_timestep("output", "Velocity", 0, outputPath=str(output_dir))
+pressure.read_timestep("output", "Pressure", 0, outputPath=str(output_dir))
+```
+
+Typical files:
+
+```text
+output.mesh.00000.h5
+output.mesh.Velocity.00000.h5
+output.mesh.Pressure.00000.h5
+output.mesh.00000.xdmf
+```
+
+The field files contain coordinate/value datasets such as `/fields/<name>` and
+`/fields/coordinates`, plus vertex-field datasets for visualisation. Reloading
+uses coordinate-based remapping. In practice this means the target variable is
+filled by comparing target coordinates to source coordinates, using a KDTree or
+similar nearest-neighbour/remap process.
+
+### Advantages
+
+- Produces XDMF/HDF5 files suitable for visualisation workflows.
+- Can remap data onto a different mesh or a different node layout.
+- Useful for postprocessing where exact finite-element section identity is not
+  required.
+
+### Disadvantages
+
+- Reload is not an exact PETSc FE-vector restart path.
+- The KDTree/remap step can be memory-heavy for large meshes.
+- At high MPI counts, remap memory can dominate postprocessing memory use.
+- Discontinuous fields and high-order fields rely on coordinate remap behavior
+  rather than PETSc section metadata.
+
+## Method B: `write_checkpoint()` / `read_checkpoint()`
+
+This is the restart and exact postprocessing workflow.
+
+Example:
+
+```python
+mesh.write_checkpoint(
+    "checkout",
+    index=0,
+    outputPath=str(output_dir),
+    meshVars=[velocity, pressure],
+)
+```
+
+Default files:
+
+```text
+checkout.mesh.00000.h5
+checkout.Velocity.00000.h5
+checkout.Pressure.00000.h5
+```
+
+Reload:
+
+```python
+mesh = uw.discretisation.Mesh("checkout.mesh.00000.h5")
+velocity = uw.discretisation.MeshVariable("Velocity", mesh, mesh.dim, degree=2)
+pressure = uw.discretisation.MeshVariable("Pressure", mesh, 1, degree=1)
+
+velocity.read_checkpoint("checkout.Velocity.00000.h5", data_name="Velocity")
+pressure.read_checkpoint("checkout.Pressure.00000.h5", data_name="Pressure")
+```
+
+By default, `write_checkpoint()` writes one checkpoint file per mesh variable.
+Use `separate_variable_files=False` to write all variables to one file:
+
+```python
+mesh.write_checkpoint(
+    "checkout",
+    index=0,
+    outputPath=str(output_dir),
+    meshVars=[velocity, pressure],
+    separate_variable_files=False,
+)
+```
+
+Combined variable file:
+
+```text
+checkout.checkpoint.00000.h5
+```
+
+The checkpoint files store PETSc DMPlex HDF5 storage version `3.0.0` data with
+the section/vector metadata required to reconstruct finite-element vectors.
+Reloading uses PETSc DMPlex topology, section, vector, and `PetscSF` metadata.
+It does not use KDTree coordinate remapping.
+
+### Advantages
+
+- Exact FE-vector reload path for restart and postprocessing.
+- Avoids KDTree memory spikes.
+- Preserves continuous, vector, and discontinuous variable layouts through
+  PETSc section metadata.
+- Per-variable files avoid forcing postprocessing to open one large combined
+  field checkpoint.
+- Better suited to large MPI jobs where memory locality matters.
+
+### Disadvantages
+
+- Does not write XDMF.
+- Does not write `/vertex_fields/...` visualisation datasets.
+- Assumes the checkpoint mesh and variable checkpoint files are used together.
+- Different-rank reload should be validated for each workflow before relying on
+  it in production.
+
+## Which Method To Use
+
+| Use case | Recommended method |
+| --- | --- |
+| ParaView/XDMF visualisation | `write_timestep()` |
+| Flexible remap onto another mesh | `write_timestep()` |
+| Exact restart/postprocessing | `write_checkpoint()` |
+| Large spherical benchmark metric evaluation | `write_checkpoint()` |
+| Avoid KDTree memory growth at high MPI counts | `write_checkpoint()` |
+
+It is valid for production scripts to write both:
+
+```python
+mesh.write_timestep("output", index=0, outputPath=str(output_dir), meshVars=[v, p])
+mesh.write_checkpoint("checkout", index=0, outputPath=str(output_dir), meshVars=[v, p])
+```
+
+The first output is for visualisation. The second output is for restart or
+metrics-from-checkpoint postprocessing.
+
+## Spherical Benchmark Evidence
+
+The spherical Thieulot benchmark exposed the practical difference between the
+two methods. Boundary metric evaluation is run in a second step after the Stokes
+solve. The old reload path used `write_timestep()` output and `read_timestep()`;
+the new path uses `write_checkpoint()` output and `read_checkpoint()`.
+
+### Resource Usage
+
+| Resolution | Method | NCPUs | Walltime | CPU time | Memory used | Exit status |
+| --- | --- | ---: | ---: | ---: | ---: | --- |
+| `1/64` | `write_timestep/read_timestep` | 144 | `00:03:43` | `07:04:27` | `211.27 GB` | `0` |
+| `1/64` | `write_checkpoint/read_checkpoint` | 144 | `00:02:41` | `05:21:14` | `233.67 GB` | `0` |
+| `1/128` | `write_timestep/read_timestep` | 1152 | `00:13:55` | `214:02:57` | `3.92 TB` | `0` |
+| `1/128` | `write_checkpoint/read_checkpoint` | 1152 | `00:03:57` | `64:19:53` | `1.83 TB` | `0` |
+
+For the `1/128` case, checkpoint reload reduced memory by about `2.09 TB` and
+reduced walltime by about `3.5x`.
+
+### Metric Agreement
+
+`1/128` spherical Thieulot benchmark:
+
+| Metric | `write_timestep/read_timestep` | `write_checkpoint/read_checkpoint` | Difference |
+| --- | ---: | ---: | ---: |
+| `v_l2_norm` | `1.4319274480265082e-06` | `1.4319274480231255e-06` | `-3.38e-18` |
+| `p_l2_norm` | `5.985841567394967e-04` | `5.985841567395382e-04` | `4.15e-17` |
+| `p_l2_norm_abs` | `1.0566381005355924e-03` | `1.0566381005356654e-03` | `7.30e-17` |
+| `sigma_rr_l2_norm_lower` | `1.117914337768646e-03` | `1.1256362820288926e-03` | `7.72e-06` |
+| `sigma_rr_l2_norm_upper` | `4.461443231341268e-05` | `3.811141458727819e-05` | `-6.50e-06` |
+| `u_dot_n_l2_norm_lower_abs` | `2.2509850571644799e-04` | `2.2509850571645164e-04` | `3.65e-18` |
+| `u_dot_n_l2_norm_upper_abs` | `5.535239716141496e-05` | `5.535239716141875e-05` | `3.79e-18` |
+
+Velocity, pressure, and normal-velocity metrics agree to roundoff. The
+remaining `sigma_rr` differences are small and come from the benchmark stress
+recovery path. The checkpoint workflow computes stress after reload by
+projecting deviatoric-stress components and forming `sigma_rr`; it does not
+reuse the old `read_timestep()` remap path.
+
+`1/64` spherical Thieulot benchmark:
+
+| Metric | `write_timestep/read_timestep` | `write_checkpoint/read_checkpoint` | Difference |
+| --- | ---: | ---: | ---: |
+| `v_l2_norm` | `1.1662200663950889e-05` | `1.1662200663957042e-05` | `6.15e-18` |
+| `p_l2_norm` | `2.7573367818459473e-03` | `2.7573367818460497e-03` | `1.02e-16` |
+| `sigma_rr_l2_norm_lower` | `4.368560398155481e-03` | `4.381908965541248e-03` | `1.33e-05` |
+| `sigma_rr_l2_norm_upper` | `1.6315543718450765e-04` | `1.6047310456195621e-04` | `-2.68e-06` |
+
+## Notes For Benchmark Scripts
+
+For production benchmark workflows:
+
+- run the solve stage first
+- write `write_timestep()` output if visualisation files are needed
+- write `write_checkpoint()` output for restart/postprocessing
+- exit before metric evaluation
+- run a second metrics-from-checkpoint job
+- reload mesh from `<base>.mesh.<index>.h5`
+- reload fields with `MeshVariable.read_checkpoint(...)`
+- compute metrics from reloaded fields
+
+This separates solver memory from postprocessing memory and avoids the KDTree
+reload path for large benchmark metric jobs.

--- a/docs/examples/WIP/developer_tools/Ex_Checkpoint_Read_MeshVariable-vectors-old.py
+++ b/docs/examples/WIP/developer_tools/Ex_Checkpoint_Read_MeshVariable-vectors-old.py
@@ -128,8 +128,8 @@ vc.data[:, :] = 0.0
 pc.data[:, 0] = 0.0
 index1pc.data[:, 0] = 0.0
 
-pc.load_from_checkpoint(f"test_checkpointing_np1.P.0.h5", data_name="P")
-index1pc.load_from_checkpoint(
+pc.read_checkpoint(f"test_checkpointing_np1.P.0.h5", data_name="P")
+index1pc.read_checkpoint(
     f"test_checkpointing_np1.Index1proc.0.h5", data_name="Index1proc"
 )
 
@@ -296,11 +296,11 @@ v3 = uw.discretisation.MeshVariable("U3", mesh3, mesh3.dim, degree=2)
 p3 = uw.discretisation.MeshVariable("P3", mesh3, 1, degree=1, continuous=True)
 
 # %%
-v3.load_from_checkpoint(f"{expt_name}.U.0.h5", data_name="U")
-p3.load_from_checkpoint(f"{expt_name}.P.0.h5", data_name="P")
+v3.read_checkpoint(f"{expt_name}.U.0.h5", data_name="U")
+p3.read_checkpoint(f"{expt_name}.P.0.h5", data_name="P")
 
-vc.load_from_checkpoint(f"{expt_name}.U.0.h5", data_name="U")
-pc.load_from_checkpoint(f"{expt_name}.P.0.h5", data_name="P")
+vc.read_checkpoint(f"{expt_name}.U.0.h5", data_name="U")
+pc.read_checkpoint(f"{expt_name}.P.0.h5", data_name="P")
 
 
 # %%
@@ -372,7 +372,7 @@ if uw.mpi.rank == 0:
     print("U2", U2[0:7, 0].T)
 
 # %%
-vc.load_from_checkpoint(f"viz_chpt_np{uw.mpi.size}.U.0.h5", data_name="U")
+vc.read_checkpoint(f"viz_chpt_np{uw.mpi.size}.U.0.h5", data_name="U")
 
 # %%
 # it should be fine to test this proc-by-proc
@@ -403,8 +403,8 @@ mesh2 = uw.meshing.UnstructuredSimplexBox(
 v2 = uw.discretisation.MeshVariable("U", mesh2, mesh2.dim, degree=2)
 p2 = uw.discretisation.MeshVariable("P", mesh2, 1, degree=1, continuous=True)
 
-v2.load_from_checkpoint(f"viz_chpt_np{uw.mpi.size}.U.0.h5", data_name="U")
-p2.load_from_checkpoint(f"viz_chpt_np{uw.mpi.size}.P.0.h5", data_name="P")
+v2.read_checkpoint(f"viz_chpt_np{uw.mpi.size}.U.0.h5", data_name="U")
+p2.read_checkpoint(f"viz_chpt_np{uw.mpi.size}.P.0.h5", data_name="P")
 
 
 # TODO: Consider uw.synchronised_array_update() for multi-variable assignment
@@ -432,8 +432,8 @@ mesh3.dm.view()
 v3 = uw.discretisation.MeshVariable("U", mesh3, mesh3.dim, degree=2)
 p3 = uw.discretisation.MeshVariable("P", mesh3, 1, degree=1, continuous=True)
 
-v3.load_from_checkpoint(f"viz_chpt_np{uw.mpi.size}.U.0.h5", data_name="U")
-p3.load_from_checkpoint(f"viz_chpt_np{uw.mpi.size}.P.0.h5", data_name="P")
+v3.read_checkpoint(f"viz_chpt_np{uw.mpi.size}.U.0.h5", data_name="U")
+p3.read_checkpoint(f"viz_chpt_np{uw.mpi.size}.P.0.h5", data_name="P")
 
 # TODO: Consider uw.synchronised_array_update() for multi-variable assignment
 print(f"i   - {uw.mpi.rank}: ", v3.data[0:7, 0].T)

--- a/docs/examples/WIP/developer_tools/Ex_Checkpoint_Read_MeshVariable-vectors.py
+++ b/docs/examples/WIP/developer_tools/Ex_Checkpoint_Read_MeshVariable-vectors.py
@@ -113,11 +113,11 @@ pc.data[:, 0] = 0.0
 indexc.data[:, 0] = 0.0
 
 filename = f"{expt_name}.P.0.h5"
-pc.load_from_checkpoint(filename, data_name="P")
+pc.read_checkpoint(filename, data_name="P")
 filename = f"{expt_name}.U.0.h5"
-vc.load_from_checkpoint(filename, data_name="U")
+vc.read_checkpoint(filename, data_name="U")
 filename = f"{expt_name}.Index.0.h5"
-indexc.load_from_checkpoint(filename, data_name="Index")
+indexc.read_checkpoint(filename, data_name="Index")
 
 # %%
 # mesh.write_visualisation_xdmf(expt_name+"_c",
@@ -286,11 +286,11 @@ v3 = uw.discretisation.MeshVariable("U3", mesh3, mesh3.dim, degree=2)
 p3 = uw.discretisation.MeshVariable("P3", mesh3, 1, degree=1, continuous=True)
 
 # %%
-v3.load_from_checkpoint(f"{expt_name}.U.0.h5", data_name="U")
-p3.load_from_checkpoint(f"{expt_name}.P.0.h5", data_name="P")
+v3.read_checkpoint(f"{expt_name}.U.0.h5", data_name="U")
+p3.read_checkpoint(f"{expt_name}.P.0.h5", data_name="P")
 
-vc.load_from_checkpoint(f"{expt_name}.U.0.h5", data_name="U")
-pc.load_from_checkpoint(f"{expt_name}.P.0.h5", data_name="P")
+vc.read_checkpoint(f"{expt_name}.U.0.h5", data_name="U")
+pc.read_checkpoint(f"{expt_name}.P.0.h5", data_name="P")
 
 
 # %%
@@ -362,7 +362,7 @@ if uw.mpi.rank == 0:
     print("U2", U2[0:7, 0].T)
 
 # %%
-vc.load_from_checkpoint(f"viz_chpt_np{uw.mpi.size}.U.0.h5", data_name="U")
+vc.read_checkpoint(f"viz_chpt_np{uw.mpi.size}.U.0.h5", data_name="U")
 
 # %%
 # it should be fine to test this proc-by-proc
@@ -393,8 +393,8 @@ mesh2 = uw.meshing.UnstructuredSimplexBox(
 v2 = uw.discretisation.MeshVariable("U", mesh2, mesh2.dim, degree=2)
 p2 = uw.discretisation.MeshVariable("P", mesh2, 1, degree=1, continuous=True)
 
-v2.load_from_checkpoint(f"viz_chpt_np{uw.mpi.size}.U.0.h5", data_name="U")
-p2.load_from_checkpoint(f"viz_chpt_np{uw.mpi.size}.P.0.h5", data_name="P")
+v2.read_checkpoint(f"viz_chpt_np{uw.mpi.size}.U.0.h5", data_name="U")
+p2.read_checkpoint(f"viz_chpt_np{uw.mpi.size}.P.0.h5", data_name="P")
 
 
 # TODO: Consider uw.synchronised_array_update() for multi-variable assignment
@@ -422,8 +422,8 @@ mesh3.dm.view()
 v3 = uw.discretisation.MeshVariable("U", mesh3, mesh3.dim, degree=2)
 p3 = uw.discretisation.MeshVariable("P", mesh3, 1, degree=1, continuous=True)
 
-v3.load_from_checkpoint(f"viz_chpt_np{uw.mpi.size}.U.0.h5", data_name="U")
-p3.load_from_checkpoint(f"viz_chpt_np{uw.mpi.size}.P.0.h5", data_name="P")
+v3.read_checkpoint(f"viz_chpt_np{uw.mpi.size}.U.0.h5", data_name="U")
+p3.read_checkpoint(f"viz_chpt_np{uw.mpi.size}.P.0.h5", data_name="P")
 
 # TODO: Consider uw.synchronised_array_update() for multi-variable assignment
 print(f"i   - {uw.mpi.rank}: ", v3.data[0:7, 0].T)

--- a/docs/examples/WIP/developer_tools/Ex_Checkpoint_Read_MeshVariable.py
+++ b/docs/examples/WIP/developer_tools/Ex_Checkpoint_Read_MeshVariable.py
@@ -617,11 +617,11 @@ v3 = uw.discretisation.MeshVariable("U3", mesh3, mesh3.dim, degree=2)
 p3 = uw.discretisation.MeshVariable("P3", mesh3, 1, degree=1, continuous=True)
 
 # %%
-v3.load_from_checkpoint(f"{expt_name}.U.0.h5", data_name="U")
-p3.load_from_checkpoint(f"{expt_name}.P.0.h5", data_name="P")
+v3.read_checkpoint(f"{expt_name}.U.0.h5", data_name="U")
+p3.read_checkpoint(f"{expt_name}.P.0.h5", data_name="P")
 
-vc.load_from_checkpoint(f"{expt_name}.U.0.h5", data_name="U")
-pc.load_from_checkpoint(f"{expt_name}.P.0.h5", data_name="P")
+vc.read_checkpoint(f"{expt_name}.U.0.h5", data_name="U")
+pc.read_checkpoint(f"{expt_name}.P.0.h5", data_name="P")
 
 
 # %%
@@ -693,7 +693,7 @@ if uw.mpi.rank == 0:
     print("U2", U2[0:7, 0].T)
 
 # %%
-vc.load_from_checkpoint(f"viz_chpt_np{uw.mpi.size}.U.0.h5", data_name="U")
+vc.read_checkpoint(f"viz_chpt_np{uw.mpi.size}.U.0.h5", data_name="U")
 
 # %%
 # it should be fine to test this proc-by-proc
@@ -724,8 +724,8 @@ mesh2 = uw.meshing.UnstructuredSimplexBox(
 v2 = uw.discretisation.MeshVariable("U", mesh2, mesh2.dim, degree=2)
 p2 = uw.discretisation.MeshVariable("P", mesh2, 1, degree=1, continuous=True)
 
-v2.load_from_checkpoint(f"viz_chpt_np{uw.mpi.size}.U.0.h5", data_name="U")
-p2.load_from_checkpoint(f"viz_chpt_np{uw.mpi.size}.P.0.h5", data_name="P")
+v2.read_checkpoint(f"viz_chpt_np{uw.mpi.size}.U.0.h5", data_name="U")
+p2.read_checkpoint(f"viz_chpt_np{uw.mpi.size}.P.0.h5", data_name="P")
 
 
 # TODO: Consider uw.synchronised_array_update() for multi-variable assignment
@@ -753,8 +753,8 @@ mesh3.dm.view()
 v3 = uw.discretisation.MeshVariable("U", mesh3, mesh3.dim, degree=2)
 p3 = uw.discretisation.MeshVariable("P", mesh3, 1, degree=1, continuous=True)
 
-v3.load_from_checkpoint(f"viz_chpt_np{uw.mpi.size}.U.0.h5", data_name="U")
-p3.load_from_checkpoint(f"viz_chpt_np{uw.mpi.size}.P.0.h5", data_name="P")
+v3.read_checkpoint(f"viz_chpt_np{uw.mpi.size}.U.0.h5", data_name="U")
+p3.read_checkpoint(f"viz_chpt_np{uw.mpi.size}.P.0.h5", data_name="P")
 
 # TODO: Consider uw.synchronised_array_update() for multi-variable assignment
 print(f"i   - {uw.mpi.rank}: ", v3.data[0:7, 0].T)

--- a/src/underworld3/cython/petsc_discretisation.pyx
+++ b/src/underworld3/cython/petsc_discretisation.pyx
@@ -60,6 +60,34 @@ def petsc_fvm_get_local_cell_sizes(mesh) -> np.array:
         return cell_radii, cell_centroids
 
 
+def petsc_dmplex_load_local_vector(dm, viewer, sectiondm, sf, data_name):
+        """
+        Load a DMPlex checkpoint section and vector through PETSc's local-vector path.
+
+        petsc4py's DMPlex.sectionLoad wrapper always requests both the global and
+        local data SFs. For restart files whose section contains local overlap dofs,
+        the global-data SF construction can fail before the local path is usable.
+        This wrapper follows the PETSc API directly and requests only localDataSF.
+        """
+
+        cdef DM c_dm = dm
+        cdef Viewer c_viewer = viewer
+        cdef DM c_sectiondm = sectiondm
+        cdef SF c_sf = sf
+        cdef Vec c_vec
+        cdef PetscSF local_sf = NULL
+        load_vec = None
+
+        CHKERRQ(DMPlexSectionLoad(c_dm.dm, c_viewer.vwr, c_sectiondm.dm, c_sf.sf, NULL, &local_sf))
+        load_vec = sectiondm.createLocalVec()
+        load_vec.setName(data_name)
+        c_vec = load_vec
+        CHKERRQ(DMPlexLocalVectorLoad(c_dm.dm, c_viewer.vwr, c_sectiondm.dm, local_sf, c_vec.vec))
+        CHKERRQ(PetscSFDestroy(&local_sf))
+
+        return load_vec
+
+
 def petsc_dm_create_submesh_from_label(incoming_dm, label_name, label_value, marked_faces=False):
         """
         Extract a submesh from a DMPlex using a label.

--- a/src/underworld3/cython/petsc_extras.pxi
+++ b/src/underworld3/cython/petsc_extras.pxi
@@ -5,10 +5,11 @@ from petsc4py.PETSc cimport DS,  PetscDS
 from petsc4py.PETSc cimport Vec, PetscVec
 from petsc4py.PETSc cimport Mat, PetscMat
 from petsc4py.PETSc cimport IS,  PetscIS
+from petsc4py.PETSc cimport SF,  PetscSF
 from petsc4py.PETSc cimport FE,  PetscFE
 from petsc4py.PETSc cimport DMLabel, PetscDMLabel
 from petsc4py.PETSc cimport PetscQuadrature, PetscSection
-from petsc4py.PETSc cimport MPI_Comm, PetscMat, GetCommDefault, PetscViewer
+from petsc4py.PETSc cimport MPI_Comm, PetscMat, GetCommDefault, Viewer, PetscViewer
 
 
 from underworld3.cython.petsc_types cimport PetscBool, PetscInt, PetscReal, PetscScalar
@@ -70,6 +71,9 @@ cdef extern from "petsc.h" nogil:
     PetscErrorCode PetscDSAddBdResidual( PetscDS, PetscInt, PetscDSBdResidualFn, PetscDSBdResidualFn )
 
     PetscErrorCode DMPlexCreateSubmesh(PetscDM, PetscDMLabel label, PetscInt value, PetscBool markedFaces, PetscDM *subdm)
+    PetscErrorCode DMPlexSectionLoad(PetscDM, PetscViewer, PetscDM, PetscSF, PetscSF *, PetscSF *)
+    PetscErrorCode DMPlexLocalVectorLoad(PetscDM, PetscViewer, PetscDM, PetscSF, PetscVec)
+    PetscErrorCode PetscSFDestroy(PetscSF *)
     PetscErrorCode UW_DMPlexFilter(PetscDM, PetscDMLabel, PetscInt, PetscBool, PetscBool, PetscDM *)
     PetscErrorCode DMGetLabel(PetscDM dm, const char name[], PetscDMLabel *label)
 

--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -150,11 +150,15 @@ def _from_plexh5(
     viewer = PETSc.ViewerHDF5().create(filename, "r", comm=comm)
     h5plex = PETSc.DMPlex().create(comm=comm)
     h5plex.setName("uw_mesh")
-    sf0 = h5plex.topologyLoad(viewer)
-    h5plex.coordinatesLoad(viewer, sf0)
-    h5plex.labelsLoad(viewer, sf0)
-    h5plex.markBoundaryFaces("All_Boundaries", 1001)
-    viewer.destroy()
+    viewer.pushFormat(PETSc.Viewer.Format.HDF5_PETSC)
+    try:
+        sf0 = h5plex.topologyLoad(viewer)
+        h5plex.coordinatesLoad(viewer, sf0)
+        h5plex.labelsLoad(viewer, sf0)
+        h5plex.markBoundaryFaces("All_Boundaries", 1001)
+    finally:
+        viewer.popFormat()
+        viewer.destroy()
 
     if not return_sf:
         return h5plex
@@ -519,7 +523,7 @@ class Mesh(Stateful, uw_object):
             self.dm.setRefinementUniform()
 
             if not self.dm.isDistributed():
-                self.dm.distribute()
+                self.sf1 = self.dm.distribute()
 
             # self.dm_hierarchy = self.dm.refineHierarchy(refinement)
 
@@ -556,7 +560,7 @@ class Mesh(Stateful, uw_object):
             self.dm.setRefinementUniform()
 
             if not self.dm.isDistributed():
-                self.dm.distribute()
+                self.sf1 = self.dm.distribute()
 
             self.dm_hierarchy = [self.dm]
             for i in range(coarsening):
@@ -577,7 +581,7 @@ class Mesh(Stateful, uw_object):
 
         else:
             if not self.dm.isDistributed():
-                self.dm.distribute()
+                self.sf1 = self.dm.distribute()
 
             self.dm_hierarchy = [self.dm]
             self.dm_h = self.dm.clone()
@@ -2560,30 +2564,33 @@ class Mesh(Stateful, uw_object):
                     checkpoint_file = filename + f".checkpoint.{index:05}.h5"
 
                 viewer = PETSc.ViewerHDF5().create(checkpoint_file, "w", comm=PETSc.COMM_WORLD)
+                viewer.pushFormat(PETSc.Viewer.Format.HDF5_PETSC)
+                try:
+                    # Store the parallel-mesh section information for restoring the checkpoint.
+                    self.dm.sectionView(viewer, self.dm)
 
-                # Store the parallel-mesh section information for restoring the checkpoint.
-                self.dm.sectionView(viewer, self.dm)
+                    if meshVars is not None:
+                        for var in meshVars:
+                            var._sync_lvec_to_gvec()
+                            iset, subdm = self.dm.createSubDM(var.field_id)
+                            subdm.setName(var.clean_name)
+                            self.dm.globalVectorView(viewer, subdm, var._gvec)
+                            self.dm.sectionView(viewer, subdm)
+                            # v._gvec.view(viewer) # would add viz information plus a duplicate of the data
 
-                if meshVars is not None:
-                    for var in meshVars:
-                        var._sync_lvec_to_gvec()
-                        iset, subdm = self.dm.createSubDM(var.field_id)
-                        subdm.setName(var.clean_name)
-                        self.dm.globalVectorView(viewer, subdm, var._gvec)
-                        self.dm.sectionView(viewer, subdm)
-                        # v._gvec.view(viewer) # would add viz information plus a duplicate of the data
+                    if swarmVars is not None:
+                        for svar in swarmVars:
+                            var = svar._meshVar
+                            var._sync_lvec_to_gvec()
+                            iset, subdm = self.dm.createSubDM(var.field_id)
+                            subdm.setName(var.clean_name)
+                            self.dm.globalVectorView(viewer, subdm, var._gvec)
+                            self.dm.sectionView(viewer, subdm)
 
-                if swarmVars is not None:
-                    for svar in swarmVars:
-                        var = svar._meshVar
-                        var._sync_lvec_to_gvec()
-                        iset, subdm = self.dm.createSubDM(var.field_id)
-                        subdm.setName(var.clean_name)
-                        self.dm.globalVectorView(viewer, subdm, var._gvec)
-                        self.dm.sectionView(viewer, subdm)
-
-                uw.mpi.barrier()  # should not be required
-                viewer.destroy()
+                    uw.mpi.barrier()  # should not be required
+                finally:
+                    viewer.popFormat()
+                    viewer.destroy()
         finally:
             if old_dm_name is not None:
                 self.dm.setName(old_dm_name)
@@ -2613,8 +2620,12 @@ class Mesh(Stateful, uw_object):
             # viewer.pushTimestepping(viewer)
             # viewer.setTimestep(index)
 
-        viewer(self.dm)
-        viewer.destroy()
+        viewer.pushFormat(PETSc.Viewer.Format.HDF5_PETSC)
+        try:
+            viewer(self.dm)
+        finally:
+            viewer.popFormat()
+            viewer.destroy()
 
         ## Add boundary metadata to the file
 

--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -2532,16 +2532,76 @@ class Mesh(Stateful, uw_object):
         swarmVars: Optional[list] = [],
         index: Optional[int] = 0,
         unique_id: Optional[bool] = False,
+        separate_variable_files: bool = False,
     ):
-        """Write data in a format that can be restored for restarting the simulation.
+        """Write PETSc DMPlex checkpoint files for restart/postprocessing.
 
-        The difference between this and the visualisation is 1) the parallel section needs
-        to be stored to reload the data correctly, and 2) the visualisation information (vertex form of fields)
-        is not stored. This routine uses dmplex VectorView and VectorLoad functionality.
+        Checkpoint output stores PETSc DMPlex section/vector metadata required
+        for exact parallel reload. Unlike ``write_timestep()``, this is restart
+        output and does not write XDMF or vertex-field visualisation datasets.
+
+        Parameters
+        ----------
+        filename
+            Checkpoint base filename. With ``outputPath`` unset, this may include
+            a directory. With ``outputPath`` set, it is joined to that directory.
+        outputPath
+            Optional output directory, matching the ``write_timestep()`` style.
+        meshUpdates
+            If ``False``, write the mesh checkpoint only when it does not already
+            exist. If ``True``, always write the indexed mesh checkpoint.
+        meshVars, swarmVars
+            Variables to write into checkpoint files.
+        index
+            Checkpoint index used in output filenames.
+        unique_id
+            Preserve existing unique-rank filename behaviour for checkpoint data.
+        separate_variable_files
+            If ``False`` (default), write all variables into one file:
+            ``<base>.checkpoint.<index>.h5``. If ``True``, write one file per
+            variable: ``<base>.<variable>.checkpoint.<index>.h5``.
         """
 
         if outputPath:
             filename = os.path.join(outputPath, filename)
+
+        def _checkpoint_filename(var_name=None):
+            variable_part = f".{var_name}" if var_name is not None else ""
+            if unique_id:
+                return filename + f"{uw.mpi.unique}{variable_part}.checkpoint.{index:05}.h5"
+            return filename + f"{variable_part}.checkpoint.{index:05}.h5"
+
+        def _write_variable(viewer, var):
+            if var._lvec is None:
+                var._set_vec(available=True)
+
+            iset, subdm = self.dm.createSubDM(var.field_id)
+            subdm.setName(var.clean_name)
+            old_lvec_name = var._lvec.getName()
+
+            try:
+                var._lvec.setName(var.clean_name)
+                self.dm.sectionView(viewer, subdm)
+                self.dm.localVectorView(viewer, subdm, var._lvec)
+            finally:
+                var._lvec.setName(old_lvec_name)
+                iset.destroy()
+                subdm.destroy()
+
+        def _write_checkpoint_file(checkpoint_file, variables):
+            viewer = PETSc.ViewerHDF5().create(checkpoint_file, "w", comm=PETSc.COMM_WORLD)
+            viewer.pushFormat(PETSc.Viewer.Format.HDF5_PETSC)
+            try:
+                # Store the parallel-mesh section information for restoring the checkpoint.
+                self.dm.sectionView(viewer, self.dm)
+
+                for var in variables:
+                    _write_variable(viewer, var)
+
+                uw.mpi.barrier()  # should not be required
+            finally:
+                viewer.popFormat()
+                viewer.destroy()
 
         old_dm_name = self.dm.getName()
         self.dm.setName("uw_mesh")
@@ -2561,49 +2621,17 @@ class Mesh(Stateful, uw_object):
                 else:
                     self.write(filename + f".mesh.{index:05}.h5")
 
-                # Checkpoint file
+                variables = []
+                if meshVars is not None:
+                    variables.extend(meshVars)
+                if swarmVars is not None:
+                    variables.extend(svar._meshVar for svar in swarmVars)
 
-                if unique_id:
-                    checkpoint_file = filename + f"{uw.mpi.unique}.checkpoint.{index:05}.h5"
+                if separate_variable_files:
+                    for var in variables:
+                        _write_checkpoint_file(_checkpoint_filename(var.clean_name), [var])
                 else:
-                    checkpoint_file = filename + f".checkpoint.{index:05}.h5"
-
-                viewer = PETSc.ViewerHDF5().create(checkpoint_file, "w", comm=PETSc.COMM_WORLD)
-                viewer.pushFormat(PETSc.Viewer.Format.HDF5_PETSC)
-                try:
-                    # Store the parallel-mesh section information for restoring the checkpoint.
-                    self.dm.sectionView(viewer, self.dm)
-
-                    if meshVars is not None:
-                        for var in meshVars:
-                            if var._lvec is None:
-                                var._set_vec(available=True)
-                            iset, subdm = self.dm.createSubDM(var.field_id)
-                            subdm.setName(var.clean_name)
-                            old_lvec_name = var._lvec.getName()
-                            var._lvec.setName(var.clean_name)
-                            self.dm.sectionView(viewer, subdm)
-                            self.dm.localVectorView(viewer, subdm, var._lvec)
-                            var._lvec.setName(old_lvec_name)
-                            # v._gvec.view(viewer) # would add viz information plus a duplicate of the data
-
-                    if swarmVars is not None:
-                        for svar in swarmVars:
-                            var = svar._meshVar
-                            if var._lvec is None:
-                                var._set_vec(available=True)
-                            iset, subdm = self.dm.createSubDM(var.field_id)
-                            subdm.setName(var.clean_name)
-                            old_lvec_name = var._lvec.getName()
-                            var._lvec.setName(var.clean_name)
-                            self.dm.sectionView(viewer, subdm)
-                            self.dm.localVectorView(viewer, subdm, var._lvec)
-                            var._lvec.setName(old_lvec_name)
-
-                    uw.mpi.barrier()  # should not be required
-                finally:
-                    viewer.popFormat()
-                    viewer.destroy()
+                    _write_checkpoint_file(_checkpoint_filename(), variables)
         finally:
             if old_dm_name is not None:
                 self.dm.setName(old_dm_name)

--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -403,10 +403,11 @@ class Mesh(Stateful, uw_object):
 
                 f.close()
 
-                # This needs to be done when reading a dm from a checkpoint
-                # or building from an imported mesh format
-
-                self.dm.setFromOptions()
+                # Do not call setFromOptions() here. DMPlexTopologyLoad()
+                # returns the topology SF needed to reload checkpoint fields.
+                # setFromOptions() can repartition/reorder the DM before UW
+                # composes that SF with any later redistribution SF, leaving
+                # checkpoint field reloads mapped to stale point numbering.
 
             else:
                 raise RuntimeError(
@@ -2571,21 +2572,29 @@ class Mesh(Stateful, uw_object):
 
                     if meshVars is not None:
                         for var in meshVars:
-                            var._sync_lvec_to_gvec()
+                            if var._lvec is None:
+                                var._set_vec(available=True)
                             iset, subdm = self.dm.createSubDM(var.field_id)
                             subdm.setName(var.clean_name)
-                            self.dm.globalVectorView(viewer, subdm, var._gvec)
+                            old_lvec_name = var._lvec.getName()
+                            var._lvec.setName(var.clean_name)
                             self.dm.sectionView(viewer, subdm)
+                            self.dm.localVectorView(viewer, subdm, var._lvec)
+                            var._lvec.setName(old_lvec_name)
                             # v._gvec.view(viewer) # would add viz information plus a duplicate of the data
 
                     if swarmVars is not None:
                         for svar in swarmVars:
                             var = svar._meshVar
-                            var._sync_lvec_to_gvec()
+                            if var._lvec is None:
+                                var._set_vec(available=True)
                             iset, subdm = self.dm.createSubDM(var.field_id)
                             subdm.setName(var.clean_name)
-                            self.dm.globalVectorView(viewer, subdm, var._gvec)
+                            old_lvec_name = var._lvec.getName()
+                            var._lvec.setName(var.clean_name)
                             self.dm.sectionView(viewer, subdm)
+                            self.dm.localVectorView(viewer, subdm, var._lvec)
+                            var._lvec.setName(old_lvec_name)
 
                     uw.mpi.barrier()  # should not be required
                 finally:

--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -1,5 +1,6 @@
 from typing import Optional, Tuple, Union
 from enum import Enum
+from contextlib import contextmanager
 
 import os
 import weakref
@@ -25,6 +26,24 @@ import underworld3.timing as timing
 ## Introduce these two specific types of coordinate tracking vector objects
 
 from sympy.vector import CoordSys3D
+
+
+@contextmanager
+def _temporary_petsc_option(key, value):
+    opts = PETSc.Options()
+    try:
+        old_value = opts.getString(key)
+    except KeyError:
+        old_value = None
+    opts[key] = value
+    try:
+        yield
+    finally:
+        if old_value is None:
+            opts.delValue(key)
+        else:
+            opts[key] = old_value
+
 
 ## Add the ability to inherit an Enum, so we can add standard boundary
 ## types to ones that are supplied by the users / the meshing module
@@ -128,18 +147,19 @@ def _from_plexh5(
     if comm == None:
         comm = PETSc.COMM_WORLD
 
-    # Use createFromFile for a single-call load (issue #96: the separate
-    # topologyLoad + coordinatesLoad + labelsLoad pipeline leaves the
-    # coordinate DM in a state that DMPlexComputeBdIntegral cannot handle).
-    h5plex = PETSc.DMPlex().createFromFile(filename, interpolate=True, comm=comm)
-
+    viewer = PETSc.ViewerHDF5().create(filename, "r", comm=comm)
+    h5plex = PETSc.DMPlex().create(comm=comm)
     h5plex.setName("uw_mesh")
+    sf0 = h5plex.topologyLoad(viewer)
+    h5plex.coordinatesLoad(viewer, sf0)
+    h5plex.labelsLoad(viewer, sf0)
     h5plex.markBoundaryFaces("All_Boundaries", 1001)
+    viewer.destroy()
 
     if not return_sf:
         return h5plex
     else:
-        return h5plex.getPointSF(), h5plex
+        return sf0, h5plex
 
 
 class Mesh(Stateful, uw_object):
@@ -2514,52 +2534,59 @@ class Mesh(Stateful, uw_object):
         is not stored. This routine uses dmplex VectorView and VectorLoad functionality.
         """
 
-        # The mesh checkpoint is the same as the one required for visualisation
-
-        if not meshUpdates:
-            from pathlib import Path
-
-            mesh_file = filename + ".mesh.0.h5"
-            path = Path(mesh_file)
-            if not path.is_file():
-                self.write(mesh_file)
-
-        else:
-            self.write(filename + f".mesh.{index:05}.h5")
-
-        # Checkpoint file
-
-        if unique_id:
-            checkpoint_file = filename + f"{uw.mpi.unique}.checkpoint.{index:05}.h5"
-        else:
-            checkpoint_file = filename + f".checkpoint.{index:05}.h5"
-
+        old_dm_name = self.dm.getName()
         self.dm.setName("uw_mesh")
-        viewer = PETSc.ViewerHDF5().create(checkpoint_file, "w", comm=PETSc.COMM_WORLD)
 
-        # Store the parallel-mesh section information for restoring the checkpoint.
-        self.dm.sectionView(viewer, self.dm)
+        try:
+            with _temporary_petsc_option("dm_plex_view_hdf5_storage_version", "3.0.0"):
+                # The mesh checkpoint is the same as the one required for visualisation
 
-        if meshVars is not None:
-            for var in meshVars:
-                var._sync_lvec_to_gvec()
-                iset, subdm = self.dm.createSubDM(var.field_id)
-                subdm.setName(var.clean_name)
-                self.dm.globalVectorView(viewer, subdm, var._gvec)
-                self.dm.sectionView(viewer, subdm)
-                # v._gvec.view(viewer) # would add viz information plus a duplicate of the data
+                if not meshUpdates:
+                    from pathlib import Path
 
-        if swarmVars is not None:
-            for svar in swarmVars:
-                var = svar._meshVar
-                var._sync_lvec_to_gvec()
-                iset, subdm = self.dm.createSubDM(var.field_id)
-                subdm.setName(var.clean_name)
-                self.dm.globalVectorView(viewer, subdm, var._gvec)
-                self.dm.sectionView(viewer, subdm)
+                    mesh_file = filename + ".mesh.0.h5"
+                    path = Path(mesh_file)
+                    if not path.is_file():
+                        self.write(mesh_file)
 
-        uw.mpi.barrier()  # should not be required
-        viewer.destroy()
+                else:
+                    self.write(filename + f".mesh.{index:05}.h5")
+
+                # Checkpoint file
+
+                if unique_id:
+                    checkpoint_file = filename + f"{uw.mpi.unique}.checkpoint.{index:05}.h5"
+                else:
+                    checkpoint_file = filename + f".checkpoint.{index:05}.h5"
+
+                viewer = PETSc.ViewerHDF5().create(checkpoint_file, "w", comm=PETSc.COMM_WORLD)
+
+                # Store the parallel-mesh section information for restoring the checkpoint.
+                self.dm.sectionView(viewer, self.dm)
+
+                if meshVars is not None:
+                    for var in meshVars:
+                        var._sync_lvec_to_gvec()
+                        iset, subdm = self.dm.createSubDM(var.field_id)
+                        subdm.setName(var.clean_name)
+                        self.dm.globalVectorView(viewer, subdm, var._gvec)
+                        self.dm.sectionView(viewer, subdm)
+                        # v._gvec.view(viewer) # would add viz information plus a duplicate of the data
+
+                if swarmVars is not None:
+                    for svar in swarmVars:
+                        var = svar._meshVar
+                        var._sync_lvec_to_gvec()
+                        iset, subdm = self.dm.createSubDM(var.field_id)
+                        subdm.setName(var.clean_name)
+                        self.dm.globalVectorView(viewer, subdm, var._gvec)
+                        self.dm.sectionView(viewer, subdm)
+
+                uw.mpi.barrier()  # should not be required
+                viewer.destroy()
+        finally:
+            if old_dm_name is not None:
+                self.dm.setName(old_dm_name)
 
     @timing.routine_timer_decorator
     def write(self, filename: str, index: Optional[int] = None):

--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -2532,7 +2532,7 @@ class Mesh(Stateful, uw_object):
         swarmVars: Optional[list] = [],
         index: Optional[int] = 0,
         unique_id: Optional[bool] = False,
-        separate_variable_files: bool = False,
+        separate_variable_files: bool = True,
     ):
         """Write PETSc DMPlex checkpoint files for restart/postprocessing.
 
@@ -2557,19 +2557,19 @@ class Mesh(Stateful, uw_object):
         unique_id
             Preserve existing unique-rank filename behaviour for checkpoint data.
         separate_variable_files
-            If ``False`` (default), write all variables into one file:
-            ``<base>.checkpoint.<index>.h5``. If ``True``, write one file per
-            variable: ``<base>.<variable>.checkpoint.<index>.h5``.
+            If ``True`` (default), write one file per variable:
+            ``<base>.<variable>.<index>.h5``. If ``False``, write all variables
+            into one file: ``<base>.checkpoint.<index>.h5``.
         """
 
         if outputPath:
             filename = os.path.join(outputPath, filename)
 
         def _checkpoint_filename(var_name=None):
-            variable_part = f".{var_name}" if var_name is not None else ""
+            variable_part = f".{var_name}" if var_name is not None else ".checkpoint"
             if unique_id:
-                return filename + f"{uw.mpi.unique}{variable_part}.checkpoint.{index:05}.h5"
-            return filename + f"{variable_part}.checkpoint.{index:05}.h5"
+                return filename + f"{uw.mpi.unique}{variable_part}.{index:05}.h5"
+            return filename + f"{variable_part}.{index:05}.h5"
 
         def _write_variable(viewer, var):
             if var._lvec is None:
@@ -2613,7 +2613,7 @@ class Mesh(Stateful, uw_object):
                 if not meshUpdates:
                     from pathlib import Path
 
-                    mesh_file = filename + ".mesh.0.h5"
+                    mesh_file = filename + f".mesh.{index:05}.h5"
                     path = Path(mesh_file)
                     if not path.is_file():
                         self.write(mesh_file)

--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -2526,6 +2526,7 @@ class Mesh(Stateful, uw_object):
     def write_checkpoint(
         self,
         filename: str,
+        outputPath: str = "",
         meshUpdates: bool = True,
         meshVars: Optional[list] = [],
         swarmVars: Optional[list] = [],
@@ -2538,6 +2539,9 @@ class Mesh(Stateful, uw_object):
         to be stored to reload the data correctly, and 2) the visualisation information (vertex form of fields)
         is not stored. This routine uses dmplex VectorView and VectorLoad functionality.
         """
+
+        if outputPath:
+            filename = os.path.join(outputPath, filename)
 
         old_dm_name = self.dm.getName()
         self.dm.setName("uw_mesh")

--- a/src/underworld3/discretisation/discretisation_mesh_variables.py
+++ b/src/underworld3/discretisation/discretisation_mesh_variables.py
@@ -1274,7 +1274,7 @@ class _BaseMeshVariable(Stateful, uw_object):
 
     @timing.routine_timer_decorator
     @uw.collective_operation
-    def load_from_checkpoint(
+    def read_checkpoint(
         self,
         filename: str,
         data_name: Optional[str] = None,

--- a/src/underworld3/discretisation/discretisation_mesh_variables.py
+++ b/src/underworld3/discretisation/discretisation_mesh_variables.py
@@ -1272,6 +1272,53 @@ class _BaseMeshVariable(Stateful, uw_object):
 
         return
 
+    @timing.routine_timer_decorator
+    @uw.collective_operation
+    def load_from_checkpoint(
+        self,
+        filename: str,
+        data_name: Optional[str] = None,
+    ):
+        """Load this mesh variable from ``Mesh.write_checkpoint()`` output.
+
+        This is an exact PETSc DMPlex section/vector reload path. It does not
+        use the coordinate/KDTree remapping used by ``read_timestep()``.
+        """
+
+        if data_name is None:
+            data_name = self.clean_name
+
+        if self._lvec is None:
+            self._set_vec(available=True)
+
+        indexset, subdm = self.mesh.dm.createSubDM(self.field_id)
+        sectiondm = subdm.clone()
+        viewer = PETSc.ViewerHDF5().create(filename, "r", comm=PETSc.COMM_WORLD)
+
+        old_mesh_name = self.mesh.dm.getName()
+        old_vec_name = self._gvec.getName()
+
+        try:
+            self.mesh.dm.setName("uw_mesh")
+            subdm.setName(data_name)
+            sectiondm.setName(data_name)
+            self._gvec.setName(data_name)
+
+            gsf, _ = self.mesh.dm.sectionLoad(viewer, sectiondm, self.mesh.sf)
+            subdm.setSection(sectiondm.getSection())
+            self.mesh.dm.globalVectorLoad(viewer, subdm, gsf, self._gvec)
+            subdm.globalToLocal(self._gvec, self._lvec, addv=False)
+        finally:
+            self._gvec.setName(old_vec_name)
+            if old_mesh_name is not None:
+                self.mesh.dm.setName(old_mesh_name)
+            viewer.destroy()
+            sectiondm.destroy()
+            indexset.destroy()
+            subdm.destroy()
+
+        return
+
     @property
     def fn(self) -> sympy.Basic:
         """

--- a/src/underworld3/discretisation/discretisation_mesh_variables.py
+++ b/src/underworld3/discretisation/discretisation_mesh_variables.py
@@ -1292,24 +1292,57 @@ class _BaseMeshVariable(Stateful, uw_object):
             self._set_vec(available=True)
 
         indexset, subdm = self.mesh.dm.createSubDM(self.field_id)
-        sectiondm = subdm.clone()
+        sectiondm = self.mesh.dm.clone()
         viewer = PETSc.ViewerHDF5().create(filename, "r", comm=PETSc.COMM_WORLD)
         viewer.pushFormat(PETSc.Viewer.Format.HDF5_PETSC)
 
         old_mesh_name = self.mesh.dm.getName()
+        old_lvec_name = self._lvec.getName()
         old_vec_name = self._gvec.getName()
 
         try:
             self.mesh.dm.setName("uw_mesh")
             subdm.setName(data_name)
             sectiondm.setName(data_name)
+            self._lvec.setName(data_name)
             self._gvec.setName(data_name)
 
-            gsf, _ = self.mesh.dm.sectionLoad(viewer, sectiondm, self.mesh.sf)
-            subdm.setSection(sectiondm.getSection())
-            self.mesh.dm.globalVectorLoad(viewer, subdm, gsf, self._gvec)
-            subdm.globalToLocal(self._gvec, self._lvec, addv=False)
+            from underworld3.cython.petsc_discretisation import (
+                petsc_dmplex_load_local_vector,
+            )
+
+            loaded_lvec = petsc_dmplex_load_local_vector(
+                self.mesh.dm, viewer, sectiondm, self.mesh.sf, data_name
+            )
+
+            source_section = sectiondm.getSection()
+            target_section = subdm.getSection()
+            source_array = loaded_lvec.array_r
+            target_array = self._lvec.array
+            p_start, p_end = target_section.getChart()
+
+            for point in range(p_start, p_end):
+                target_dof = target_section.getDof(point)
+                if target_dof == 0:
+                    continue
+
+                source_dof = source_section.getDof(point)
+                if source_dof < target_dof:
+                    raise RuntimeError(
+                        f"Checkpoint section has {source_dof} dofs for point {point}, "
+                        f"but target variable requires {target_dof}."
+                    )
+
+                source_offset = source_section.getOffset(point)
+                target_offset = target_section.getOffset(point)
+                target_array[target_offset : target_offset + target_dof] = (
+                    source_array[source_offset : source_offset + target_dof]
+                )
+
+            loaded_lvec.destroy()
+            self._sync_lvec_to_gvec()
         finally:
+            self._lvec.setName(old_lvec_name)
             self._gvec.setName(old_vec_name)
             if old_mesh_name is not None:
                 self.mesh.dm.setName(old_mesh_name)

--- a/src/underworld3/discretisation/discretisation_mesh_variables.py
+++ b/src/underworld3/discretisation/discretisation_mesh_variables.py
@@ -1294,6 +1294,7 @@ class _BaseMeshVariable(Stateful, uw_object):
         indexset, subdm = self.mesh.dm.createSubDM(self.field_id)
         sectiondm = subdm.clone()
         viewer = PETSc.ViewerHDF5().create(filename, "r", comm=PETSc.COMM_WORLD)
+        viewer.pushFormat(PETSc.Viewer.Format.HDF5_PETSC)
 
         old_mesh_name = self.mesh.dm.getName()
         old_vec_name = self._gvec.getName()
@@ -1312,6 +1313,7 @@ class _BaseMeshVariable(Stateful, uw_object):
             self._gvec.setName(old_vec_name)
             if old_mesh_name is not None:
                 self.mesh.dm.setName(old_mesh_name)
+            viewer.popFormat()
             viewer.destroy()
             sectiondm.destroy()
             indexset.destroy()

--- a/src/underworld3/discretisation/enhanced_variables.py
+++ b/src/underworld3/discretisation/enhanced_variables.py
@@ -462,6 +462,10 @@ class EnhancedMeshVariable(DimensionalityMixin, MathematicalMixin):
         """Load from HDF5 plex vector."""
         return self._base_var.load_from_h5_plex_vector(*args, **kwargs)
 
+    def load_from_checkpoint(self, *args, **kwargs):
+        """Load from a PETSc DMPlex checkpoint file."""
+        return self._base_var.load_from_checkpoint(*args, **kwargs)
+
     def write(self, *args, **kwargs):
         """Write variable data to HDF5 file."""
         return self._base_var.write(*args, **kwargs)

--- a/src/underworld3/discretisation/enhanced_variables.py
+++ b/src/underworld3/discretisation/enhanced_variables.py
@@ -462,9 +462,9 @@ class EnhancedMeshVariable(DimensionalityMixin, MathematicalMixin):
         """Load from HDF5 plex vector."""
         return self._base_var.load_from_h5_plex_vector(*args, **kwargs)
 
-    def load_from_checkpoint(self, *args, **kwargs):
+    def read_checkpoint(self, *args, **kwargs):
         """Load from a PETSc DMPlex checkpoint file."""
-        return self._base_var.load_from_checkpoint(*args, **kwargs)
+        return self._base_var.read_checkpoint(*args, **kwargs)
 
     def write(self, *args, **kwargs):
         """Write variable data to HDF5 file."""

--- a/tests/test_0003_save_load.py
+++ b/tests/test_0003_save_load.py
@@ -56,7 +56,13 @@ def test_meshvariable_checkpoint_roundtrip(tmp_path):
     d.data[:, 0] = 5.0 * d.coords[:, 0] + 7.0 * d.coords[:, 1]
 
     checkpoint_base = tmp_path / "restart"
-    mesh.write_checkpoint(str(checkpoint_base), meshUpdates=False, meshVars=[x, u, d], index=0)
+    mesh.write_checkpoint(
+        "restart",
+        outputPath=str(tmp_path),
+        meshUpdates=False,
+        meshVars=[x, u, d],
+        index=0,
+    )
 
     mesh_reloaded = uw.discretisation.Mesh(f"{checkpoint_base}.mesh.0.h5")
     x_reloaded = uw.discretisation.MeshVariable("x", mesh_reloaded, 1, degree=1)

--- a/tests/test_0003_save_load.py
+++ b/tests/test_0003_save_load.py
@@ -63,9 +63,9 @@ def test_meshvariable_checkpoint_roundtrip(tmp_path):
     u_reloaded = uw.discretisation.MeshVariable("u", mesh_reloaded, 2, degree=2)
     d_reloaded = uw.discretisation.MeshVariable("d", mesh_reloaded, 1, degree=1, continuous=False)
 
-    x_reloaded.load_from_checkpoint(f"{checkpoint_base}.checkpoint.00000.h5", data_name="x")
-    u_reloaded.load_from_checkpoint(f"{checkpoint_base}.checkpoint.00000.h5", data_name="u")
-    d_reloaded.load_from_checkpoint(f"{checkpoint_base}.checkpoint.00000.h5", data_name="d")
+    x_reloaded.read_checkpoint(f"{checkpoint_base}.checkpoint.00000.h5", data_name="x")
+    u_reloaded.read_checkpoint(f"{checkpoint_base}.checkpoint.00000.h5", data_name="u")
+    d_reloaded.read_checkpoint(f"{checkpoint_base}.checkpoint.00000.h5", data_name="d")
 
     # Parallel DMPlex reloads may repartition the mesh, so compare against the
     # defining functions on the reloaded coordinates rather than local row order.

--- a/tests/test_0003_save_load.py
+++ b/tests/test_0003_save_load.py
@@ -86,9 +86,10 @@ def test_meshvariable_checkpoint_roundtrip(tmp_path):
         meshUpdates=False,
         meshVars=[x, u, d],
         index=0,
+        separate_variable_files=False,
     )
 
-    mesh_reloaded = uw.discretisation.Mesh(f"{checkpoint_base}.mesh.0.h5")
+    mesh_reloaded = uw.discretisation.Mesh(f"{checkpoint_base}.mesh.00000.h5")
     x_reloaded = uw.discretisation.MeshVariable("x", mesh_reloaded, 1, degree=1)
     u_reloaded = uw.discretisation.MeshVariable("u", mesh_reloaded, 2, degree=2)
     d_reloaded = uw.discretisation.MeshVariable("d", mesh_reloaded, 1, degree=1, continuous=False)
@@ -106,17 +107,16 @@ def test_meshvariable_checkpoint_roundtrip(tmp_path):
         meshUpdates=False,
         meshVars=[x, u, d],
         index=0,
-        separate_variable_files=True,
     )
 
-    mesh_reloaded = uw.discretisation.Mesh(f"{separate_base}.mesh.0.h5")
+    mesh_reloaded = uw.discretisation.Mesh(f"{separate_base}.mesh.00000.h5")
     x_reloaded = uw.discretisation.MeshVariable("x", mesh_reloaded, 1, degree=1)
     u_reloaded = uw.discretisation.MeshVariable("u", mesh_reloaded, 2, degree=2)
     d_reloaded = uw.discretisation.MeshVariable("d", mesh_reloaded, 1, degree=1, continuous=False)
 
-    x_reloaded.read_checkpoint(f"{separate_base}.x.checkpoint.00000.h5", data_name="x")
-    u_reloaded.read_checkpoint(f"{separate_base}.u.checkpoint.00000.h5", data_name="u")
-    d_reloaded.read_checkpoint(f"{separate_base}.d.checkpoint.00000.h5", data_name="d")
+    x_reloaded.read_checkpoint(f"{separate_base}.x.00000.h5", data_name="x")
+    u_reloaded.read_checkpoint(f"{separate_base}.u.00000.h5", data_name="u")
+    d_reloaded.read_checkpoint(f"{separate_base}.d.00000.h5", data_name="d")
 
     assert_reloaded_fields(x_reloaded, u_reloaded, d_reloaded)
 

--- a/tests/test_0003_save_load.py
+++ b/tests/test_0003_save_load.py
@@ -36,6 +36,29 @@ def test_meshvariable_save_and_read(tmp_path):
     assert np.allclose(X.array, X2.array)
 
 
+def test_meshvariable_checkpoint_roundtrip(tmp_path):
+    import underworld3 as uw
+    from underworld3.meshing import UnstructuredSimplexBox
+
+    mesh = UnstructuredSimplexBox(
+        minCoords=(0.0, 0.0),
+        maxCoords=(1.0, 1.0),
+        cellSize=1.0 / 8.0,
+    )
+
+    x = uw.discretisation.MeshVariable("x", mesh, 1, degree=1)
+    x.data[:, 0] = x.coords[:, 0] + 2.0 * x.coords[:, 1]
+
+    checkpoint_base = tmp_path / "restart"
+    mesh.write_checkpoint(str(checkpoint_base), meshUpdates=False, meshVars=[x], index=0)
+
+    mesh_reloaded = uw.discretisation.Mesh(f"{checkpoint_base}.mesh.0.h5")
+    x_reloaded = uw.discretisation.MeshVariable("x", mesh_reloaded, 1, degree=1)
+    x_reloaded.load_from_checkpoint(f"{checkpoint_base}.checkpoint.00000.h5", data_name="x")
+
+    np.testing.assert_allclose(x_reloaded.data, x.data, atol=1.0e-12)
+
+
 def test_swarm_save_and_load(tmp_path):
     import underworld3 as uw
     from underworld3.meshing import UnstructuredSimplexBox

--- a/tests/test_0003_save_load.py
+++ b/tests/test_0003_save_load.py
@@ -55,6 +55,30 @@ def test_meshvariable_checkpoint_roundtrip(tmp_path):
     u.data[:, 1] = u.coords[:, 0] + 4.0 * u.coords[:, 1]
     d.data[:, 0] = 5.0 * d.coords[:, 0] + 7.0 * d.coords[:, 1]
 
+    def assert_reloaded_fields(x_reloaded, u_reloaded, d_reloaded):
+        # Parallel DMPlex reloads may repartition the mesh, so compare against the
+        # defining functions on the reloaded coordinates rather than local row order.
+        np.testing.assert_allclose(
+            x_reloaded.data[:, 0],
+            x_reloaded.coords[:, 0] + 2.0 * x_reloaded.coords[:, 1],
+            atol=1.0e-12,
+        )
+        np.testing.assert_allclose(
+            u_reloaded.data[:, 0],
+            3.0 * u_reloaded.coords[:, 0] - u_reloaded.coords[:, 1],
+            atol=1.0e-12,
+        )
+        np.testing.assert_allclose(
+            u_reloaded.data[:, 1],
+            u_reloaded.coords[:, 0] + 4.0 * u_reloaded.coords[:, 1],
+            atol=1.0e-12,
+        )
+        np.testing.assert_allclose(
+            d_reloaded.data[:, 0],
+            5.0 * d_reloaded.coords[:, 0] + 7.0 * d_reloaded.coords[:, 1],
+            atol=1.0e-12,
+        )
+
     checkpoint_base = tmp_path / "restart"
     mesh.write_checkpoint(
         "restart",
@@ -73,28 +97,28 @@ def test_meshvariable_checkpoint_roundtrip(tmp_path):
     u_reloaded.read_checkpoint(f"{checkpoint_base}.checkpoint.00000.h5", data_name="u")
     d_reloaded.read_checkpoint(f"{checkpoint_base}.checkpoint.00000.h5", data_name="d")
 
-    # Parallel DMPlex reloads may repartition the mesh, so compare against the
-    # defining functions on the reloaded coordinates rather than local row order.
-    np.testing.assert_allclose(
-        x_reloaded.data[:, 0],
-        x_reloaded.coords[:, 0] + 2.0 * x_reloaded.coords[:, 1],
-        atol=1.0e-12,
+    assert_reloaded_fields(x_reloaded, u_reloaded, d_reloaded)
+
+    separate_base = tmp_path / "restart_separate"
+    mesh.write_checkpoint(
+        "restart_separate",
+        outputPath=str(tmp_path),
+        meshUpdates=False,
+        meshVars=[x, u, d],
+        index=0,
+        separate_variable_files=True,
     )
-    np.testing.assert_allclose(
-        u_reloaded.data[:, 0],
-        3.0 * u_reloaded.coords[:, 0] - u_reloaded.coords[:, 1],
-        atol=1.0e-12,
-    )
-    np.testing.assert_allclose(
-        u_reloaded.data[:, 1],
-        u_reloaded.coords[:, 0] + 4.0 * u_reloaded.coords[:, 1],
-        atol=1.0e-12,
-    )
-    np.testing.assert_allclose(
-        d_reloaded.data[:, 0],
-        5.0 * d_reloaded.coords[:, 0] + 7.0 * d_reloaded.coords[:, 1],
-        atol=1.0e-12,
-    )
+
+    mesh_reloaded = uw.discretisation.Mesh(f"{separate_base}.mesh.0.h5")
+    x_reloaded = uw.discretisation.MeshVariable("x", mesh_reloaded, 1, degree=1)
+    u_reloaded = uw.discretisation.MeshVariable("u", mesh_reloaded, 2, degree=2)
+    d_reloaded = uw.discretisation.MeshVariable("d", mesh_reloaded, 1, degree=1, continuous=False)
+
+    x_reloaded.read_checkpoint(f"{separate_base}.x.checkpoint.00000.h5", data_name="x")
+    u_reloaded.read_checkpoint(f"{separate_base}.u.checkpoint.00000.h5", data_name="u")
+    d_reloaded.read_checkpoint(f"{separate_base}.d.checkpoint.00000.h5", data_name="d")
+
+    assert_reloaded_fields(x_reloaded, u_reloaded, d_reloaded)
 
 
 def test_swarm_save_and_load(tmp_path):

--- a/tests/test_0003_save_load.py
+++ b/tests/test_0003_save_load.py
@@ -47,16 +47,29 @@ def test_meshvariable_checkpoint_roundtrip(tmp_path):
     )
 
     x = uw.discretisation.MeshVariable("x", mesh, 1, degree=1)
+    u = uw.discretisation.MeshVariable("u", mesh, 2, degree=2)
+    d = uw.discretisation.MeshVariable("d", mesh, 1, degree=1, continuous=False)
+
     x.data[:, 0] = x.coords[:, 0] + 2.0 * x.coords[:, 1]
+    u.data[:, 0] = 3.0 * u.coords[:, 0] - u.coords[:, 1]
+    u.data[:, 1] = u.coords[:, 0] + 4.0 * u.coords[:, 1]
+    d.data[:, 0] = 5.0 * d.coords[:, 0] + 7.0 * d.coords[:, 1]
 
     checkpoint_base = tmp_path / "restart"
-    mesh.write_checkpoint(str(checkpoint_base), meshUpdates=False, meshVars=[x], index=0)
+    mesh.write_checkpoint(str(checkpoint_base), meshUpdates=False, meshVars=[x, u, d], index=0)
 
     mesh_reloaded = uw.discretisation.Mesh(f"{checkpoint_base}.mesh.0.h5")
     x_reloaded = uw.discretisation.MeshVariable("x", mesh_reloaded, 1, degree=1)
+    u_reloaded = uw.discretisation.MeshVariable("u", mesh_reloaded, 2, degree=2)
+    d_reloaded = uw.discretisation.MeshVariable("d", mesh_reloaded, 1, degree=1, continuous=False)
+
     x_reloaded.load_from_checkpoint(f"{checkpoint_base}.checkpoint.00000.h5", data_name="x")
+    u_reloaded.load_from_checkpoint(f"{checkpoint_base}.checkpoint.00000.h5", data_name="u")
+    d_reloaded.load_from_checkpoint(f"{checkpoint_base}.checkpoint.00000.h5", data_name="d")
 
     np.testing.assert_allclose(x_reloaded.data, x.data, atol=1.0e-12)
+    np.testing.assert_allclose(u_reloaded.data, u.data, atol=1.0e-12)
+    np.testing.assert_allclose(d_reloaded.data, d.data, atol=1.0e-12)
 
 
 def test_swarm_save_and_load(tmp_path):

--- a/tests/test_0003_save_load.py
+++ b/tests/test_0003_save_load.py
@@ -67,9 +67,28 @@ def test_meshvariable_checkpoint_roundtrip(tmp_path):
     u_reloaded.load_from_checkpoint(f"{checkpoint_base}.checkpoint.00000.h5", data_name="u")
     d_reloaded.load_from_checkpoint(f"{checkpoint_base}.checkpoint.00000.h5", data_name="d")
 
-    np.testing.assert_allclose(x_reloaded.data, x.data, atol=1.0e-12)
-    np.testing.assert_allclose(u_reloaded.data, u.data, atol=1.0e-12)
-    np.testing.assert_allclose(d_reloaded.data, d.data, atol=1.0e-12)
+    # Parallel DMPlex reloads may repartition the mesh, so compare against the
+    # defining functions on the reloaded coordinates rather than local row order.
+    np.testing.assert_allclose(
+        x_reloaded.data[:, 0],
+        x_reloaded.coords[:, 0] + 2.0 * x_reloaded.coords[:, 1],
+        atol=1.0e-12,
+    )
+    np.testing.assert_allclose(
+        u_reloaded.data[:, 0],
+        3.0 * u_reloaded.coords[:, 0] - u_reloaded.coords[:, 1],
+        atol=1.0e-12,
+    )
+    np.testing.assert_allclose(
+        u_reloaded.data[:, 1],
+        u_reloaded.coords[:, 0] + 4.0 * u_reloaded.coords[:, 1],
+        atol=1.0e-12,
+    )
+    np.testing.assert_allclose(
+        d_reloaded.data[:, 0],
+        5.0 * d_reloaded.coords[:, 0] + 7.0 * d_reloaded.coords[:, 1],
+        atol=1.0e-12,
+    )
 
 
 def test_swarm_save_and_load(tmp_path):

--- a/tests/test_0003_save_load.py
+++ b/tests/test_0003_save_load.py
@@ -3,11 +3,26 @@ import pytest
 # All tests in this module are quick core tests
 pytestmark = pytest.mark.level_1
 import numpy as np
+from pathlib import Path
+
+
+def _shared_tmp_path(tmp_path, uw):
+    """Use one rank-0 pytest tmp path for collective MPI I/O tests."""
+
+    shared_path = str(tmp_path) if uw.mpi.rank == 0 else None
+    shared_path = uw.mpi.comm.bcast(shared_path, root=0)
+    shared_path = Path(shared_path)
+    if uw.mpi.rank == 0:
+        shared_path.mkdir(parents=True, exist_ok=True)
+    uw.mpi.barrier()
+    return shared_path
 
 
 def test_mesh_save_and_load(tmp_path):
     import underworld3
     from underworld3.meshing import UnstructuredSimplexBox
+
+    tmp_path = _shared_tmp_path(tmp_path, underworld3)
 
     mesh = UnstructuredSimplexBox(minCoords=(0.0, 0.0), maxCoords=(1.0, 1.0), cellSize=1.0 / 32.0)
 
@@ -21,6 +36,8 @@ def test_mesh_save_and_load(tmp_path):
 def test_meshvariable_save_and_read(tmp_path):
     import underworld3
     from underworld3.meshing import UnstructuredSimplexBox
+
+    tmp_path = _shared_tmp_path(tmp_path, underworld3)
 
     mesh = UnstructuredSimplexBox(minCoords=(0.0, 0.0), maxCoords=(1.0, 1.0), cellSize=1.0 / 32.0)
 
@@ -39,6 +56,8 @@ def test_meshvariable_save_and_read(tmp_path):
 def test_meshvariable_checkpoint_roundtrip(tmp_path):
     import underworld3 as uw
     from underworld3.meshing import UnstructuredSimplexBox
+
+    tmp_path = _shared_tmp_path(tmp_path, uw)
 
     mesh = UnstructuredSimplexBox(
         minCoords=(0.0, 0.0),
@@ -125,6 +144,8 @@ def test_swarm_save_and_load(tmp_path):
     import underworld3 as uw
     from underworld3.meshing import UnstructuredSimplexBox
 
+    tmp_path = _shared_tmp_path(tmp_path, uw)
+
     mesh = UnstructuredSimplexBox(minCoords=(0.0, 0.0), maxCoords=(1.0, 1.0), cellSize=1.0 / 32.0)
 
     swarm = uw.swarm.Swarm(mesh)
@@ -136,8 +157,11 @@ def test_swarm_save_and_load(tmp_path):
 
 
 def test_swarmvariable_save_and_load(tmp_path):
+    import underworld3 as uw
     from underworld3 import swarm
     from underworld3.meshing import UnstructuredSimplexBox
+
+    tmp_path = _shared_tmp_path(tmp_path, uw)
 
     mesh = UnstructuredSimplexBox(minCoords=(0.0, 0.0), maxCoords=(1.0, 1.0), cellSize=1.0 / 32.0)
     swarm = swarm.Swarm(mesh)


### PR DESCRIPTION
## Summary

This PR adds a PETSc DMPlex checkpoint reload path for UW3 mesh variables and documents when to use checkpoint output versus timestep/visualisation output.

## Motivation

`write_timestep()` / `read_timestep()` is useful for visualisation and flexible coordinate remapping, but its KDTree/remap path is memory-heavy for large postprocessing jobs. Spherical benchmark postprocessing at `1/128` on Gadi used close to the full 4.5 TB allocation with the old reload path.

This PR adds a restart/postprocessing-oriented path that reloads variables through PETSc DMPlex section/vector metadata instead of KDTree remapping.

## Changes

- Add `MeshVariable.read_checkpoint(...)` for PETSc DMPlex section/vector reload.
- Preserve and compose the topology-load `PetscSF` needed by PETSc DMPlex checkpoint reload.
- Write checkpoint files with PETSc DMPlex HDF5 storage version `3.0.0`.
- Add `outputPath` support to `Mesh.write_checkpoint(...)`.
- Default `write_checkpoint()` to one HDF5 file per mesh variable.
- Keep `separate_variable_files=False` support for a combined variable checkpoint file.
- Add scalar, vector, and discontinuous variable roundtrip test coverage.
- Document the checkpoint reload design and compare output/reload methods.

## File layout

Default checkpoint output now uses:

```text
checkout.mesh.00000.h5
checkout.Velocity.00000.h5
checkout.Pressure.00000.h5
```

Combined variable output remains available with `separate_variable_files=False`:

```text
checkout.checkpoint.00000.h5
```

## Validation

Local tests:

```text
./uw python -m pytest tests/test_0003_save_load.py -q
5 passed

mpirun -np 2 ./uw python -m pytest tests/test_0003_save_load.py::test_meshvariable_checkpoint_roundtrip -q
checkpoint roundtrip passed under 2 MPI ranks
```

Gadi spherical benchmark evidence is documented in:

- `docs/developer/design/petsc-dmplex-checkpoint-reload-plan.md`
- `docs/developer/subsystems/checkpoint-output-and-reload-methods.md`

Key `1/128` result:

| Method | NCPUs | Walltime | Memory used |
| --- | ---: | ---: | ---: |
| `write_timestep/read_timestep` | 1152 | `00:13:55` | `3.92 TB` |
| `write_checkpoint/read_checkpoint` | 1152 | `00:03:57` | `1.83 TB` |

Velocity, pressure, and normal-velocity metrics matched to roundoff in the benchmark comparison. Boundary `sigma_rr` uses a benchmark-side post-reload stress-recovery path and is documented separately from the checkpoint reload mechanism.

## Notes

The full `tests/test_0003_save_load.py` module under MPI includes broader swarm save/load behavior and was not used as the MPI checkpoint validation target. The checkpoint-specific roundtrip test passes under 2 MPI ranks.