### PR TITLE
Revert PR #172 (integrals regression) + xfail CellWiseIntegral parity tests

### DIFF
--- a/src/underworld3/cython/petsc_maths.pyx
+++ b/src/underworld3/cython/petsc_maths.pyx
@@ -300,10 +300,15 @@ class CellWiseIntegral:
         cdef Vec cgvec
         cgvec = a_global
 
-        ## Does this need to be consistent with everything else ?
-
+        # TODO(BUG): clone+createDefault+createDS gives dmc a single P1 field,
+        # but cgvec is packed for mesh.dm's multi-field layout — the integral
+        # reads the wrong DOFs and over-counts by ~2x on the unit square.
+        # Same bug as PR #172 (reverted in PR #173-followup). Tests in
+        # tests/test_0501_integrals.py::test_cellwise_integrate_* are xfail
+        # until this is rewritten to integrate against mesh.dm + getDS()
+        # directly (the pre-PR-172 Integral pattern).
         cdef DM dmc = self.mesh.dm.clone()
-        cdef FE fec = FE().createDefault(self.dim, 1, False, -1)
+        cdef FE fec = FE().createDefault(self.mesh.dim, 1, False, -1)
         dmc.setField(0, fec)
         dmc.createDS()
 

--- a/src/underworld3/cython/petsc_maths.pyx
+++ b/src/underworld3/cython/petsc_maths.pyx
@@ -102,46 +102,31 @@ class Integral:
             raise RuntimeError("Integral evaluation for Dyadic integrands not supported.")
 
 
-        # BUGFIX(#171): clone the mesh DM and create a fresh DS per call,
-        # rather than mutating the shared mesh DS. The previous code path
-        # was:
-        #     ds = self.mesh.dm.getDS()           # shared DS
-        #     PetscDSSetObjective(ds, 0, fn)      # mutate it
-        #     DMPlexComputeIntegralFEM(...)
-        # PetscDSSetObjective on the shared DS makes
-        # DMPlexComputeIntegralFEM cost grow linearly with repeated
-        # evaluate() calls in long simulations — observed in convection
-        # diagnostics where t_vol grew from 5 s to 833 s over ~3000 calls.
-        # The sister class CellWiseIntegral already takes the
-        # clone-DM + createDS path; this brings Integral in line.
-        # Explicit destroy of the clone at the end keeps long runs bounded.
-        mesh = self.mesh
+        self.dm = self.mesh.dm  # .clone()
+        mesh=self.mesh
 
         _getext_result = getext(self.mesh, JITCallbackSet(residual=(self.fn,)),
                                 self.mesh.vars.values(), verbose=verbose)
         cdef PtrContainer ext = _getext_result.ptrobj
 
         # Pull out vec for variables, and go ahead with the integral
+
         self.mesh.update_lvec()
-        a_global = self.mesh.dm.getGlobalVec()
-        self.mesh.dm.localToGlobal(self.mesh.lvec, a_global)
+        a_global = self.dm.getGlobalVec()
+        self.dm.localToGlobal(self.mesh.lvec, a_global)
 
         cdef Vec cgvec
         cgvec = a_global
 
-        cdef DM dmc = self.mesh.dm.clone()
-        cdef FE fec = FE().createDefault(self.mesh.dim, 1, False, -1)
-        dmc.setField(0, fec)
-        dmc.createDS()
-
-        cdef DS ds = dmc.getDS()
+        cdef DM dm = self.dm
+        cdef DS ds = self.dm.getDS()
         cdef PetscScalar val_array[256]
 
+        # Now set callback...
         ierr = PetscDSSetObjective(ds.ds, 0, ext.fns_residual[0]); CHKERRQ(ierr)
-        ierr = DMPlexComputeIntegralFEM(dmc.dm, cgvec.vec, &(val_array[0]), NULL); CHKERRQ(ierr)
+        ierr = DMPlexComputeIntegralFEM(dm.dm, cgvec.vec, &(val_array[0]), NULL); CHKERRQ(ierr)
 
-        self.mesh.dm.restoreGlobalVec(a_global)
-        dmc.destroy()
+        self.dm.restoreGlobalVec(a_global)
 
         # We're making an assumption here that PetscScalar is same as double.
         # Need to check where this may not be the case.

--- a/tests/test_0501_integrals.py
+++ b/tests/test_0501_integrals.py
@@ -166,3 +166,42 @@ def test_integrate_swarmvar_deriv_00():
     assert abs(value + 2) < 0.0001
 
     return
