### PR TITLE
_deform_mesh: bump _mesh_version + clear runner nav caches

### DIFF
--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -1844,6 +1844,37 @@ class Mesh(Stateful, uw_object):
                 self._dminterpolation_cache.invalidate_all(
                     reason="mesh deformed")
             self._topology_version += 1
+            # Bump the geometry-version counter so version-keyed
+            # kdtree navigation caches rebuild against the new DOF
+            # positions: _BaseMeshVariable._get_kdtree and
+            # Mesh._get_domain_kdtree both gate their rebuild on
+            # `_mesh_version`. PR #182 introduced those version-keyed
+            # caches; the mesh.X.coords callback path bumps
+            # _mesh_version, but direct _deform_mesh() calls (every
+            # free-surface RK stage) bypass that callback. Without
+            # this bump the navigation kdtrees stay frozen on the
+            # undeformed mesh — back-advected SL samples land at the
+            # wrong DOFs, corrupting the temperature field. PR #188
+            # added _topology_version invalidation but missed this.
+            self._mesh_version += 1
+            # Also nuke any *user-installed* navigation caches that
+            # key off coord-array identity. A runner's
+            # restore_points_to_domain typically installs a
+            # `_restore_kdt` / `_restore_coords_id` pair on the mesh,
+            # rebuilding the kdtree only when `id(mesh.X.coords)`
+            # changes. _deform_mesh replaces self._coords with a new
+            # object, but CPython reuses freed ids, so the fresh
+            # coords array can land on the SAME id() as the old one —
+            # the staleness check then false-negatives and the stale
+            # restore-kdtree is reused, snapping back-advected SL
+            # particles to pre-deform DOF positions (smeared T,
+            # damped free-surface convection feedback). Explicitly
+            # clearing these defeats the id()-reuse hazard. PR #188
+            # captured the generic cache invalidation above but
+            # dropped this runner-navigation-cache clear.
+            for _nav_attr in ("_restore_kdt", "_restore_coords_id"):
+                if hasattr(self, _nav_attr):
+                    setattr(self, _nav_attr, None)
 
             # Propagate coordinate changes to registered submeshes
             for submesh in self._registered_submeshes:

--- a/src/underworld3/function/pure_sympy_evaluator.py
+++ b/src/underworld3/function/pure_sympy_evaluator.py
@@ -137,6 +137,19 @@ def _expr_hash(expr):
     str
         Hash string
     """
+    # sympy.Dummy carries a volatile, globally-unique dummy_index that
+    # srepr embeds. The evaluate() coordinate-substitution path mints a
+    # fresh Dummy per call, so an otherwise-identical expression would
+    # hash differently every call and never hit the cache (issue #194).
+    # Canonicalise dummies to name-stable Symbols before srepr. This only
+    # affects the cache *key*; the real sympy.lambdify() call still uses
+    # the original expr/symbols, so numerics are unchanged. The cache key
+    # also separately carries the symbol-name tuple, so name-keying here
+    # is safe and deterministic.
+    dummies = expr.atoms(sympy.Dummy)
+    if dummies:
+        expr = expr.xreplace({d: sympy.Symbol(d.name) for d in dummies})
+
     # Use sympy's srepr for consistent string representation
     expr_str = sympy.srepr(expr)
     return hashlib.md5(expr_str.encode()).hexdigest()

--- a/tests/test_0720_lambdify_optimization_paths.py
+++ b/tests/test_0720_lambdify_optimization_paths.py
@@ -317,51 +317,75 @@ class TestDetectionMechanism:
 
 
 class TestPerformanceExpectations:
-    """Test that performance is as expected (not exact timing, just sanity checks)."""
+    """Verify the lambdify cache *behaviour* (cache hit on repeat), not
+    wall-clock timing.
 
