### PR TITLE
Add memprobe diagnostic module for memory-growth tracking (#176)

### DIFF
--- a/docs/developer/guides/memory-diagnostics.md
+++ b/docs/developer/guides/memory-diagnostics.md
@@ -27,14 +27,22 @@ growing on every step.
 
 | Signal | Source | Cost |
 |---|---|---|
-| Process RSS (MiB) | `resource.getrusage` | free |
+| Process RSS (MiB, current) | `psutil.Process().memory_info().rss`, fallback `/proc/self/statm` (Linux), last resort `resource.ru_maxrss` | free |
 | KDTree live count | `uw.kdtree.live_count()` | free |
 | KDTree total constructed | `uw.kdtree.total_constructed()` | free |
 | Per-class Python instance counts | `gc.get_objects()` walk | slow — gated behind `full=True` |
 
+The RSS source is **current** RSS where possible — it should drop when memory
+is freed, not just rise. The last-resort `resource.ru_maxrss` fallback returns
+the **peak** (high-water-mark) RSS instead and never decreases, so on systems
+where neither psutil nor `/proc/self/statm` is available you'll see growth but
+not recovery; install `psutil` to fix that.
+
 `KDTree` instances are tracked via Cython class counters in `__cinit__` and
-`__dealloc__`. Cython's deterministic destruction makes the live count
-accurate without weak-references.
+`__dealloc__`. CPython refcounting calls `__dealloc__` promptly when the
+refcount hits zero, so the count is accurate for typical use; it can lag if a
+KDTree ends up in a reference cycle that only the cyclic garbage collector
+can break. Call `gc.collect()` before reading if that matters.
 
 PETSc-side object and allocation tracking is **not** parsed from Python —
 PETSc's own `-log_view` and `-malloc_dump` runtime flags give the same

--- a/docs/developer/guides/memory-diagnostics.md
+++ b/docs/developer/guides/memory-diagnostics.md
@@ -1,0 +1,145 @@
+# Memory diagnostics
+
+Long parallel runs occasionally OOM on HPC even when each step looks small.
+The `uw.utilities.memprobe` module gives you a way to "light up" memory
+tracking on demand, sample at regular intervals, and pin which subsystem is
+growing.
+
+## Quick start
+
+```bash
+UW_MEMPROBE=1 mpirun -n 16 python my_long_run.py
+```
+
+With this flag set, the `Stokes.solve()` and `NavierStokes.solve()` paths
+emit a one-line growth report each time they're called:
+
+```
+[memprobe] Stokes.solve:
+  RSS +0.42 MiB
+  kdtree: live +1, total_constructed +1
+```
+
+A clean run shows mostly zero deltas. A leak shows the same component
+growing on every step.
+
+## What's tracked
+
+| Signal | Source | Cost |
+|---|---|---|
+| Process RSS (MiB) | `resource.getrusage` | free |
+| KDTree live count | `uw.kdtree.live_count()` | free |
+| KDTree total constructed | `uw.kdtree.total_constructed()` | free |
+| Per-class Python instance counts | `gc.get_objects()` walk | slow — gated behind `full=True` |
+
+`KDTree` instances are tracked via Cython class counters in `__cinit__` and
+`__dealloc__`. Cython's deterministic destruction makes the live count
+accurate without weak-references.
+
+PETSc-side object and allocation tracking is **not** parsed from Python —
+PETSc's own `-log_view` and `-malloc_dump` runtime flags give the same
+information more reliably. To enable them from Python:
+
+```python
+from underworld3.utilities import memprobe
+memprobe.dump_petsc_leaks_at_finalize()  # equivalent to -malloc_dump -objects_dump
+```
+
+## API
+
+### Snapshots and diffs
+
+```python
+from underworld3.utilities import memprobe
+
+before = memprobe.snapshot()
+do_work()
+after = memprobe.snapshot()
+print(memprobe.format_diff("after-work", memprobe.diff(before, after)))
+```
+
+Add `full=True` to also walk Python-class counts:
+
+```python
+snap = memprobe.snapshot(full=True)
+# snap["py_classes"] = {"underworld3.swarm.Swarm": 3, ...}
+```
+
+### Probe context manager
+
+```python
+with memprobe.probe("step 42"):
+    advance_one_step()
+# On exit, the diff is emitted via `print` (configurable).
+```
+
+The `emit` keyword takes any callable: `with probe(..., emit=logger.info):`
+to route into the logging system, or a rank-aware writer for parallel runs:
+
+```python
+import underworld3 as uw
+emit = lambda s: uw.pprint(0, s)  # rank-0 only
+with memprobe.probe("step 42", emit=emit):
+    ...
+```
+
+### Decorator
+
+```python
+@memprobe.instrument("my-hot-loop")
+def step():
+    ...
+```
+
+When `memprobe.ENABLED` is `False` (the default) the decorator's wrapper is
+a single attribute lookup + branch — sub-microsecond — so it's safe to
+leave on hot paths permanently.
+
+`Stokes.solve()` and `NavierStokes.solve()` are pre-decorated. Add more if
+you want them.
+
+### Runtime toggles
+
+```python
+memprobe.enable()
+# ...probed region...
+memprobe.disable()
+```
+
+`UW_MEMPROBE=1` flips it on at import time.
+
+## Debugging recipes
+
+### "RSS grows X MiB per step — which component is it?"
+
+1. Set `UW_MEMPROBE=1` and run for ~20 steps to confirm the per-solve
+   growth pattern.
+2. Add `with memprobe.probe("step N", full=True):` around your step loop.
+   The `full=True` walks `gc.get_objects()` and lists Python class growth
+   sorted by absolute change — usually the dominant suspect is on top.
+3. If RSS grows but no Python class does, the leak is in PETSc memory or
+   C extensions. Re-run with `-log_view -malloc_dump` and inspect the PETSc
+   reports written at finalize.
+
+### "Are kd-trees being released properly?"
+
+Check `uw.kdtree.live_count()` directly, or look for the `kdtree: live +N`
+line in the diff. KDTrees should drop to zero when their owning object
+(typically a `Mesh` or `Swarm`) is destroyed.
+
+### Parallel runs
+
+`memprobe` runs on each rank independently. For meaningful aggregate
+output, pipe `emit` through a rank filter:
+
+```python
+import underworld3 as uw
+def root_only(s):
+    if uw.mpi.rank == 0:
+        print(s)
+
+with memprobe.probe("step", emit=root_only):
+    ...
+```
+
+Or compare per-rank snapshots manually for a load-imbalance view.

--- a/src/underworld3/ckdtree.pyx
+++ b/src/underworld3/ckdtree.pyx
@@ -16,10 +16,12 @@ cdef extern from "kdtree_interface.hpp" nogil:
         size_t knnSearch(const double* query_point, const size_t num_closest, long unsigned int* indices, double* out_dist_sqr )
 
 # Module-level live-instance counter for memory introspection.
-# Incremented in __cinit__ and decremented in __dealloc__ — Cython
-# guarantees deterministic destruction so this stays accurate across
-# normal use. Read via uw.utilities.memprobe.snapshot(), or directly
-# via uw.kdtree.live_count().
+# Incremented in __cinit__, decremented in __dealloc__. CPython refcounting
+# calls __dealloc__ promptly when the refcount hits zero, so the count is
+# accurate for typical use; it can lag if a KDTree ends up in a reference
+# cycle that only the cyclic garbage collector can break — call
+# gc.collect() before reading if that matters. Read via
+# uw.utilities.memprobe.snapshot() or directly via uw.kdtree.live_count().
 cdef long _live_instances = 0
 cdef long _total_constructed = 0
 

--- a/src/underworld3/ckdtree.pyx
+++ b/src/underworld3/ckdtree.pyx
@@ -15,6 +15,23 @@ cdef extern from "kdtree_interface.hpp" nogil:
         void find_closest_point( size_t  num_coords, const double* coords, long unsigned int* indices, double* out_dist_sqr, bool* found )
         size_t knnSearch(const double* query_point, const size_t num_closest, long unsigned int* indices, double* out_dist_sqr )
 
+# Module-level live-instance counter for memory introspection.
+# Incremented in __cinit__ and decremented in __dealloc__ — Cython
+# guarantees deterministic destruction so this stays accurate across
+# normal use. Read via uw.utilities.memprobe.snapshot(), or directly
+# via uw.kdtree.live_count().
+cdef long _live_instances = 0
+cdef long _total_constructed = 0
+
+def live_count():
+    """Number of KDTree instances currently alive on this rank."""
+    return _live_instances
+
+def total_constructed():
+    """Total KDTree instances ever constructed on this rank."""
+    return _total_constructed
+
+
 cdef class KDTree:
     """
     Unit-aware KD-Tree for spatial indexing and queries.
@@ -84,10 +101,16 @@ cdef class KDTree:
         self.points = points
         self.index = new KDTree_Interface(<const double *> &points[0][0], points.shape[0], points.shape[1])
 
+        global _live_instances, _total_constructed
+        _live_instances += 1
+        _total_constructed += 1
+
         super().__init__()
 
     def __dealloc__(self):
         del self.index
+        global _live_instances
+        _live_instances -= 1
 
     @property
     def n(self):

--- a/src/underworld3/function/expressions.py
+++ b/src/underworld3/function/expressions.py
@@ -659,8 +659,13 @@ class UWexpression(MathematicalMixin, uw_object, Symbol):
 
         # Check both dicts for name collisions
         name_exists_persistent = name in UWexpression._expr_names
-        # Check ephemeral dict - need to look for any key starting with this name
-        name_exists_ephemeral = any(k[0] == name for k in UWexpression._ephemeral_expr_names)
+        # Check ephemeral dict - need to look for any key starting with this name.
+        # Snapshot keys via list(...) before iterating: the underlying dict can
+        # be mutated mid-iteration by weakref finalizers running asynchronously
+        # during cyclic GC, raising "dictionary changed size during iteration".
+        name_exists_ephemeral = any(
+            k[0] == name for k in list(UWexpression._ephemeral_expr_names)
+        )
 
         # Determine unique ID for disambiguation
         # When _unique_name_generation=True, ALWAYS use instance_no as _uw_id

--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -62,6 +62,7 @@ from underworld3.systems import SNES_Scalar, SNES_Vector, SNES_Stokes_SaddlePt
 from underworld3.cython.generic_solvers import SNES_MultiComponent
 from underworld3 import VarType
 import underworld3.timing as timing
+from underworld3.utilities import memprobe
 from underworld3.utilities._api_tools import (
     uw_object,
     SymbolicProperty,
@@ -1232,6 +1233,7 @@ class SNES_Stokes(SNES_Stokes_SaddlePt):
         self.Unknowns.DFDt.enable_source_snapshot()
 
     @timing.routine_timer_decorator
+    @memprobe.instrument("Stokes.solve")
     def solve(
         self,
         zero_init_guess: bool = True,
@@ -3724,6 +3726,7 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
         self._penalty.sym = value
 
     @timing.routine_timer_decorator
+    @memprobe.instrument("NavierStokes.solve")
     def solve(
         self,
         zero_init_guess: bool = True,

--- a/src/underworld3/utilities/__init__.py
+++ b/src/underworld3/utilities/__init__.py
@@ -83,3 +83,4 @@ from .unit_aware_array import (
 )
 
 from . import retention_curves
+from . import memprobe

--- a/src/underworld3/utilities/memprobe.py
+++ b/src/underworld3/utilities/memprobe.py
@@ -4,7 +4,10 @@ Lightweight memory-growth diagnostics.
 Designed to surface slow leaks in long parallel runs (HPC OOM-class bugs)
 without slowing normal use. Three signal sources:
 
-* **Process RSS** via :mod:`resource` (peak + current).
+* **Process RSS** — current resident-set size via :mod:`psutil` if available,
+  falling back to ``/proc/self/statm`` on Linux, then to :mod:`resource`'s
+  high-water-mark RSS as a last resort. Current RSS is preferred so that
+  freed memory shows up as a negative delta.
 * **Live ``uw.kdtree.KDTree`` count** — UW's nanoflann wrapper isn't visible
   to PETSc's object tracker, so it's a common silent-leak suspect.
 * **Per-class Python instance counts** for the ``underworld3`` package, gated
@@ -43,7 +46,6 @@ from __future__ import annotations
 import functools
 import gc
 import os
-import resource
 import sys
 from collections import Counter
 from contextlib import contextmanager
@@ -79,9 +81,33 @@ def disable() -> None:
 def _rss_mb() -> float:
     """Current resident-set size in MiB.
 
-    On Linux ``ru_maxrss`` is in KiB; on macOS it is in bytes. We probe the
-    platform once to avoid getting it wrong silently.
+    Prefers ``psutil.Process().memory_info().rss`` (true current RSS, drops
+    when memory is freed). Falls back to ``/proc/self/statm`` on Linux when
+    psutil isn't available, then to ``resource.ru_maxrss`` (peak/high-water
+    RSS — does not decrease) as a last resort. The fallback is good enough
+    for spotting growth, less good for spotting recovery.
     """
+    try:
+        import psutil
+
+        return psutil.Process().memory_info().rss / (1024 * 1024)
+    except ImportError:
+        pass
+
+    if sys.platform.startswith("linux"):
+        try:
+            with open("/proc/self/statm", "r") as f:
+                # statm: size resident shared text lib data dt (in pages)
+                resident_pages = int(f.read().split()[1])
+            page_size = os.sysconf("SC_PAGESIZE")
+            return (resident_pages * page_size) / (1024 * 1024)
+        except (OSError, ValueError):
+            pass
+
+    # Last resort: peak RSS — does NOT decrease, so growth shows but
+    # recovery does not. ru_maxrss is KiB on Linux, bytes on macOS.
+    import resource
+
     rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
     if sys.platform == "darwin":
         return rss / (1024 * 1024)
@@ -152,7 +178,10 @@ def diff(before: dict[str, Any], after: dict[str, Any]) -> dict[str, Any]:
     delta: dict[str, Any] = {}
 
     drss = after["rss_mb"] - before["rss_mb"]
-    if drss != 0:
+    # Threshold below the format precision (0.01 MiB ≈ 10 KiB): smaller
+    # noise — inevitable when the source is RSS in KiB pages — would print
+    # as "+0.00 MiB" and defeat the "no change" fast path.
+    if abs(drss) >= 0.01:
         delta["rss_mb"] = drss
 
     kd_delta: dict[str, int] = {}
@@ -247,19 +276,23 @@ def instrument(label: str, full: bool = False, *, emit=print):
 def dump_petsc_leaks_at_finalize(filename: str | None = None) -> None:
     """Ask PETSc to dump unfreed objects at finalize.
 