+
+
+# CellWiseIntegral parity tests — the sister class of Integral that returns a
+# per-cell array.  These are marked xfail because CellWiseIntegral.evaluate()
+# clones mesh.dm and attaches a fresh single-field discretisation
+# (FE.createDefault + setField + createDS), but then integrates against
+# mesh.dm.getGlobalVec() which is packed for the original multi-field layout.
+# The mismatch produces a ~2× over-count on simple cases — the same bug that
+# motivated the revert of PR #172 for Integral.
+#
+# These tests will start passing once CellWiseIntegral.evaluate() is rewritten
+# to integrate against mesh.dm + mesh.dm.getDS() directly (matching the
+# pre-PR-172 Integral pattern).
+@pytest.mark.xfail(reason="CellWiseIntegral has the same field-cloning bug "
+                          "that motivated the PR #172 revert")
+def test_cellwise_integrate_constants():
+
+    calculator = uw.maths.CellWiseIntegral(mesh, fn=1.0)
+    cell_values = calculator.evaluate()
+
+    # Sum of per-cell volumes equals the total mesh volume (unit square = 1.0).
+    assert abs(np.sum(cell_values) - 1.0) < 0.001
+
+    return
+
+
+@pytest.mark.xfail(reason="CellWiseIntegral has the same field-cloning bug "
+                          "that motivated the PR #172 revert")
+def test_cellwise_integrate_meshvar():
+
+    s_soln.data[:, 0] = np.sin(np.pi * s_soln.coords[:, 0])
+
+    calculator = uw.maths.CellWiseIntegral(mesh, fn=s_soln.sym[0])
+    cell_values = calculator.evaluate()
+
+    # Sum matches the global Integral: ∫∫ sin(πx) dx dy = 2/π over the unit square.
+    assert abs(np.sum(cell_values) - 2 / np.pi) < 0.001
+
+    return


### PR DESCRIPTION
## Summary

PR #172 ("Perf: clone DM in `Integral.evaluate()` (3× speedup; closes #171 narrative)") introduced a regression that broke 4 tests in `tests/test_0501_integrals.py`. CI on the merged commit (`fe05c63`) and on `development`'s HEAD shows these failures. This PR reverts #172 to restore correctness, and adds parity test coverage for the sister `CellWiseIntegral` class — which the original PR claimed worked but never actually has.

## What broke

The change in #172 was:

```python
dmc = self.mesh.dm.clone()                # PETSc DMClone does not copy fields
fec = FE.createDefault(dim, 1, False, -1)
dmc.setField(0, fec)                      # clone now has just one P1 field
dmc.createDS()
PetscDSSetObjective(dmc.getDS(), 0, fn)
DMPlexComputeIntegralFEM(dmc, cgvec, ...) # cgvec packed for mesh.dm's multi-field layout
```

The integrand reads through `dmc`'s single-field DS, but the vector being integrated (`cgvec`) was packed for `mesh.dm`'s full multi-field layout. The DOFs read are wrong, producing ~2× over-counts on simple cases and NaN/0 on derivative integrands. All four failing tests are explained by this mismatch.

## Performance ground truth (#171)

The PR's stated motivation was to fix linear-time growth in `t_vol` over long convection runs (5 s → 833 s over ~3000 calls). The PR itself notes it could not reproduce the slowdown locally (200 calls × 100-cell mesh stayed flat). The fix was speculative; correctness on the failing tests was lost in exchange for an unverified perf benefit. Issue #171 should be reopened with a real reproducer before any further attempt.

## What's in this PR

1. **Revert `fe05c63`** — restores the pre-#172 `Integral.evaluate()` (uses `mesh.dm` + `mesh.dm.getDS()` directly).
2. **CellWiseIntegral parity tests (xfail)** — the sister class had zero test coverage. While auditing, found two latent bugs:
   - `self.dim` typo (it should be `self.mesh.dim`) — fixed; the class would crash with `AttributeError` before now.
   - With the typo fixed, `CellWiseIntegral` exhibits the same field-cloning bug as #172 — sum of per-cell volumes returns 2.0 instead of 1.0 on the unit square.

   The two new tests (`test_cellwise_integrate_constants`, `test_cellwise_integrate_meshvar`) are marked `xfail` with a clear reason. They will start passing when `CellWiseIntegral.evaluate()` is rewritten to use the same `mesh.dm + getDS()` pattern that the reverted `Integral` already uses.

3. **Inline `TODO(BUG)`** in `CellWiseIntegral.evaluate()` pointing at the same write-up.

## Test plan

- [x] `pytest tests/test_0501_integrals.py -v` — 9 passed, 3 xfailed (1 pre-existing + 2 new with documented reasons)
- [ ] CI shows the previously-failing 4 integrals tests now pass
- [ ] Reopen issue #171 with a note that the linear-growth issue still needs a real reproducer; until then, correctness wins

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)