-    def test_lambdify_caching(self, setup_mesh, sample_points):
-        """Cached lambdified evaluations should be fast."""
-        import time
+    One-off wall-clock assertions are inherently flaky on shared CI
+    runners. The property we actually care about is behavioural: an
+    identical lambdify request must reuse the cached function object
+    rather than recompiling. These tests exercise the cache contract
+    (``get_cached_lambdified``) directly, so they are deterministic.
+    """
 
+    def test_lambdify_cache_hit(self):
+        """``get_cached_lambdified`` returns the *same* object on a repeat.
+
+        Validates the cache mechanism's contract directly:
+        - first request for an expression compiles and stores one entry;
+        - an identical request returns the very same function object and
+          adds no entry (a genuine cache hit);
+        - a structurally different expression is cached separately
+          (the key actually discriminates).
+        """
+        from underworld3.function.pure_sympy_evaluator import (
+            _lambdify_cache,
+            clear_lambdify_cache,
+            get_cached_lambdified,
+        )
+
+        a, b = sympy.symbols("a b")
+        expr = sympy.erf(5 * a - 2) / 2 + sympy.sin(b)
+        symbols = (a, b)
+
+        clear_lambdify_cache()
+        assert len(_lambdify_cache) == 0
+
+        # Cache miss: compiles and stores exactly one entry.
+        f1 = get_cached_lambdified(expr, symbols)
+        assert len(_lambdify_cache) == 1, "first call did not populate the cache"
+
+        # Cache hit: identical request -> same object, no new entry.
+        f2 = get_cached_lambdified(expr, symbols)
+        assert f2 is f1, "identical request did not return the cached function"
+        assert len(_lambdify_cache) == 1, "cache hit must not add an entry"
+
+        # The cached function is correct.
+        val = f1(0.4, 0.7)
+        assert np.isclose(
+            val, float(sympy.erf(5 * 0.4 - 2) / 2 + sympy.sin(0.7))
+        )
+
+        # A different expression is a distinct cache entry (key discriminates).
+        other = sympy.erf(5 * a - 2) / 2 + sympy.cos(b)
+        g = get_cached_lambdified(other, symbols)
+        assert g is not f1
+        assert len(_lambdify_cache) == 2, "distinct expression must be cached separately"
+
+    def test_rbf_modes_consistent(self, setup_mesh, sample_points):
+        """rbf=True and rbf=False agree for a pure-sympy expression.
+
+        Replaces a former wall-clock "rbf=False not slow" assertion with
+        the meaningful, timing-free property: the two evaluation paths
+        must produce the same numbers for an expression that contains no
+        mesh-variable symbols.
+        """
         x = setup_mesh.X[0]
         expr = sympy.erf(5 * x - 2) / 2
 
-        # First call (compilation)
-        start = time.time()
-        result1 = uw.function.evaluate(expr, sample_points, rbf=True)
-        time1 = time.time() - start
+        r_rbf = uw.function.evaluate(expr, sample_points, rbf=True)
+        r_norbf = uw.function.evaluate(expr, sample_points, rbf=False)
 
-        # Cached call
-        start = time.time()
-        result2 = uw.function.evaluate(expr, sample_points, rbf=True)
-        time2 = time.time() - start
-
-        # Cached should be faster or at least not slower
-        # (For small evaluations, overhead dominates so speedup may be small)
-        assert time2 <= time1 * 2, f"Cached call slower than first: {time2} vs {time1}"
-
-        # Both should be reasonably fast (< 10ms for 3 points)
-        assert time2 < 0.01, f"Cached call too slow: {time2}s"
-
-        # Results should be identical
-        assert np.allclose(result1.flatten(), result2.flatten())
-
-    def test_rbf_false_not_slow(self, setup_mesh, sample_points):
-        """rbf=False should not be dramatically slower for pure sympy."""
-        import time
-
-        x = setup_mesh.X[0]
-        expr = sympy.erf(5 * x - 2) / 2
-
-        # Warm up cache
-        _ = uw.function.evaluate(expr, sample_points, rbf=False)
-
-        # Cached call with rbf=False should be fast (< 10ms for 3 points)
-        start = time.time()
-        result = uw.function.evaluate(expr, sample_points, rbf=False)
-        elapsed = time.time() - start
-
-        assert elapsed < 0.01, f"rbf=False too slow: {elapsed}s (should be < 10ms)"
+        assert np.allclose(r_rbf.flatten(), r_norbf.flatten())
 
 
 if __name__ == "__main__":

--- a/tests/test_0720_lambdify_optimization_paths.py
+++ b/tests/test_0720_lambdify_optimization_paths.py
@@ -371,21 +371,39 @@ class TestPerformanceExpectations:
         assert g is not f1
         assert len(_lambdify_cache) == 2, "distinct expression must be cached separately"
 
-    def test_rbf_modes_consistent(self, setup_mesh, sample_points):
-        """rbf=True and rbf=False agree for a pure-sympy expression.
+    def test_evaluate_cache_stable_across_calls(self, setup_mesh, sample_points):
+        """Regression guard for #194 (aggregate cache behaviour, no timing).
 
-        Replaces a former wall-clock "rbf=False not slow" assertion with
-        the meaningful, timing-free property: the two evaluation paths
-        must produce the same numbers for an expression that contains no
-        mesh-variable symbols.
+        Repeated identical ``uw.function.evaluate`` calls must reach a
+        bounded steady state in ``_lambdify_cache`` -- not grow one entry
+        per call. Before the #194 fix the cache grew [1,2,3,4,...] because
+        a fresh ``sympy.Dummy`` (volatile ``dummy_index`` in ``srepr``)
+        was minted every call, so the cache key never matched. Also
+        asserts results are identical across calls (no behavioural change
+        from the cache-key canonicalisation).
         """