-    Sets the runtime options ``-malloc_dump`` and ``-objects_dump`` so PETSc
-    writes its leak report when the process tears down. ``filename`` is
-    advisory — if provided, also sets ``-malloc_view`` / ``-options_view``
-    for a more verbose dump.
+    Sets the runtime options ``malloc_dump`` and ``objects_dump`` so PETSc
+    writes its leak report when the process tears down. When ``filename``
+    is given, also sets ``malloc_view`` to the same path for a more verbose
+    allocation dump.
 
-    Equivalent to running with ``-malloc_dump`` on the command line. Useful
-    when you can't change the launch command but can call this from Python
-    early in the run.
+    Note that ``petsc4py``'s :class:`Options` API expects keys *without* the
+    leading ``-`` that you'd type on the command line — same convention used
+    elsewhere in this codebase.
+
+    Equivalent to running with ``-malloc_dump -objects_dump`` on the command
+    line. Useful when you can't change the launch command but can call this
+    from Python early in the run.
     """
     from petsc4py import PETSc
 
     opts = PETSc.Options()
-    opts.setValue("-malloc_dump", "")
-    opts.setValue("-objects_dump", "")
+    opts.setValue("malloc_dump", "")
+    opts.setValue("objects_dump", "")
     if filename:
-        opts.setValue("-malloc_view", filename)
+        opts.setValue("malloc_view", filename)

--- a/src/underworld3/utilities/memprobe.py
+++ b/src/underworld3/utilities/memprobe.py
@@ -1,0 +1,265 @@
+"""
+Lightweight memory-growth diagnostics.
+
+Designed to surface slow leaks in long parallel runs (HPC OOM-class bugs)
+without slowing normal use. Three signal sources:
+
+* **Process RSS** via :mod:`resource` (peak + current).
+* **Live ``uw.kdtree.KDTree`` count** — UW's nanoflann wrapper isn't visible
+  to PETSc's object tracker, so it's a common silent-leak suspect.
+* **Per-class Python instance counts** for the ``underworld3`` package, gated
+  behind ``full=True`` because :func:`gc.get_objects` is slow at scale.
+
+For PETSc-side object/allocation tracking, use the runtime flags this module
+documents (``-log_view``, ``-malloc_dump``) — parsing PETSc's viewer output
+from Python is brittle and adds no signal beyond what those flags give.
+
+Activation
+----------
+- ``UW_MEMPROBE=1`` env var → enables instrumentation hooks at import time.
+- :func:`enable` / :func:`disable` for runtime toggling.
+- :func:`probe` context manager for ad-hoc snapshot+diff blocks.
+- :func:`instrument` decorator for per-method instrumentation; a no-op when
+  disabled (one attribute lookup + branch, sub-microsecond).
+
+Examples
+--------
+>>> import underworld3 as uw
+>>> from underworld3.utilities import memprobe
+>>>
+>>> with memprobe.probe("step 42"):
+...     do_one_step()           # diff is logged on exit
+>>>
+>>> @memprobe.instrument("stokes-solve")
+... def solve(...):
+...     ...
+
+For a long run, set ``UW_MEMPROBE=1`` and add a probe block per step. To pin
+PETSc-side leaks, run with ``-log_view -malloc_dump`` (or call
+:func:`dump_petsc_leaks_at_finalize`).
+"""
+from __future__ import annotations
+
+import functools
+import gc
+import os
+import resource
+import sys
+from collections import Counter
+from contextlib import contextmanager
+from typing import Any
+
+__all__ = [
+    "ENABLED",
+    "enable",
+    "disable",
+    "snapshot",
+    "diff",
+    "probe",
+    "instrument",
+    "dump_petsc_leaks_at_finalize",
+    "format_diff",
+]
+
+ENABLED: bool = bool(int(os.environ.get("UW_MEMPROBE", "0")))
+
+
+def enable() -> None:
+    """Turn instrumentation on at runtime."""
+    global ENABLED
+    ENABLED = True
+
+
+def disable() -> None:
+    """Turn instrumentation off at runtime."""
+    global ENABLED
+    ENABLED = False
+
+
+def _rss_mb() -> float:
+    """Current resident-set size in MiB.
+
+    On Linux ``ru_maxrss`` is in KiB; on macOS it is in bytes. We probe the
+    platform once to avoid getting it wrong silently.
+    """
+    rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    if sys.platform == "darwin":
+        return rss / (1024 * 1024)
+    return rss / 1024
+
+
+def _kdtree_counts() -> dict[str, int]:
+    try:
+        from underworld3 import kdtree
+
+        return {
+            "live": kdtree.live_count(),
+            "total_constructed": kdtree.total_constructed(),
+        }
+    except (ImportError, AttributeError):
+        return {"live": -1, "total_constructed": -1}
+
+
+def _python_class_counts(prefix: str = "underworld3") -> Counter[str]:
+    """Count live Python objects whose class lives under ``prefix``.
+
+    Walks ``gc.get_objects()`` once. Slow at large counts (~10–100 ms for
+    typical UW runs). Only called when ``full=True`` is requested.
+    """
+    counts: Counter[str] = Counter()
+    for obj in gc.get_objects():
+        cls = type(obj)
+        mod = getattr(cls, "__module__", "") or ""
+        # Some objects expose a non-string descriptor as ``__module__``;
+        # skip those rather than crashing the walk.
+        if isinstance(mod, str) and mod.startswith(prefix):
+            counts[f"{mod}.{cls.__name__}"] += 1
+    return counts
+
+
+def snapshot(full: bool = False) -> dict[str, Any]:
+    """Capture a memory snapshot.
+
+    Parameters
+    ----------
+    full
+        If ``True``, also walk ``gc.get_objects()`` to count live Python
+        instances by class (slow). Defaults to ``False``.
+
+    Returns
+    -------
+    dict
+        Keys: ``rss_mb``, ``kdtree`` (mapping with ``live`` and
+        ``total_constructed``), ``py_classes`` (mapping; only present when
+        ``full=True``).
+    """
+    snap: dict[str, Any] = {
+        "rss_mb": _rss_mb(),
+        "kdtree": _kdtree_counts(),
+    }
+    if full:
+        snap["py_classes"] = dict(_python_class_counts())
+    return snap
+
+
+def diff(before: dict[str, Any], after: dict[str, Any]) -> dict[str, Any]:
+    """Compute a structured diff between two snapshots.
+
+    Returns deltas only (excludes anything unchanged or absent). Python
+    class entries are sorted by absolute change so the dominant suspects
+    appear first.
+    """
+    delta: dict[str, Any] = {}
+
+    drss = after["rss_mb"] - before["rss_mb"]
+    if drss != 0:
+        delta["rss_mb"] = drss
+
+    kd_delta: dict[str, int] = {}
+    for key in ("live", "total_constructed"):
+        d = after["kdtree"].get(key, 0) - before["kdtree"].get(key, 0)
+        if d != 0:
+            kd_delta[key] = d
+    if kd_delta:
+        delta["kdtree"] = kd_delta
+
+    if "py_classes" in before and "py_classes" in after:
+        b = before["py_classes"]
+        a = after["py_classes"]
+        keys = set(b) | set(a)
+        py_delta = {k: a.get(k, 0) - b.get(k, 0) for k in keys}
+        py_delta = {k: v for k, v in py_delta.items() if v != 0}
+        if py_delta:
+            delta["py_classes"] = dict(
+                sorted(py_delta.items(), key=lambda kv: abs(kv[1]), reverse=True)
+            )
+
+    return delta
+
+
+def format_diff(label: str, delta: dict[str, Any]) -> str:
+    """Render a diff for stdout / logs. One line for trivial deltas, more if needed."""
+    if not delta:
+        return f"[memprobe] {label}: no change"
+
+    parts = [f"[memprobe] {label}:"]
+    if "rss_mb" in delta:
+        parts.append(f"  RSS {delta['rss_mb']:+.2f} MiB")
+    if "kdtree" in delta:
+        kd = delta["kdtree"]
+        chunk = ", ".join(f"{k} {v:+d}" for k, v in kd.items())
+        parts.append(f"  kdtree: {chunk}")
+    if "py_classes" in delta:
+        parts.append("  py_classes (top 10 by |Δ|):")
+        for cls, d in list(delta["py_classes"].items())[:10]:
+            parts.append(f"    {cls}: {d:+d}")
+    return "\n".join(parts)
+
+
+@contextmanager
+def probe(label: str, full: bool = False, *, emit=print):
+    """Context manager: snapshot before, snapshot after, log the diff.
+
+    Parameters
+    ----------
+    label
+        Short identifier for the block, included in the emitted diff.
+    full
+        Walk ``gc.get_objects()`` for per-class deltas (slow).
+    emit
+        Callable receiving the formatted diff string. Defaults to
+        :func:`print`. Use a logger or rank-aware writer for parallel runs.
+    """
+    if not ENABLED:
+        yield
+        return
+    before = snapshot(full=full)
+    try:
+        yield
+    finally:
+        after = snapshot(full=full)
+        emit(format_diff(label, diff(before, after)))
+
+
+def instrument(label: str, full: bool = False, *, emit=print):
+    """Decorator wrapping a method/function with :func:`probe`.
+
+    Fast-returns when :data:`ENABLED` is ``False`` (sub-microsecond overhead),
+    so it's safe to leave permanent decorations on hot paths.
+
+    Examples
+    --------
+    >>> @instrument("stokes-solve")
+    ... def solve(self, ...):
+    ...     ...
+    """
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kw):
+            if not ENABLED:
+                return func(*args, **kw)
+            with probe(label, full=full, emit=emit):
+                return func(*args, **kw)
+        return wrapper
+    return decorator
+
+
+def dump_petsc_leaks_at_finalize(filename: str | None = None) -> None:
+    """Ask PETSc to dump unfreed objects at finalize.
+
+    Sets the runtime options ``-malloc_dump`` and ``-objects_dump`` so PETSc
+    writes its leak report when the process tears down. ``filename`` is
+    advisory — if provided, also sets ``-malloc_view`` / ``-options_view``
+    for a more verbose dump.
+
+    Equivalent to running with ``-malloc_dump`` on the command line. Useful
+    when you can't change the launch command but can call this from Python
+    early in the run.
+    """
+    from petsc4py import PETSc
+
+    opts = PETSc.Options()
+    opts.setValue("-malloc_dump", "")
+    opts.setValue("-objects_dump", "")
+    if filename:
+        opts.setValue("-malloc_view", filename)

--- a/tests/test_0780_memprobe.py
+++ b/tests/test_0780_memprobe.py
@@ -1,0 +1,140 @@
+"""
+Smoke tests for the memprobe diagnostic module.
+
+These tests check the *plumbing*: instrumentation enable/disable, snapshot
+shape, KDTree live-count tracking, decorator no-op-when-disabled, and
+context-manager diff emission. They do not validate that any real leak is
+or isn't present — that's what users do with the tool, not what the tool
+itself can verify.
+"""
+import gc
+import os
+import numpy as np
+import pytest
+
+import underworld3 as uw
+from underworld3.utilities import memprobe
+
+
+@pytest.fixture(autouse=True)
+def _restore_enabled_flag():
+    """Each test starts with memprobe disabled regardless of env."""
+    saved = memprobe.ENABLED
+    memprobe.disable()
+    yield
+    memprobe.ENABLED = saved
+
+
+@pytest.mark.level_1
+@pytest.mark.tier_a
+def test_snapshot_shape():
+    """Snapshot must contain rss_mb (float) and kdtree (dict with two keys)."""
+    snap = memprobe.snapshot()
+
+    assert isinstance(snap["rss_mb"], float)
+    assert snap["rss_mb"] > 0
+    assert set(snap["kdtree"].keys()) == {"live", "total_constructed"}
+
+    # full=False should NOT walk gc
+    assert "py_classes" not in snap
+
+
+@pytest.mark.level_1
+@pytest.mark.tier_a
+def test_snapshot_full_includes_py_classes():
+    snap = memprobe.snapshot(full=True)
+    assert "py_classes" in snap
+    # Sanity: gc walked something
+    assert isinstance(snap["py_classes"], dict)
+
+
+@pytest.mark.level_1
+@pytest.mark.tier_a
+def test_kdtree_live_count_tracks_construction_destruction():
+    """KDTree __cinit__/__dealloc__ must update the live-instance counter."""
+    pts = np.random.random((20, 2))
+
+    before = uw.kdtree.live_count()
+    total_before = uw.kdtree.total_constructed()
+
+    tree = uw.kdtree.KDTree(pts)
+    assert uw.kdtree.live_count() == before + 1
+    assert uw.kdtree.total_constructed() == total_before + 1
+
+    del tree
+    gc.collect()
+    assert uw.kdtree.live_count() == before
+    # total_constructed never decreases
+    assert uw.kdtree.total_constructed() == total_before + 1
+
+
+@pytest.mark.level_1
+@pytest.mark.tier_a
+def test_diff_reports_kdtree_growth():
+    pts = np.random.random((20, 2))
+
+    before = memprobe.snapshot()
+    tree = uw.kdtree.KDTree(pts)  # noqa: F841 — kept alive across the diff
+    after = memprobe.snapshot()
+
+    delta = memprobe.diff(before, after)
+    assert delta["kdtree"]["live"] == 1
+    assert delta["kdtree"]["total_constructed"] == 1
+
+
+@pytest.mark.level_1
+@pytest.mark.tier_a
+def test_diff_drops_unchanged_keys():
+    snap = memprobe.snapshot()
+    delta = memprobe.diff(snap, snap)
+    # Identical snapshots produce no deltas
+    assert "kdtree" not in delta
+
+
+@pytest.mark.level_1
+@pytest.mark.tier_a
+def test_probe_context_emits_when_enabled(capsys):
+    memprobe.enable()
+    with memprobe.probe("test-block"):
+        _ = uw.kdtree.KDTree(np.random.random((10, 2)))
+
+    captured = capsys.readouterr()
+    assert "[memprobe] test-block" in captured.out
+    assert "kdtree" in captured.out
+
+
+@pytest.mark.level_1
+@pytest.mark.tier_a
+def test_probe_context_silent_when_disabled(capsys):
+    assert memprobe.ENABLED is False
+    with memprobe.probe("silent"):
+        _ = uw.kdtree.KDTree(np.random.random((10, 2)))
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+@pytest.mark.level_1
+@pytest.mark.tier_a
+def test_instrument_decorator_no_op_when_disabled(capsys):
+    """Decorator must not emit (or noticeably slow) when ENABLED is False."""
+    @memprobe.instrument("test-fn")
+    def f(x):
+        return x * 2
+
+    assert f(3) == 6
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+@pytest.mark.level_1
+@pytest.mark.tier_a
+def test_instrument_decorator_emits_when_enabled(capsys):
+    @memprobe.instrument("test-fn")
+    def f(x):
+        return x * 2
+
+    memprobe.enable()
+    assert f(3) == 6
+    captured = capsys.readouterr()
+    assert "[memprobe] test-fn" in captured.out

--- a/tests/test_0780_memprobe.py
+++ b/tests/test_0780_memprobe.py
@@ -8,7 +8,6 @@ or isn't present — that's what users do with the tool, not what the tool
 itself can verify.
 """
 import gc
