### PR TITLE
Use uw.kdtree.KDTree in mesh.adapt (drop scipy.spatial.cKDTree)

### DIFF
--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -1242,10 +1242,8 @@ class Mesh(Stateful, uw_object):
         if hasattr(self, '_vertex_map') and self._vertex_map is not None:
             return self._vertex_map
 
-        from scipy.spatial import cKDTree
-
-        tree = cKDTree(self.X.coords)
-        dists, indices = tree.query(self.parent.X.coords)
+        tree = uw.kdtree.KDTree(self.X.coords)
+        dists, indices = tree.query(self.parent.X.coords, sqr_dists=False)
         matched = dists < 1.0e-10
 
         # parent_rows[i] -> sub_rows[i]: matched vertex pairs
@@ -1378,13 +1376,12 @@ class Mesh(Stateful, uw_object):
                 # Interpolate from backed-up data via kd-tree IDW
                 if var_name in old_var_backups:
                     try:
-                        from scipy.spatial import cKDTree
                         old_coords, old_data = old_var_backups[var_name]
                         new_coords = old_var.coords
 
-                        tree = cKDTree(old_coords)
+                        tree = uw.kdtree.KDTree(old_coords)
                         nnn = 3 if self.dim == 2 else 4
-                        dists, indices = tree.query(new_coords, k=nnn)
+                        dists, indices = tree.query(new_coords, k=nnn, sqr_dists=False)
 
                         # Inverse distance weighting
                         weights = 1.0 / (dists + 1e-30)
@@ -1431,14 +1428,13 @@ class Mesh(Stateful, uw_object):
         Returns (sub_rows, parent_rows) — numpy arrays of matching DOF indices.
         """
         import numpy as np
-        from scipy.spatial import cKDTree
 
         key = (id(parent_var), id(sub_var))
         if key in self._dof_maps:
             return self._dof_maps[key]
 
-        tree = cKDTree(sub_var.coords)
-        dists, indices = tree.query(parent_var.coords)
+        tree = uw.kdtree.KDTree(sub_var.coords)
+        dists, indices = tree.query(parent_var.coords, sqr_dists=False)
         matched = dists < 1.0e-10
 
         # indices[matched] maps parent row → sub row


### PR DESCRIPTION
## Summary
- Three sites in \`discretisation_mesh.py\` used \`scipy.spatial.cKDTree\` for the mesh-to-mesh variable transfer that runs during \`Mesh.adapt\`. These were the only \`scipy.spatial.cKDTree\` usages left in \`src/\`.
- Replaced with \`uw.kdtree.KDTree\` (nanoflann-backed) — the same backend already used by \`read_timestep\`, swarm migration, and the RBF interpolator path.
- \`.query\` API is scipy-compatible — same \`(d, i)\` return, same \`k=\` — but defaults to squared distances. Passing \`sqr_dists=False\` preserves the previous linear-distance semantics so the existing threshold (\`1.0e-10\` for exact-match) and IDW weighting (\`1.0 / (dists + 1e-30)\`) are unchanged.

## Sites changed
- \`sub_vertex_map\` (line 1247) — parent-submesh vertex match.
- \`_re_extract_from_parent\` variable IDW transfer (line 1385) — kept k=3 (2D) / k=4 (3D) IDW.
- \`_build_dof_map\` (line 1440) — parent-submesh DOF match.

## Test plan
- [x] No \`scipy.spatial.cKDTree\` references remain in \`src/\` (verified by grep).
- [x] \`pytest -m \"level_1 and tier_a\"\` on \`amr-dev\` — **56 passed, 3 skipped, 0 failed**.

## Notes
This is a minor consistency fix. The bigger architectural item — extracting the global point-location toolkit from \`global_evaluate_nd\` into a reusable swarm-shaped utility so \`mesh.adapt\` and \`read_timestep\` can stop rebuilding rank-local trees redundantly — is recorded in the planning file and is *not* part of this PR.

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)