### PR TITLE
README: add curated badge bar (release, license, Python, docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 <img src="docs/media/SocialShareS.png" width="80%">
 </center>
 
+[![Latest release](https://img.shields.io/github/v/release/underworldcode/underworld3?label=release)](https://github.com/underworldcode/underworld3/releases/latest)
+[![License: LGPL-3.0](https://img.shields.io/github/license/underworldcode/underworld3)](https://www.gnu.org/licenses/lgpl-3.0)
+[![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
+[![Documentation](https://img.shields.io/readthedocs/underworld3)](https://underworld3.readthedocs.io/en/latest/)
+
 Welcome to `Underworld3`, a mathematically self-describing, finite-element code for geodynamic modelling. This quick-start guide has basic installation instructions and a brief introduction to some of the concepts in the `Underworld3` code.
 
 All `Underworld3` source code is released under the LGPL-3 open source licence. This covers all files in `underworld3` constituting the Underworld3 Python module. Notebooks, stand-alone documentation and Python scripts which show how the code is used and run are licensed under the Creative Commons Attribution 4.0 International License.


### PR DESCRIPTION
## Summary

Adds a four-badge bar at the top of `README.md`:

- **release** — latest GitHub release tag
- **license** — LGPL-3.0
- **python** — 3.10+
- **docs** — Read the Docs build status

These are at-a-glance identifiers for visitors landing on the repo. CI status badges, Binder launchers, DOI, and JOSS badges remain unchanged in their existing sections — DOI and JOSS keep their prose context in *References and Archives*.

Deliberately excluded: "commits this month", "last commit", and similar activity badges. On a maturing scientific codebase a quiet week doesn't mean what those badges suggest, and they incentivise churn over substance.

## Test plan

- [ ] Render preview on GitHub PR diff looks clean
- [ ] All four badges resolve (no broken images)
- [ ] Mobile rendering — badges wrap rather than overflow

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)