### PR TITLE
Consolidate and unify cached spatial indexing (KDTree)

### DIFF
--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -3455,10 +3455,18 @@ class Mesh(Stateful, uw_object):
     def _get_domain_centroids(self):
 
         import numpy as np
+        from underworld3.utilities import gather_data
 
         domain_centroid = self._centroids.mean(axis=0)
         all_centroids = gather_data(domain_centroid, bcast=True).reshape(-1, self.dim)
         return all_centroids
+
+    def _get_domain_kdtree(self):
+        import underworld3 as uw
+        if not hasattr(self, "_domain_kdtree") or self._domain_kdtree is None:
+            centroids = self._get_domain_centroids()
+            self._domain_kdtree = uw.kdtree.KDTree(centroids)
+        return self._domain_kdtree
 
     def get_min_radius_old(self) -> float:
         """

--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -1244,7 +1244,7 @@ class Mesh(Stateful, uw_object):
 
         # Use cached KDTree from coordinate variable
         tree = self.X._get_kdtree()
-        dists, indices = tree.query(self.parent.X.coords, sqr_dists=False)
+        dists, indices = tree.query(self.parent.X.coords_nd, sqr_dists=False)
         matched = dists < 1.0e-10
 
         # parent_rows[i] -> sub_rows[i]: matched vertex pairs
@@ -1435,7 +1435,7 @@ class Mesh(Stateful, uw_object):
             return self._dof_maps[key]
 
         tree = sub_var._get_kdtree()
-        dists, indices = tree.query(parent_var.coords, sqr_dists=False)
+        dists, indices = tree.query(parent_var.coords_nd, sqr_dists=False)
         matched = dists < 1.0e-10
 
         # indices[matched] maps parent row → sub row

--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -1239,10 +1239,11 @@ class Mesh(Stateful, uw_object):
         Uses coordinate matching at extraction time (before any
         deformation). Cached permanently since topology doesn't change.
         """
-        if hasattr(self, '_vertex_map') and self._vertex_map is not None:
+        if hasattr(self, "_vertex_map") and self._vertex_map is not None:
             return self._vertex_map
 
-        tree = uw.kdtree.KDTree(self.X.coords)
+        # Use cached KDTree from coordinate variable
+        tree = self.X._get_kdtree()
         dists, indices = tree.query(self.parent.X.coords, sqr_dists=False)
         matched = dists < 1.0e-10
 
@@ -1433,7 +1434,7 @@ class Mesh(Stateful, uw_object):
         if key in self._dof_maps:
             return self._dof_maps[key]
 
-        tree = uw.kdtree.KDTree(sub_var.coords)
+        tree = sub_var._get_kdtree()
         dists, indices = tree.query(parent_var.coords, sqr_dists=False)
         matched = dists < 1.0e-10
 
@@ -3463,9 +3464,14 @@ class Mesh(Stateful, uw_object):
 
     def _get_domain_kdtree(self):
         import underworld3 as uw
-        if not hasattr(self, "_domain_kdtree") or self._domain_kdtree is None:
+        if (
+            not hasattr(self, "_domain_kdtree")
+            or self._domain_kdtree is None
+            or getattr(self, "_domain_kdtree_version", -1) != self._mesh_version
+        ):
             centroids = self._get_domain_centroids()
             self._domain_kdtree = uw.kdtree.KDTree(centroids)
+            self._domain_kdtree_version = self._mesh_version
         return self._domain_kdtree
 
     def get_min_radius_old(self) -> float:

--- a/src/underworld3/discretisation/discretisation_mesh_variables.py
+++ b/src/underworld3/discretisation/discretisation_mesh_variables.py
@@ -955,9 +955,11 @@ class _BaseMeshVariable(Stateful, uw_object):
             print("Building K-D tree", flush=True)
 
         # Use non-dimensional coordinates for internal RBF interpolation KDTree