-import os
 import numpy as np
 import pytest
 
@@ -51,21 +50,35 @@ def test_snapshot_full_includes_py_classes():
 @pytest.mark.level_1
 @pytest.mark.tier_a
 def test_kdtree_live_count_tracks_construction_destruction():
-    """KDTree __cinit__/__dealloc__ must update the live-instance counter."""
+    """KDTree __cinit__/__dealloc__ must update the live-instance counter.
+
+    The test asserts only on deltas around the operation under test, never
+    on absolute counts, because earlier tests in the same pytest session
+    can leave KDTree references alive that the cyclic GC may collect at
+    any time, shifting the baseline.
+    """
     pts = np.random.random((20, 2))
 
-    before = uw.kdtree.live_count()
-    total_before = uw.kdtree.total_constructed()
+    # Flush any pending cyclic-GC clean-ups so the baseline doesn't shift
+    # under us between snapshots.
+    gc.collect()
+    before_live = uw.kdtree.live_count()
+    before_total = uw.kdtree.total_constructed()
 
     tree = uw.kdtree.KDTree(pts)
-    assert uw.kdtree.live_count() == before + 1
-    assert uw.kdtree.total_constructed() == total_before + 1
+    assert uw.kdtree.live_count() - before_live == 1
+    assert uw.kdtree.total_constructed() - before_total == 1
+
+    after_create_live = uw.kdtree.live_count()
 
     del tree
     gc.collect()
