### PR TITLE
CI: replace micromamba + environment.yaml with pixi

### DIFF
--- a/.github/workflows/build_uw3_and_test.yaml
+++ b/.github/workflows/build_uw3_and_test.yaml
@@ -1,7 +1,12 @@
 name: test_uw3
 
-# We should trigger this from an upload event. Note that pdoc requires us to import the
-# built code, so this is a building test as well as documentation deployment
+# Build + test on every PR / push to main / development.
+#
+# Uses pixi (with the committed pixi.lock) for a deterministic, fast install
+# rather than micromamba + environment.yaml, which had been backtracking for
+# 60+ minutes on conda-forge solves and timing the runner out before tests
+# could start. The pixi.lock matches what local development uses, so CI now
+# runs against the same dependency state developers see.
 
 on:
   push:
@@ -17,27 +22,27 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
+
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Conda environment with Micromamba
-        uses: mamba-org/setup-micromamba@v2
+      - name: Install pixi from lockfile
+        uses: prefix-dev/setup-pixi@v0.9.4
         with:
-          environment-file: ./environment.yaml
-          cache-downloads: true
-          cache-environment: true
+          # Use the env that matches local development for tests.
+          # `dev` = conda-petsc + runtime + dev features (pytest, jupyter, etc.)
+          environments: dev
+          # Hard-fail if pixi.lock disagrees with pixi.toml — never re-solve
+          # silently in CI; that's exactly the failure mode we're escaping.
+          frozen: true
+          cache: true
 
       - name: Build UW3
-        shell: bash -l {0}
-        run: |
-          export PETSC_DIR="/home/runner/micromamba/envs/uw3_test/lib"
-          VERSION=`python3 setup.py --version`
-          echo "UW - version " ${VERSION}
-
-          ## TODO. Use scripts/compile.sh once it is in development
-          pip install -e . --no-build-isolation
+        # `pixi run -e dev build` invokes the build task from pixi.toml,
+        # which is `pip install . --no-build-isolation` (non-editable —
+        # editable installs are project policy violation, see CLAUDE.md).
+        run: pixi run -e dev build
 
       - name: Run tests
-        shell: bash -l {0}
-        run: |
-          ./scripts/test.sh --p 2
+        run: pixi run -e dev ./scripts/test.sh --p 2


### PR DESCRIPTION
## Summary

Replaces the failing micromamba + \`environment.yaml\` install step with \`prefix-dev/setup-pixi\` against the committed \`pixi.lock\`. The CI now uses the same pinned dependency set developers use locally, deterministically, in seconds rather than 60+ minutes.

## Why

Since 2026-04-30 every push to \`development\` and every PR has failed CI with the runner timing out:

\`\`\`text
Resolving Environment ⧖ Starting           # 02:51:02
##[error]The runner has received a shutdown signal.   # 03:57:25
\`\`\`

Three consecutive \`push\`-event runs on \`development\` have failed the same way; PRs #154, #163 inherited it. The 66-minute window is **entirely** in micromamba's conda-forge dependency resolve — tests never start. Diagnosis chain: \`environment.yaml\` has loose constraints (\`python <= 3.11\`, an exact pin on \`petsc=3.21.5\` that's now a year-old in conda-forge, and several unpinned packages including \`pykdtree\` which UW3 doesn't even use any more), and recent conda-forge package state shifts have put the solver into deep backtracking.

## What changes

| Step | Before | After |
|---|---|---|
| Install | \`mamba-org/setup-micromamba@v2\` + \`environment.yaml\` (60+ min, often timing out) | \`prefix-dev/setup-pixi@v0.9.4\` + \`pixi.lock\` (\`frozen: true\`), seconds |
| Build | \`pip install -e .\` (editable, against project policy per CLAUDE.md) | \`pixi run -e dev build\` (= \`pip install . --no-build-isolation\`, non-editable) |
| Test | \`./scripts/test.sh --p 2\` | \`pixi run -e dev ./scripts/test.sh --p 2\` |
| Timeout | none (runner default ≳ 6h) | explicit 60 min cap |

## What does NOT change

- \`environment.yaml\` is **kept** for now because PR #133 (Gadi Singularity container) consumes it; removing it across the boundary of an open PR would create a cross-PR ordering hazard. We can prune it after #133 lands or after a deliberate cleanup pass.
- The test invocation, suite, and parallel-rank count are identical.

## Test plan

This PR's own CI run is the test plan — if it completes green in <10 min instead of timing out at ~90 min, we've fixed the unblocker.

If the pixi step succeeds but tests then expose a real divergence vs the previous environment (different Python minor, different package versions), that's a useful signal — the existing \`environment.yaml\` has been silently falling out of sync with \`pixi.lock\` for a while, and tests passing under one but not the other tells us where the latent bugs are.

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)