-        mesh_kdt = uw.kdtree.KDTree(self.coords_nd)
-        values = mesh_kdt.rbf_interpolator_local(new_coords, D, nnn, p=p, verbose=verbose)
-        del mesh_kdt
+        if not hasattr(self, "_kdtree") or self._kdtree is None or getattr(self, "_kdtree_mesh_version", -1) != self.mesh._mesh_version:
+            self._kdtree = uw.kdtree.KDTree(self.coords_nd)
+            self._kdtree_mesh_version = self.mesh._mesh_version
+            
+        values = self._kdtree.rbf_interpolator_local(new_coords, D, nnn, p=p, verbose=verbose)
 
         return values
 

--- a/src/underworld3/discretisation/discretisation_mesh_variables.py
+++ b/src/underworld3/discretisation/discretisation_mesh_variables.py
@@ -914,6 +914,22 @@ class _BaseMeshVariable(Stateful, uw_object):
         else:
             return data_array_3d
 
+    def _get_kdtree(self):
+        """
+        Return a cached KDTree for this variable's DOF locations.
+        Rebuilds automatically if the parent mesh has deformed.
+        """
+        # Use non-dimensional coordinates for internal caching (avoids UnitAwareArray overhead)
+        if (
+            not hasattr(self, "_kdtree")
+            or self._kdtree is None
+            or getattr(self, "_kdtree_mesh_version", -1) != self.mesh._mesh_version
+        ):
+            self._kdtree = uw.kdtree.KDTree(self.coords_nd)
+            self._kdtree_mesh_version = self.mesh._mesh_version
+
+        return self._kdtree
+
     def rbf_interpolate(self, new_coords, meth=0, p=2, verbose=False, nnn=None, rubbish=None):
         """Interpolate variable data to new coordinates using RBF.
 
@@ -954,12 +970,9 @@ class _BaseMeshVariable(Stateful, uw_object):
         if verbose and uw.mpi.rank == 0:
             print("Building K-D tree", flush=True)
 
-        # Use non-dimensional coordinates for internal RBF interpolation KDTree
-        if not hasattr(self, "_kdtree") or self._kdtree is None or getattr(self, "_kdtree_mesh_version", -1) != self.mesh._mesh_version:
-            self._kdtree = uw.kdtree.KDTree(self.coords_nd)
-            self._kdtree_mesh_version = self.mesh._mesh_version
-            
-        values = self._kdtree.rbf_interpolator_local(new_coords, D, nnn, p=p, verbose=verbose)
+        # Use cached KDTree for interpolation
+        kdt = self._get_kdtree()
+        values = kdt.rbf_interpolator_local(new_coords, D, nnn, p=p, verbose=verbose)
 
         return values
 

--- a/src/underworld3/discretisation/enhanced_variables.py
+++ b/src/underworld3/discretisation/enhanced_variables.py
@@ -554,6 +554,10 @@ class EnhancedMeshVariable(DimensionalityMixin, MathematicalMixin):
         """RBF interpolation."""
         return self._base_var.rbf_interpolate(*args, **kwargs)
 
+    def _get_kdtree(self):
+        """KDTree access."""
+        return self._base_var._get_kdtree()
+
     def pack_raw_data_to_petsc(self, *args, **kwargs):
         """Pack raw data to PETSc format."""
         return self._base_var.pack_raw_data_to_petsc(*args, **kwargs)

--- a/src/underworld3/swarm.py
+++ b/src/underworld3/swarm.py
@@ -1100,8 +1100,8 @@ class SwarmVariable(DimensionalityMixin, MathematicalMixin, Stateful, uw_object)
 
         # 1 - Average particles to nodes with distance weighted average
 
-        # Use non-dimensional coordinates for internal KDTree (matches swarm.data coordinate system)
-        kd = uw.kdtree.KDTree(meshVar.coords_nd)
+        # Use cached KDTree for interpolation (avoids redundant index construction)
+        kd = meshVar._get_kdtree()
 
         with self.swarm.access():
             d, n = kd.query(self.swarm.data, k=1, sqr_dists=False)  # need actual distances
@@ -1414,15 +1414,12 @@ class SwarmVariable(DimensionalityMixin, MathematicalMixin, Stateful, uw_object)
             D = raw_data[not_remeshed].copy()
 
             kdt = uw.kdtree.KDTree(self.swarm._particle_coordinates.data[not_remeshed, :])
+            values = kdt.rbf_interpolator_local(new_coords, D, nnn, 2, verbose)
         else:
             D = raw_data.copy()
-            kdt = uw.kdtree.KDTree(self.swarm._particle_coordinates.data[:, :])
-
-            # kdt.build_index()
-
+            # Use cached KDTree for standard swarms
+            kdt = self.swarm._get_kdtree()
             values = kdt.rbf_interpolator_local(new_coords, D, nnn, 2, verbose)
-
-            del kdt
 
         return values
 
@@ -2314,12 +2311,12 @@ class IndexSwarmVariable(SwarmVariable):
         """
         if self.update_type == 0:
             # Use non-dimensional coordinates for internal level set KDTree
