### PR TITLE
Default Stokes velocity subsolve to FGMRES (#147)

### DIFF
--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -3990,8 +3990,10 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
         p_name = "pressure" # pressureField.clean_name
         v_name = "velocity" # velocityField.clean_name
 
-        # Works / mostly quick
+        # Pressure subsolve — flexible GMRES + GASM. (FGMRES is right-
+        # preconditioned by construction; no need to set pc_side explicitly.)
         self.petsc_options[f"fieldsplit_{p_name}_ksp_type"] = "fgmres"
+        self.petsc_options[f"fieldsplit_{p_name}_ksp_max_it"] = 200
         self.petsc_options[f"fieldsplit_{p_name}_ksp_rtol"]  = self._tolerance
         self.petsc_options[f"fieldsplit_{p_name}_pc_type"] = "gasm"
         # self.petsc_options[f"fieldsplit_{p_name}_pc_gasm_type"] = "basic"
@@ -4003,8 +4005,20 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
         # self.petsc_options[f"fieldsplit_{p_name}_pc_gamg_type"] = "agg"
         # self.petsc_options[f"fieldsplit_{p_name}_pc_gamg_repartition"] = True
 
-        # Great set of options for gamg
-        self.petsc_options[f"fieldsplit_{v_name}_ksp_type"] = "cg"
+        # Velocity subsolve — flexible GMRES + GAMG.
+        #
+        # FGMRES (not CG/FCG) is the default to remain robust under non-stationary
+        # preconditioning and weakly-indefinite coarse operators. The mg_levels
+        # KSP is bounded but variable-iteration (mg_levels_ksp_converged_maxits)
+        # so the GAMG application is non-linear; CG/FCG's residual recurrence
+        # cannot accommodate this, and at scale (large parallel partitions, sharp
+        # internal sources, free-slip Nitsche) PETSc reports DIVERGED_PC_FAILED
+        # / indefinite matrix or GMRES residual-recursion mismatch. See issue
+        # #147 for the spherical-Kramer benchmark on Gadi that drove this change;
+        # gthyagi's validated FGMRES configuration completed at np=144,
+        # cellsize=1/32 where CG/FCG and standard GMRES both failed.
+        self.petsc_options[f"fieldsplit_{v_name}_ksp_type"] = "fgmres"
+        self.petsc_options[f"fieldsplit_{v_name}_ksp_max_it"] = 200
         self.petsc_options[f"fieldsplit_{v_name}_ksp_rtol"]  = self._tolerance * 0.1
         self.petsc_options[f"fieldsplit_{v_name}_pc_type"]  = "gamg"
         self.petsc_options[f"fieldsplit_{v_name}_pc_gamg_type"]  = "agg"
@@ -4396,8 +4410,10 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
         p_name = "pressure" # pressureField.clean_name
         v_name = "velocity" # velocityField.clean_name
 
-        # Works / mostly quick
+        # Pressure subsolve — flexible GMRES + GASM. (FGMRES is right-
+        # preconditioned by construction; no need to set pc_side explicitly.)
         self.petsc_options[f"fieldsplit_{p_name}_ksp_type"] = "fgmres"
+        self.petsc_options[f"fieldsplit_{p_name}_ksp_max_it"] = 200
         self.petsc_options[f"fieldsplit_{p_name}_ksp_rtol"]  = self._tolerance
         self.petsc_options[f"fieldsplit_{p_name}_pc_type"] = "gasm"
         self.petsc_options[f"fieldsplit_{p_name}_pc_gasm_type"] = "basic"
@@ -4409,8 +4425,11 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
         # self.petsc_options[f"fieldsplit_{p_name}_pc_gamg_type"] = "agg"
         # self.petsc_options[f"fieldsplit_{p_name}_pc_gamg_repartition"] = True
 
-
-        self.petsc_options[f"fieldsplit_velocity_ksp_type"] = "cg"
+        # Velocity subsolve — see corresponding block in __init__ for the
+        # rationale (FGMRES default for robustness to non-stationary GAMG
+        # preconditioning and weakly-indefinite coarse operators; issue #147).
+        self.petsc_options[f"fieldsplit_velocity_ksp_type"] = "fgmres"
+        self.petsc_options[f"fieldsplit_velocity_ksp_max_it"] = 200
         self.petsc_options[f"fieldsplit_velocity_pc_type"]  = "gamg"
         self.petsc_options[f"fieldsplit_velocity_pc_gamg_type"]  = "agg"
         self.petsc_options[f"fieldsplit_velocity_pc_gamg_repartition"]  = True


### PR DESCRIPTION
## Summary
- Default \`fieldsplit_velocity_ksp_type\` changes from \`cg\` → \`fgmres\` in both the \`SNES_Stokes_SaddlePt\` constructor and the \`strategy\` setter (which re-applies the same defaults).
- Adds \`ksp_max_it = 200\` safety bound to both pressure and velocity subsolves.
- \`pc_side\` is intentionally **not** set — FGMRES is right-preconditioned by construction; leaving \`pc_side\` unset keeps the defaults compatible with user overrides to CG/FCG (which require left preconditioning).

Closes #147 (no UW3 doc note needed; the default just works).

## Why
The Schur fieldsplit preconditioner uses inner Krylov solvers — GAMG with \`mg_levels_ksp_max_it=3\` and \`_converged_maxits=true\` — whose application is non-linear (variable iteration count per call). CG/FCG and standard GMRES build their residual recurrence assuming a *linear* preconditioner, so the recurrence drifts from the true residual under non-stationary preconditioning.

Combined with the weakly-indefinite coarse operators that GAMG produces on partition-stressed problems with sharp internal sources (Kramer case1's internal-boundary delta forcing), the velocity block trips PETSc's \"DIVERGED_PC_FAILED / indefinite matrix\" check or the GMRES residual-recursion mismatch.

FGMRES handles non-stationary preconditioning by storing the preconditioned vectors explicitly rather than relying on the m-term recurrence. It's the right default for any solver that composes nested Krylov methods, independent of whether the bilinear form is symmetric.

This is **not** about Nitsche introducing asymmetry — UW3's Nitsche default is symmetric (\`theta=1\`). The non-stationarity comes from GAMG.

## Test plan
- [x] \`pytest -m \"level_1 and tier_a\"\` on \`amr-dev\` — 56 passed, 3 skipped, 0 failed (no regressions).
- [x] 8 existing tests that explicitly set \`fieldsplit_velocity_ksp_type = fcg\` after solver construction continue to work — user overrides cleanly replace the default.
- [x] User reset path: \`solver.strategy = \"default\"\` re-applies the new FGMRES defaults via the same code path (line 4428 of \`petsc_generic_snes_solvers.pyx\`).

## Validated by gthyagi (#147)
At-scale validation on Gadi using the proposed configuration:

| cellsize | CPUs | walltime | true residual ratio |
|---|---:|---:|---:|
| \`1/8\` | 8 | 4m26s | 5.4e-07 |
| \`1/16\` | 32 | 26m | 3.5e-08 |
| \`1/32\` | 144 | 24m | 3.6e-09 |

CG/FCG and standard GMRES failed on this case; FGMRES completed cleanly.

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)