### PR TITLE
Fix SNES + DM-hierarchy leak in solver _build() rebuild path (#157)

### DIFF
--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -596,12 +596,44 @@ class SolverBaseClass(uw_object):
                 self._last_jit_cache_key = self._current_jit_cache_key
             return
 
-        # === Full rebuild path — teardown DM and reconstruct ===
+        # === Full rebuild path — teardown DM/SNES and reconstruct ===
+        # BUGFIX(#157): two PETSc objects were leaking on every is_setup=False
+        # rebuild:
+        #   (1) self.snes — _setup_solver() does
+        #         self.snes = PETSc.SNES().create(...)
+        #       unconditionally; the previous SNES (with its KSP, PC, and
+        #       full GAMG hierarchy of coarse operator matrices) was just
+        #       overwritten.
+        #   (2) self.dm_hierarchy[:-1] — only self.dm == dm_hierarchy[-1]
+        #       was destroyed here; coarse DMs from the previous build
+        #       leaked.
+        # Tight is_setup=False loops (notably SNES_Tensor_Projection.solve()
+        # cycling 6 symmetric tensor components in 3D) accumulate one SNES
+        # plus one full coarse-DM hierarchy per iteration — large enough at
+        # Gadi scale to push past memory limits during stress recovery
+        # postprocessing. _reset() already had the correct destroy
+        # sequence; this brings _build() into line with it.
+        # NB self.snes / self.dm_hierarchy may not exist yet on the first
+        # build, so use getattr/hasattr-style guards rather than `is not None`.
+        if getattr(self, "snes", None) is not None:
+            if verbose and uw.mpi.rank == 0:
+                print(f"Destroy solver SNES", flush=True)
+            self.snes.destroy()
+            self.snes = None
+
         if self.dm is not None:
             if verbose and uw.mpi.rank == 0:
-                print(f"Destroy solver DM", flush=True)
+                print(f"Destroy solver DM hierarchy", flush=True)
 
-            self.dm.destroy()
+            if hasattr(self, "dm_hierarchy") and self.dm_hierarchy:
+                # Destroys each level — including dm_hierarchy[-1] which
+                # is self.dm — so no separate self.dm.destroy() needed.
+                for coarse_dm in self.dm_hierarchy:
+                    if coarse_dm is not None:
+                        coarse_dm.destroy()
+                self.dm_hierarchy = [None]
+            else:
+                self.dm.destroy()
             self.dm = None
             if hasattr(self, "_stokes_nullspace"):
                 self._stokes_nullspace = None


### PR DESCRIPTION
## Summary
Two PETSc objects leaked on every \`is_setup=False\` rebuild in \`SolverBaseClass._build()\`. \`_reset()\` already had the right teardown sequence; \`_build()\` just didn't borrow from it.

Partially addresses #157 (the per-component path in \`SNES_Tensor_Projection.solve()\` was the worst-case offender).

## Leaks

| Object | Why it leaked | Where it was created |
|---|---|---|
| \`self.snes\` | \`_setup_solver()\` always does \`self.snes = PETSc.SNES().create(...)\` — overwriting the previous SNES (with its KSP, PC, full GAMG hierarchy of coarse operator matrices) without destroying it | \`petsc_generic_snes_solvers.pyx:1980\` (and analogues in \`SNES_Vector\` / \`SNES_MultiComponent\`) |
| \`self.dm_hierarchy[:-1]\` | \`_build()\` only called \`self.dm.destroy()\`, which is \`dm_hierarchy[-1]\`. Coarser levels were not destroyed. | \`_setup_discretisation()\` does \`self.dm_hierarchy = mesh.clone_dm_hierarchy()\` (independent clones, owned by the solver — safe to destroy) |

## Why this matters for #157
\`SNES_Tensor_Projection.solve()\` cycles 6 symmetric tensor components in 3D, setting \`is_setup=False\` between each. Per tensor projection that's 5 leaked SNES objects + 5 leaked coarse-DM hierarchies. Each SNES carries its full GAMG coarse operator stack — at Gadi scale (1.92 TB on 1440 ranks reported in #157) this is plausibly the dominant memory contributor in the stress recovery postprocessing path.

## Fix
Bring \`_build()\`'s teardown into line with \`_reset()\` — destroy SNES first, then iterate \`dm_hierarchy\` destroying each coarse DM (which includes \`dm_hierarchy[-1] == self.dm\`), before reconstructing. \`self.snes\` may not exist on the first build, so the guard uses \`getattr(self, \"snes\", None) is not None\`.

## Test plan
- [x] \`pytest -m \"level_1 and tier_a\"\` on \`amr-dev\` — **56 passed, 3 skipped, 0 failed**.
- [x] No semantic change: solvers still produce identical results, only memory behaviour differs.

Adding a numerical regression test isn't proportional here — the bug is scale-dependent (only visible at the Gadi scale gthyagi reported) and the fix is hygiene under code inspection.

## Note
This complements but does not replace \`SNES_MultiComponent_Projection\` (PR #124) for the symmetric-tensor stress recovery use case in #157. That path collapses N components into one SNES solve and is the preferred architectural answer. This PR plugs the leak in the existing per-component path so users of \`SNES_Tensor_Projection\` don't silently accumulate memory while we migrate to the new path.

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)