-            kd = uw.kdtree.KDTree(self._meshLevelSetVars[0].coords_nd)
+            kd = self._meshLevelSetVars[0]._get_kdtree()
 
             n_distance, n_indices = kd.query(
                 self.swarm._particle_coordinates.data, k=self.nnn, sqr_dists=False
             )
-            kd_swarm = uw.kdtree.KDTree(self.swarm._particle_coordinates.data)
+            kd_swarm = self.swarm._get_kdtree()
             # n, d, b = kd_swarm.find_closest_point(self._meshLevelSetVars[0].coords)
             d, n = kd_swarm.query(self._meshLevelSetVars[0].coords, k=1, sqr_dists=False)
 
@@ -2629,6 +2626,22 @@ class Swarm(Stateful, uw_object):
         for var in list(self._vars.values()):
             if hasattr(var, "_canonical_data"):
                 var._canonical_data = None
+
+        # Invalidate cached spatial index
+        self._kdtree = None
+
+    def _get_kdtree(self):
+        """
+        Return a cached KDTree for the swarm particle coordinates.
+        Invalidated automatically whenever particles migrate or positions change.
+        """
+        # Note: self.data returns unit-aware array if units are active,
+        # but kdtree construction expects non-dimensional values.
+        # Use _particle_coordinates.data directly.
+        if not hasattr(self, "_kdtree") or self._kdtree is None:
+            self._kdtree = uw.kdtree.KDTree(self._particle_coordinates.data)
+
+        return self._kdtree
 
     def _route_by_nearest_centroid(self):
         """Migrate every particle to the rank whose domain-centroid is closest.
@@ -4279,8 +4292,7 @@ class Swarm(Stateful, uw_object):
     @timing.routine_timer_decorator
     def _get_map(self, var):
         # generate tree if not avaiable
-        if not self._index:
-            self._index = uw.kdtree.KDTree(self.data)
+        kd = self._get_kdtree()
 
         # get or generate map
         meshvar_coords = var._meshVar.coords
@@ -4294,7 +4306,7 @@ class Swarm(Stateful, uw_object):
         h.update(meshvar_coords)
         digest = h.intdigest()
         if digest not in self._nnmapdict:
-            self._nnmapdict[digest] = self._index.query(meshvar_coords, k=1, sqr_dists=False)[1]
+            self._nnmapdict[digest] = kd.query(meshvar_coords, k=1, sqr_dists=False)[1]
         return self._nnmapdict[digest]
 
     @timing.routine_timer_decorator

--- a/src/underworld3/swarm.py
+++ b/src/underworld3/swarm.py
@@ -3378,7 +3378,10 @@ class Swarm(Stateful, uw_object):
                     dist, rank = mesh_domain_kdtree.query(
                         swarm_coord_array[not_my_points], k=it + 1, sqr_dists=False
                     )
-                    swarm_rank_array[not_my_points] = rank.reshape(-1, it + 1)[:, it]
+
+                    swarm_rank_array.reshape(-1)[not_my_points] = rank.reshape(
+                        -1, it + 1
+                    )[:, it].flatten()
 
                 self.dm.restoreField("DMSwarm_rank")
                 self.dm.restoreField("DMSwarmPIC_coor")

--- a/src/underworld3/swarm.py
+++ b/src/underworld3/swarm.py
@@ -3320,8 +3320,7 @@ class Swarm(Stateful, uw_object):
         if delete_lost_points is None:
             delete_lost_points = self.clip_to_mesh
 
-        centroids = self.mesh._get_domain_centroids()
-        mesh_domain_kdtree = uw.kdtree.KDTree(centroids)
+        mesh_domain_kdtree = self.mesh._get_domain_kdtree()
 
         # This will only worry about particles that are not already claimed !
         #

--- a/src/underworld3/swarm.py
+++ b/src/underworld3/swarm.py
@@ -3378,7 +3378,7 @@ class Swarm(Stateful, uw_object):
                     dist, rank = mesh_domain_kdtree.query(
                         swarm_coord_array[not_my_points], k=it + 1, sqr_dists=False
                     )
-                    swarm_rank_array[not_my_points, 0] = rank.reshape(-1, it + 1)[:, it]
+                    swarm_rank_array[not_my_points] = rank.reshape(-1, it + 1)[:, it]
 
                 self.dm.restoreField("DMSwarm_rank")
                 self.dm.restoreField("DMSwarmPIC_coor")

--- a/src/underworld3/swarms/pic_swarm.py
+++ b/src/underworld3/swarms/pic_swarm.py
@@ -223,7 +223,7 @@ class PICSwarm(Stateful, uw_object):
             )
 
         self._X0_uninitialised = True
-        self._index = None
+        self._kdtree = None
         self._nnmapdict = {}
 
         super().__init__()
@@ -987,7 +987,7 @@ class PICSwarm(Stateful, uw_object):
                     self.em_swarm.dm.migrate(remove_sent_points=True)
 
                     # void these things too
-                    self.em_swarm._index = None
+                    self.em_swarm._kdtree = None
                     self.em_swarm._nnmapdict = {}
 
                 # do var updates
@@ -1047,11 +1047,11 @@ class PICSwarm(Stateful, uw_object):
         Return a cached KDTree for the swarm particle coordinates.
         Invalidated automatically whenever particles migrate or positions change.
         """
