### PR TITLE
Invalidate evaluate/DMInterp/topology caches on Mesh._deform_mesh

### DIFF
--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -1810,6 +1810,19 @@ class Mesh(Stateful, uw_object):
             if solver is not None and hasattr(solver, "is_setup"):
                 solver.is_setup = False
 
+        # Invalidate caches whose contents become stale when mesh
+        # coordinates change. Matches the cache hygiene already
+        # performed by mesh.adapt() and _legacy_access. Without these,
+        # uw.function.evaluate (and any user code that keys lookups
+        # off _topology_version) can return values computed against
+        # the pre-deform mesh.
+        self._evaluation_hash = None
+        self._evaluation_interpolated_results = None
+        if hasattr(self, '_dminterpolation_cache'):
+            self._dminterpolation_cache.invalidate_all(
+                reason="mesh deformed")
+        self._topology_version += 1
+
         # Propagate coordinate changes to registered submeshes
         for submesh in self._registered_submeshes:
             submesh.sync_coordinates_from_parent()


### PR DESCRIPTION
## Summary

After a coordinate change in ``Mesh._deform_mesh``, three mesh-level caches were left holding state computed against the pre-deform geometry. ``mesh.adapt()`` and ``_legacy_access`` (with writeable vars) already invalidate these — this PR brings ``_deform_mesh`` into line with the same hygiene.

Caches invalidated:

- ``self._evaluation_hash`` and ``self._evaluation_interpolated_results`` (the legacy ``uw.function.evaluate`` fast-path cache)
- ``self._dminterpolation_cache`` (stores DMInterpolation structures keyed by ``(coord_hash, dofcount)`` — encode cell residency for each query coord plus the reference-to-physical mapping)
- ``self._topology_version`` (bumped; downstream caches read this counter as an invalidation signal)

## Empirical impact

Tested against a free-surface convection case where ``_deform_mesh`` is called many times per step. **Bit-identical trajectory** before and after this patch — the cache was rarely returning stale values on that specific problem, because the trace-back path uses fresh coord arrays each step (cache key changes, mostly misses).

So this PR is principled hygiene rather than a curative fix for a known bug. It protects against future failure modes where user code re-uses a coord array across mesh deformations (cache key matches, stale entry returned).

## What it doesn't do

No new API surface. No behaviour change for code that doesn't hit the caches. ``mesh.adapt()`` and ``_legacy_access`` already do this; the inconsistency was that ``_deform_mesh`` didn't.

## Test plan

- [ ] Full CI suite (expect bit-identical results — these caches are rarely hit on stale entries)
- [ ] No performance regression (invalidation is O(1) for the hash nulls; ``invalidate_all`` on the DMInterpolation cache is also cheap)

## Files changed

- ``src/underworld3/discretisation/discretisation_mesh.py`` (+13 lines)

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)