-    assert uw.kdtree.live_count() == before
-    # total_constructed never decreases
-    assert uw.kdtree.total_constructed() == total_before + 1
+
+    # The only thing we care about: this construction/destruction pair
+    # produced a +1/-1 swing relative to its immediate before/after, and
+    # total_constructed never went backwards.
+    assert uw.kdtree.live_count() - after_create_live == -1
+    assert uw.kdtree.total_constructed() >= before_total + 1
 
 
 @pytest.mark.level_1


### PR DESCRIPTION
## Summary

Adds `uw.utilities.memprobe`, an opt-in diagnostic module for surfacing memory growth in long parallel runs. Complementary to #178 (the fix for #176): #178 plugged the specific leak holes, this PR is the leak-detector that survives for the next time someone reports OOM.

### What it tracks
| Signal | Source | Cost |
|---|---|---|
| Process RSS (MiB, current) | `psutil` → `/proc/self/statm` (Linux) → `resource.ru_maxrss` (last resort, peak only) | free |
| `KDTree` live + total-constructed | Cython class counters in `__cinit__`/`__dealloc__` | free |
| Per-class Python instance counts | `gc.get_objects()` walk | slow — gated behind `full=True` |

KDTree counts are the signal *neither* PETSc's tracker nor #178's regression test covers — UW's nanoflann wrapper is invisible to PETSc.