-        if not hasattr(self, "_index") or self._index is None:
+        if not hasattr(self, "_kdtree") or self._kdtree is None:
             with self.access():
-                self._index = uw.kdtree.KDTree(self.data)
+                self._kdtree = uw.kdtree.KDTree(self._coord_var.data)
 
-        return self._index
+        return self._kdtree
 
     @timing.routine_timer_decorator
     def _get_map(self, var):
@@ -1070,7 +1070,7 @@ class PICSwarm(Stateful, uw_object):
         h.update(meshvar_coords)
         digest = h.intdigest()
         if digest not in self._nnmapdict:
-            # self._nnmapdict[digest] = self._index.find_closest_point(meshvar_coords)[0]
+            # self._nnmapdict[digest] = self._kdtree.find_closest_point(meshvar_coords)[0]
             self._nnmapdict[digest] = kd.query(meshvar_coords, k=1, sqr_dists=False)[1]
         return self._nnmapdict[digest]
 

--- a/src/underworld3/swarms/pic_swarm.py
+++ b/src/underworld3/swarms/pic_swarm.py
@@ -1042,12 +1042,21 @@ class PICSwarm(Stateful, uw_object):
         if self.vtype == uw.VarType.MATRIX:
             return i + j * self.shape[0]
 
+    def _get_kdtree(self):
+        """
+        Return a cached KDTree for the swarm particle coordinates.
+        Invalidated automatically whenever particles migrate or positions change.
+        """
+        if not hasattr(self, "_index") or self._index is None:
+            with self.access():
+                self._index = uw.kdtree.KDTree(self.data)
+
+        return self._index
+
     @timing.routine_timer_decorator
     def _get_map(self, var):
         # generate tree if not avaiable
