### PR TITLE
fix(ddt): Lagrangian.__init__ — uw.swarm.UWSwarm typo

### DIFF
--- a/src/underworld3/systems/ddt.py
+++ b/src/underworld3/systems/ddt.py
@@ -2262,7 +2262,7 @@ class Lagrangian(uw_object):
         super().__init__()
 
         # create a new swarm to manage here
-        dudt_swarm = uw.swarm.UWSwarm(mesh)
+        dudt_swarm = uw.swarm.Swarm(mesh)
 
         self.mesh = mesh
         self.swarm = dudt_swarm


### PR DESCRIPTION
## Summary

- One-line fix: `uw.swarm.UWSwarm(mesh)` → `uw.swarm.Swarm(mesh)` in `Lagrangian.__init__`.
- `UWSwarm` does not exist (and never has). The typo was introduced by `0778b7d` (2025-07-07, "Fix uw.function.evaluate / eliminate evalf") while editing nearby code, and has silently blocked direct construction of `Lagrangian` DDt for ten months.

## Context

Surfaced during the in-memory snapshot toolkit work on `feature/in-memory-checkpoint`. The state-as-dataclass retrofit added a Lagrangian roundtrip test that couldn't run; investigation showed the class itself was the problem, not the retrofit. Cherry-picked here as a small standalone bugfix so consumers of `Lagrangian` don't have to wait for the snapshot feature to land.

No other `UWSwarm` references exist in the tree.

## Test plan

- [ ] `pixi run -e amr-dev python -c "import underworld3 as uw; mesh = uw.meshing.UnstructuredSimplexBox(minCoords=(0,0), maxCoords=(1,1), cellSize=1/4); T = uw.discretisation.MeshVariable('T', mesh, 1, degree=1); V = uw.discretisation.MeshVariable('V', mesh, 2, degree=2); lg = uw.systems.ddt.Lagrangian(mesh=mesh, psi_fn=T.sym, V_fn=V.sym, vtype=uw.VarType.SCALAR, degree=1, continuous=True, order=2); print(lg)"` — succeeds (previously raised `AttributeError`).
- [ ] Existing core test suite (`test_0000`-`test_0005`, `test_1052_ddt_set_initial_history`) still passes.

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)