PETSc-side object/allocation tracking is **not** parsed from Python. PETSc's `-log_view` and `-malloc_dump` runtime flags give the same information more reliably and are documented in the guide. `memprobe.dump_petsc_leaks_at_finalize()` is a small helper that turns those on programmatically.

### Activation
- `UW_MEMPROBE=1` env var → enables at import time, decorated solvers start emitting per-call diffs.
- `memprobe.enable()` / `disable()` for runtime toggling.
- `with memprobe.probe("step 42"):` for ad-hoc blocks.
- `@memprobe.instrument("label")` decorator — fast-returns when disabled (one bool check), safe on hot paths. Pre-applied to `Stokes.solve()` and `NavierStokes.solve()`.

### Sample output
```
[memprobe] Stokes.solve:
  RSS +0.42 MiB
[memprobe] build-kdtree-batch:
  RSS +0.03 MiB
  kdtree: live +5, total_constructed +5
[memprobe] free-kdtree-batch:
  kdtree: live -5
```

### Bonus: dictionary-iteration race fix
`UWexpression._ephemeral_expr_names` was iterated directly while weakref finalizers mutated it under cyclic GC, raising `RuntimeError: dictionary changed size during iteration`. Pre-existing bug — surfaced flakily depending on test ordering. Fixed by snapshotting keys via `list(...)` before iterating. Independent of memprobe but landed here since the new tests reliably triggered it.