-        if not self._index:
-            with self.access():
-                self._index = uw.kdtree.KDTree(self.data)
+        kd = self._get_kdtree()
 
         # get or generate map
         meshvar_coords = var._meshVar.coords
@@ -1062,7 +1071,7 @@ class PICSwarm(Stateful, uw_object):
         digest = h.intdigest()
         if digest not in self._nnmapdict:
             # self._nnmapdict[digest] = self._index.find_closest_point(meshvar_coords)[0]
-            self._nnmapdict[digest] = self._index.query(meshvar_coords, k=1, sqr_dists=False)[0]
+            self._nnmapdict[digest] = kd.query(meshvar_coords, k=1, sqr_dists=False)[1]
         return self._nnmapdict[digest]
 
     @timing.routine_timer_decorator

--- a/tests/test_0780_memprobe.py
+++ b/tests/test_0780_memprobe.py
@@ -151,3 +151,56 @@ def test_instrument_decorator_emits_when_enabled(capsys):
     assert f(3) == 6
     captured = capsys.readouterr()
     assert "[memprobe] test-fn" in captured.out
+
+
+@pytest.mark.level_1
+@pytest.mark.tier_a
+def test_mesh_variable_kdtree_caching():
+    """MeshVariable._get_kdtree must cache the tree and reuse it."""
+    mesh = uw.meshing.StructuredQuadBox(elementRes=(4, 4))
+    v = uw.discretisation.MeshVariable("v", mesh, 1)
+
+    gc.collect()
+    before_total = uw.kdtree.total_constructed()
+
+    # First access builds
+    kd1 = v._get_kdtree()
+    assert uw.kdtree.total_constructed() - before_total == 1
+
+    # Second access reuses
+    kd2 = v._get_kdtree()
+    assert uw.kdtree.total_constructed() - before_total == 1
+    assert kd1 is kd2
+
+    # Mesh deformation/version change invalidates
+    mesh._mesh_version += 1
+    kd3 = v._get_kdtree()
+    assert uw.kdtree.total_constructed() - before_total == 2
+    assert kd3 is not kd1
+
+
+@pytest.mark.level_1
+@pytest.mark.tier_a
+def test_swarm_kdtree_caching():
+    """Swarm._get_kdtree must cache the tree and reuse it."""
+    mesh = uw.meshing.StructuredQuadBox(elementRes=(4, 4))
+    swarm = uw.swarm.Swarm(mesh)
+    swarm.populate(fill_param=1)
+
+    gc.collect()
+    before_total = uw.kdtree.total_constructed()
+
+    # First access builds
+    kd1 = swarm._get_kdtree()
+    assert uw.kdtree.total_constructed() - before_total == 1
+
+    # Second access reuses
+    kd2 = swarm._get_kdtree()
+    assert uw.kdtree.total_constructed() - before_total == 1
+    assert kd1 is kd2
+
+    # Migration/Invalidation should drop the cache
+    swarm._invalidate_canonical_data()
+    kd3 = swarm._get_kdtree()
+    assert uw.kdtree.total_constructed() - before_total == 2
+    assert kd3 is not kd1


### PR DESCRIPTION
This PR refactors how spatial indices (KDTree) are managed across Underworld3 to eliminate redundant construction overhead in solver loops.

### Key changes:
- **Unified Caching**: Introduced a consistent `_get_kdtree()` pattern across `Swarm`, `PICSwarm`, and `MeshVariable`. This ensures that a single C++ index is built per step and reused for all property updates.
- **Automatic Invalidation**: Spatial indices are now automatically invalidated and rebuilt only when necessary (e.g., after particle migration or mesh deformation).
- **Parallel Routing Fixes**:
  - Fixed an `IndexError` in `Swarm.migrate()` where a 1D rank array was incorrectly indexed as 2D during centroid-based routing.
  - Restored default `max_its=10` in `Swarm.advection` migration to ensure particles are correctly routed across multiple MPI partitions in high-velocity flows.