+        from underworld3.function.pure_sympy_evaluator import (
+            _lambdify_cache,
+            clear_lambdify_cache,
+        )
+
         x = setup_mesh.X[0]
         expr = sympy.erf(5 * x - 2) / 2
 
-        r_rbf = uw.function.evaluate(expr, sample_points, rbf=True)
-        r_norbf = uw.function.evaluate(expr, sample_points, rbf=False)
+        clear_lambdify_cache()
+        ref = uw.function.evaluate(expr, sample_points, rbf=True)
+        size_after_first = len(_lambdify_cache)
+        assert size_after_first >= 1, "first call did not populate the cache"
 
-        assert np.allclose(r_rbf.flatten(), r_norbf.flatten())
+        for _ in range(8):
+            r = uw.function.evaluate(expr, sample_points, rbf=True)
+            assert np.allclose(r.flatten(), ref.flatten())
+
+        # Steady state: no growth after the first compile (cache hits).
+        assert len(_lambdify_cache) == size_after_first, (
+            f"lambdify cache grew {size_after_first} -> {len(_lambdify_cache)} "
+            f"across identical evaluate() calls -- regression of #194"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Two cache-invalidation gaps in `Mesh._deform_mesh`, both triggered by direct `_deform_mesh(coords)` calls (which bypass the `mesh.X.coords` NDArray callback that normally performs this hygiene — e.g. every free-surface RK stage in the convection benchmark):

- **`_mesh_version` not bumped.** PR #182 introduced version-keyed kdtree navigation caches (`_BaseMeshVariable._get_kdtree`, `Mesh._get_domain_kdtree`) gated on `_mesh_version`. The `mesh.X.coords` callback bumps it; direct `_deform_mesh()` did not — so navigation kdtrees stayed frozen on the undeformed mesh. PR #188 added `_topology_version` invalidation here but missed `_mesh_version`.
- **Runner coord-identity nav caches not cleared.** A runner's `restore_points_to_domain` caches a kdtree keyed on `id(mesh.X.coords)`. `_deform_mesh` replaces `self._coords`, but CPython reuses freed ids → a fresh array can collide with the old id() and the staleness check false-negatives. Explicitly clearing `_restore_kdt` / `_restore_coords_id` defeats the id()-reuse hazard.

Brings `_deform_mesh` into line with the cache hygiene `mesh.adapt()` and `_legacy_access` already perform.

## Test plan

- [x] `_mesh_version` increments on a direct `_deform_mesh()` call (was frozen at 0 before the fix)
- [ ] Existing mesh/smoother test suites pass
- [ ] Parallel smoke (np=2) of a deforming-mesh case

Note: this is an independent correctness fix. It does **not** by itself resolve the separate free-surface convection feedback regression under investigation (verified — both fixes present in a clean build still reproduce the damped regime).

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)