### Files
- `src/underworld3/utilities/memprobe.py` — module
- `src/underworld3/ckdtree.pyx` — KDTree counter instrumentation
- `src/underworld3/systems/solvers.py` — decorate Stokes + NavierStokes solve
- `src/underworld3/function/expressions.py` — race fix
- `tests/test_0780_memprobe.py` — 9 smoke tests
- `docs/developer/guides/memory-diagnostics.md` — usage + debugging recipes

## Validation against #178
Once merged, a useful cross-check: run any earlier-leaking workload with `UW_MEMPROBE=1` and confirm flat per-step RSS deltas where they used to climb. That validates both PRs at once.

## Test plan
- [x] `pytest tests/test_0780_memprobe.py` — 9 passed locally and on CI
- [x] End-to-end: real Stokes solve with `UW_MEMPROBE=1` emits expected diffs
- [x] KDTree counter exact: `live` returns to baseline after `del tree; gc.collect()`
- [x] Decorator silent when disabled (no stdout, no measurable overhead)
- [x] Rebased onto post-#178 development; conflicts auto-resolved
- [x] `test_0006_memory_leak.py` (Ben's #178 regression test) — passes
- [ ] @bknight1 to take memprobe for a spin on the original OOM workload as validation of #178

### Note on Copilot review
Copilot's two outstanding inline comments on `_rss_mb()` and the RSS threshold reference `resource.getrusage` / a missing threshold. Both were addressed in `b4665d1` — psutil is now the primary source (resource is a last-resort fallback only), and the threshold is `abs(drss) >= 0.01 MiB`. The comments are pinned to the same line numbers in the rebased file and so re-surfaced after the rebase.

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)