### PR TITLE
uw: prompt to install Claude Code CLI during dev setup

### DIFF
--- a/uw
+++ b/uw
@@ -967,7 +967,7 @@ COMMANDS
     set-env NAME        Change environment directly
     ai-tools            Configure external AI instruction paths
     claude-perms        Configure Claude Code permissions (safe defaults)
-    install-claude      Install Claude Code CLI globally (npm, requires dev env)
+    install-claude      Install Claude Code CLI into the dev pixi env (run via ./uw claude)
 
   Building:
     build               Build underworld3
@@ -1684,7 +1684,25 @@ case "${1:-}" in
         configure_claude_permissions "$(get_env)"
         ;;
     install-claude)
-        $PIXI run -e "$(get_env)" install-claude
+        # The install-claude pixi task lives under [feature.dev.tasks], so it
+        # only resolves in dev-feature envs (dev, amr-dev, *-dev). Guard the
+        # call so users on default/runtime get a clear message instead of a
+        # raw "task not found" error from pixi.
+        env=$(get_env)
+        case "$env" in
+            *dev*)
+                $PIXI run -e "$env" install-claude
+                ;;
+            *)
+                echo -e "${YELLOW}install-claude needs a dev environment (current: $env).${NC}"
+                echo "Switch with one of:"
+                echo "  ./uw set-env dev          # conda-forge PETSc"
+                echo "  ./uw set-env amr-dev      # custom PETSc with AMR tools"
+                echo "  ./uw set-env mpich-dev    # MPICH override"
+                echo "  ./uw set-env openmpi-dev  # OpenMPI override"
+                exit 1
+                ;;
+        esac
         ;;
     --help|-h|help)
         show_help

--- a/uw
+++ b/uw
@@ -863,6 +863,26 @@ run_setup() {
         fi
     fi
 
+    # Optional: Install the Claude Code CLI (only meaningful for the Developer feature,
+    # which brings nodejs into the env). Reuses the install-claude pixi task.
+    if [ "$feature_choice" = "3" ]; then
+        echo ""
+        echo -e "${BOLD}Claude Code CLI (Optional)${NC}"
+        echo "  Install the Claude Code CLI globally via the dev environment's npm:"
+        echo "    pixi run -e $new_env install-claude"
+        echo "  (equivalent to: npm install -g @anthropic-ai/claude-code)"
+        echo ""
+        read -p "Install Claude Code CLI now? [y/N]: " install_claude_cli
+        install_claude_cli=${install_claude_cli:-n}
+
+        if [ "$install_claude_cli" = "y" ] || [ "$install_claude_cli" = "Y" ]; then
+            $PIXI run -e "$new_env" install-claude
+            echo -e "  ${GREEN}✓${NC} Claude Code CLI installed"
+        else
+            echo "  Skipped. Run later with: ./uw install-claude"
+        fi
+    fi
+
     # Optional: Configure Claude Code permissions for unattended monitoring
     echo ""
     echo -e "${BOLD}Claude Code Permissions (Optional)${NC}"
@@ -947,6 +967,7 @@ COMMANDS
     set-env NAME        Change environment directly
     ai-tools            Configure external AI instruction paths
     claude-perms        Configure Claude Code permissions (safe defaults)
+    install-claude      Install Claude Code CLI globally (npm, requires dev env)
 
   Building:
     build               Build underworld3
@@ -1661,6 +1682,9 @@ case "${1:-}" in
         ;;
     claude-perms)
         configure_claude_permissions "$(get_env)"
+        ;;
+    install-claude)
+        $PIXI run -e "$(get_env)" install-claude
         ;;
     --help|-h|help)
         show_help


### PR DESCRIPTION
## Summary

- The `dev` pixi feature already pulls `nodejs` and defines an `install-claude` task (`npm install -g @anthropic-ai/claude-code` in `pixi.toml:327`), but `./uw setup` never invoked it. Users who picked the Developer feature got the CLI dependency implied but never installed.
- Adds an opt-in prompt at the end of `run_setup()`, only when the Developer feature is selected, defaulting to No. Reuses the existing pixi task — no shell duplication of the npm command.
- Adds a top-level `./uw install-claude` subcommand mirroring the existing `claude-perms` dispatch pattern, for post-setup or non-interactive runs.
- Lists the new subcommand under `Setup:` in `./uw --help`.

No `pixi.toml` changes. No behaviour change for the Minimal or Runtime features. The existing `claude-perms` permissions block is untouched and still runs after the new prompt.

## Test plan

- [ ] `bash -n uw` clean (verified locally)
- [ ] `./uw --help` lists `install-claude` under Setup
- [ ] `./uw setup` with Developer feature: new prompt appears, default No skips with hint
- [ ] `./uw setup` with Developer feature, accept: runs `pixi run -e <env> install-claude` and reports success
- [ ] `./uw setup` with Runtime feature: new prompt does NOT appear
- [ ] `./uw install-claude` standalone: runs the pixi task in the active env

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)