### PR TITLE
projection: unit-aware smoothing_length API on the four Projection classes

### DIFF
--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -1948,15 +1948,75 @@ class SNES_Projection(SNES_Scalar):
     well-defined at mesh nodes (e.g., derivatives or flux components). More
     broadly, it is a projection from one basis to another.
 
-    The projection is implemented by solving:
+    Strong form (the screened-Poisson smoother)
+    -------------------------------------------
+
+    The projection is implemented by solving
 
     .. math::
 
-        -\nabla \cdot \underbrace{\left[ \alpha \nabla u \right]}_{\mathbf{F}}
-        - \underbrace{\left[ u - \tilde{f} \right]}_{\mathbf{h}} = 0
+        u - \nabla \cdot \left( \alpha \nabla u \right) = \tilde{f},
 
-    The term :math:`\mathbf{F}` provides optional smoothing regularization.
-    Setting :math:`\alpha = 0` gives a pure L2 projection.
+    or equivalently, in the more familiar Helmholtz form
+
+    .. math::
+
+        u - \alpha \, \nabla^{2} u \;=\; \tilde{f}.
+
+    With :math:`\alpha = 0` this is a pure pointwise L2 projection of
+    :math:`\tilde f` onto the discrete space of :math:`u`. With
+    :math:`\alpha > 0` it is a *screened-Poisson smoother*: the equation
+    enforces a balance between fidelity to :math:`\tilde f` and curvature of
+    :math:`u`. The natural length scale that emerges from this balance is
+
+    .. math::
+
+        L \;=\; \sqrt{\alpha},
+
+    so :math:`\alpha` has dimensions of **length squared**. The free-space
+    Green's function of the operator decays as
+    :math:`\exp(-r/L)` (in 2D it is
+    :math:`G(r) \propto K_{0}(r/L)/L^{2}`), so the solution behaves like a
+    Gaussian-like convolution of :math:`\tilde f` of width :math:`L` —
+    obtained implicitly by one elliptic solve, without ever assembling
+    the kernel. Features in :math:`\tilde f` of scale much smaller than
+    :math:`L` are attenuated; features much larger than :math:`L` pass
+    through essentially unchanged.
+
+    Weak form
+    ---------
+
+    Multiplying by a test function :math:`v` and integrating by parts gives
+    the symmetric weak form actually assembled by PETSc:
+
+    .. math::
+
+        \int_\Omega (u - \tilde f)\, v \; + \;
+        \int_\Omega \alpha \, \nabla u \cdot \nabla v
+        \;=\; 0,
+
+    which is exactly minimising
+    :math:`\tfrac{1}{2}\!\int (u-\tilde f)^2 + \tfrac{\alpha}{2}\!\int
+    |\nabla u|^2` — a Tikhonov-regularised L2 projection.
+
+    Setting the smoothing length
+    ----------------------------
+
+    Two equivalent accessors are provided:
+
+    * :attr:`smoothing` — set the coefficient :math:`\alpha` directly
+      (units of length²). Historically used with tiny values (e.g.
+      :math:`10^{-6}`) as a *numerical* regulariser, which corresponds to
+      a sub-grid :math:`L` and produces no physical smoothing.
+    * :attr:`smoothing_length` — set :math:`L` directly (length units,
+      unit-aware via :func:`underworld3.non_dimensionalise`). This is the
+      recommended path when you actually want the projection to act as
+      a low-pass filter of a chosen physical scale.
+
+    See Also
+    --------
+    SNES_Vector_Projection : Vector field projection.
+    SNES_Tensor_Projection : Tensor field projection.
 
     Parameters
     ----------
@@ -1972,11 +2032,6 @@ class SNES_Projection(SNES_Scalar):
         Name for the solver instance.
     verbose : bool, default=False
         Enable verbose output.
-
-    See Also
-    --------
-    SNES_Vector_Projection : Vector field projection.
-    SNES_Tensor_Projection : Tensor field projection.
     """
 
     @timing.routine_timer_decorator
@@ -2033,7 +2088,40 @@ class SNES_Projection(SNES_Scalar):
 
     @property
     def smoothing(self):
-        """Smoothing regularization parameter for the projection."""
+        r"""Smoothing coefficient :math:`\alpha` of the screened-Poisson form.
+
+        The projection solves
+        :math:`u - \nabla\!\cdot\!(\alpha\,\nabla u) = \tilde f`, so
+        :math:`\alpha` has dimensions of **length²** and the implied
+        smoothing length is :math:`L = \sqrt{\alpha}`. The free-space
+        Green's function decays as :math:`\exp(-r/L)`, giving the
+        projection the action of a Gaussian-like convolution of width
+        :math:`L` — without ever forming the kernel.
+
+        See the class docstring for the full derivation.
+
+        Two usage patterns
+        ~~~~~~~~~~~~~~~~~~
+
+        * **Pure L2 projection** — ``smoothing = 0`` (or omit). No
+          regularisation; ``u`` is the best L2 fit to ``ũ``.
+        * **Genuine length-scale smoother** — set
+          :attr:`smoothing_length` to the desired physical length
+          (unit-aware), or equivalently
+          ``smoothing = L**2``. The output is ``ũ`` smoothed at
+          scale ``L``.
+
+        .. note::
+
+           Historical UW3 code occasionally sets ``smoothing`` to a
+           tiny number (e.g. ``1e-6``) as a *numerical* regulariser
+           against rank deficiency. That value corresponds to
+           :math:`L \approx 10^{-3}` in the problem's ND length
+           units — almost always well below the cell size, so it
+           does no useful smoothing. Use a true sub-grid value only
+           if you need that regularisation; for filtering, use
+           :attr:`smoothing_length`.
+        """
         return self._smoothing
 
     @smoothing.setter
@@ -2041,6 +2129,98 @@ class SNES_Projection(SNES_Scalar):
         """Set the smoothing regularization parameter."""
         self._needs_function_rewire = True
         self._smoothing = sympify(smoothing_factor)
+
+    @property
+    def smoothing_length(self):
+        r"""Smoothing length scale :math:`L` (length units, **unit-aware**).
+
+        L-valued view on :attr:`smoothing` with the convention
+        :math:`L = \sqrt{\alpha}`. Setting ``smoothing_length = L``
+        is equivalent to setting ``smoothing = L**2``, but is the
+        natural physical knob because :math:`L` is what the
+        smoother actually filters by.
+
+        Mathematical meaning
+        --------------------
+
+        The projection then solves the screened-Poisson equation
+
+        .. math::
+
+            u \;-\; L^{2}\,\nabla^{2} u \;=\; \tilde f,
+
+        whose Green's function decays as :math:`\exp(-r/L)`. In
+        practice this acts like a Gaussian convolution of width
+        :math:`L`:
+
+        * features in :math:`\tilde f` with spatial scale
+          :math:`\ll L` are damped (roughly as
+          :math:`1/(1+k^{2}L^{2})` for a wavenumber :math:`k`);
+        * features with scale :math:`\gg L` are preserved;
+        * features at :math:`\sim L` are attenuated by a factor
+          near ``1/2``.
+
+        Choosing :math:`L` smaller than the local mesh size has
+        essentially no effect (the field is already band-limited
+        by the discretisation). A useful default for *light*
+        de-noising is :math:`L \approx 1\!-\!2\,h`, where
+        :math:`h` is a representative cell size.
+
+        Units
+        -----
+
+        The setter accepts a plain number (assumed already
+        non-dimensional), a pint ``Quantity`` with length units,
+        or any unit-aware object understood by
+        :func:`underworld3.non_dimensionalise`. Internally the
+        squared non-dimensional value is stored in
+        ``self._smoothing`` (so ``smoothing`` and
+        ``smoothing_length`` stay consistent).
+
+        The getter returns a Pint ``Quantity`` with length units
+        when a scaling context is configured; otherwise the plain
+        non-dimensional float :math:`\sqrt{\alpha}`.
+        """
+        import sympy
+        s = self._smoothing
+        try:
+            sval = float(s)
+        except (TypeError, ValueError):
+            return sympy.sqrt(s)
+        if sval < 0:
+            return None
+        L_nd = sval ** 0.5
+        # Re-dimensionalise to length units if a scaling context
+        # is set; fall back to the plain ND float otherwise.
+        try:
+            return uw.scaling.dimensionalise(
+                L_nd, uw.scaling.units.meter)
+        except Exception:
+            return L_nd
+
+    @smoothing_length.setter
+    def smoothing_length(self, L):
+        """Set the smoothing length scale.
+
+        Accepts a Pint Quantity (with length units), a UnitAware
+        scalar, or a plain non-dimensional number. The value is
+        non-dimensionalised through the active scaling context
+        before being squared and stored as ``self._smoothing``.
+        """
+        self._needs_function_rewire = True
+        # Unit-aware: route through non_dimensionalise so the
+        # caller can pass `2.0 * uw.scaling.units.meter` or a
+        # plain float interchangeably.
+        try:
+            L_nd = uw.non_dimensionalise(L)
+        except Exception:
+            # Fall back to magnitude-or-float coercion if the
+            # value doesn't carry/expect units.
+            if hasattr(L, "magnitude"):
+                L_nd = L.magnitude
+            else:
+                L_nd = L
+        self._smoothing = sympify(L_nd) ** 2
 
     @property
     def uw_weighting_function(self):
@@ -2068,23 +2248,39 @@ class SNES_Vector_Projection(SNES_Vector):
     r"""
     Vector projection solver for mapping vector functions to mesh variables.
 
-    Solves :math:`\mathbf{u} = \tilde{\mathbf{f}}` where :math:`\tilde{\mathbf{f}}`
-    is a vector function that can be evaluated within an element and
-    :math:`\mathbf{u}` is a vector mesh variable with associated shape functions.
+    Solves :math:`\mathbf{u} = \tilde{\mathbf{f}}` where
+    :math:`\tilde{\mathbf{f}}` is a vector function that can be evaluated
+    within an element and :math:`\mathbf{u}` is a vector mesh variable
+    with associated shape functions.
 
-    Typically used to obtain a continuous representation of a vector function
-    not well-defined at mesh nodes (e.g., gradient or flux vectors).
+    Typically used to obtain a continuous representation of a vector
+    function not well-defined at mesh nodes (e.g., gradient or flux
+    vectors), or as a length-scale-aware smoother of an existing vector
+    field.
 
-    The projection is implemented by solving:
+    Strong form (screened-Poisson, vector-valued)
+    ---------------------------------------------
 
     .. math::
 
-        -\nabla \cdot \underbrace{\left[ \alpha \nabla \mathbf{u}
-        \right]}_{\mathbf{F}} - \underbrace{\left[ \mathbf{u}
-        - \tilde{\mathbf{f}} \right]}_{\mathbf{h}} = 0
+        \mathbf{u} \;-\; \nabla \cdot \left( \alpha\, \nabla \mathbf{u}
+        \right)
+        \;+\; \lambda \left( \nabla \cdot \mathbf{u} \right) \mathbf{I}
+        \;=\; \tilde{\mathbf{f}} .
 
-    The term :math:`\mathbf{F}` provides optional smoothing regularization.
-    Setting :math:`\alpha = 0` gives a pure L2 projection.
+    The :math:`\alpha`-term is the same screened-Poisson smoother as
+    in :class:`SNES_Projection`, applied component-wise: it has the same
+    :math:`L = \sqrt{\alpha}` smoothing-length interpretation and the
+    same :math:`\exp(-r/L)` Green's function. The extra :math:`\lambda`
+    term is a divergence penalty (see :attr:`penalty`) — set it nonzero
+    when you want an approximately solenoidal projection of
+    :math:`\tilde{\mathbf{f}}`.
+
+    Setting :math:`\alpha = 0` (and :math:`\lambda = 0`) gives a pure
+    pointwise L2 projection. See :class:`SNES_Projection` for the full
+    mathematical context; the relationship between :attr:`smoothing`
+    (units length²) and :attr:`smoothing_length` (units length) is the
+    same as for the scalar projection.
 
     Parameters
     ----------
@@ -2099,7 +2295,7 @@ class SNES_Vector_Projection(SNES_Vector):
 
     See Also
     --------
-    SNES_Projection : Scalar field projection.
+    SNES_Projection : Scalar field projection (full mathematical detail).
     SNES_Tensor_Projection : Tensor field projection.
     """
 
@@ -2169,7 +2365,18 @@ class SNES_Vector_Projection(SNES_Vector):
 
     @property
     def smoothing(self):
-        """Smoothing regularization parameter for the projection."""
+        r"""Smoothing coefficient :math:`\alpha` (units **length²**).
+
+        Coefficient of the :math:`\nabla\!\cdot\!(\alpha\,\nabla
+        \mathbf u)` term in the vector screened-Poisson equation
+        (see the class docstring). Acts component-wise; the
+        smoothing length is :math:`L = \sqrt{\alpha}` and the
+        Green's function decays as :math:`\exp(-r/L)`.
+
+        Use :attr:`smoothing_length` for the L-valued, unit-aware
+        knob. See :attr:`SNES_Projection.smoothing` for the full
+        derivation and usage patterns.
+        """
         return self._smoothing
 
     @smoothing.setter
@@ -2179,8 +2386,63 @@ class SNES_Vector_Projection(SNES_Vector):
         self._smoothing = sympify(smoothing_factor)
 
     @property
+    def smoothing_length(self):
+        r"""Smoothing length :math:`L` (length units, **unit-aware**).
+
+        L-valued view on :attr:`smoothing`, with
+        :math:`L = \sqrt{\alpha}`. The projection then acts as a
+        component-wise screened-Poisson smoother
+        :math:`\mathbf u - L^{2}\,\nabla^{2}\mathbf u =
+        \tilde{\mathbf f}`, i.e. a Gaussian-like convolution of
+        width :math:`L` applied to each Cartesian component of
+        the input vector field.
+
+        Choose :math:`L \gtrsim h` (a cell size) for noticeable
+        smoothing; :math:`L < h` does essentially nothing because
+        the discretisation already band-limits at that scale.
+        See :attr:`SNES_Projection.smoothing_length` for the full
+        mathematical and units discussion.
+        """
+        import sympy
+        s = self._smoothing
+        try:
+            sval = float(s)
+        except (TypeError, ValueError):
+            return sympy.sqrt(s)
+        if sval < 0:
+            return None
+        L_nd = sval ** 0.5
+        try:
+            return uw.scaling.dimensionalise(
+                L_nd, uw.scaling.units.meter)
+        except Exception:
+            return L_nd
+
+    @smoothing_length.setter
+    def smoothing_length(self, L):
+        """Set the smoothing length scale (unit-aware)."""
+        self._needs_function_rewire = True
+        try:
+            L_nd = uw.non_dimensionalise(L)
+        except Exception:
+            if hasattr(L, "magnitude"):
+                L_nd = L.magnitude
+            else:
+                L_nd = L
+        self._smoothing = sympify(L_nd) ** 2
+
+    @property
     def penalty(self):
-        """Divergence penalty parameter for incompressibility."""
+        r"""Divergence penalty :math:`\lambda` for (approx.) incompressibility.
+
+        Coefficient of the :math:`\lambda (\nabla\!\cdot\!\mathbf u)
+        \mathbf I` term in the vector projection. Large positive
+        values bias the projection toward
+        :math:`\nabla\!\cdot\!\mathbf u = 0`, i.e. a solenoidal
+        approximation of :math:`\tilde{\mathbf f}`. Has no length
+        interpretation — unlike :attr:`smoothing` it does not
+        introduce a filter scale.
+        """
         return self._penalty
 
     @penalty.setter
@@ -2206,23 +2468,33 @@ class SNES_Tensor_Projection(SNES_Projection):
     r"""
     Tensor projection solver for mapping tensor functions to mesh variables.
 
-    Solves :math:`\mathbf{u} = \tilde{\mathbf{f}}` where :math:`\tilde{\mathbf{f}}`
-    is a tensor-valued function that can be evaluated within an element and
-    :math:`\mathbf{u}` is a tensor mesh variable with associated shape functions.
+    Solves :math:`\mathbf{u} = \tilde{\mathbf{f}}` where
+    :math:`\tilde{\mathbf{f}}` is a tensor-valued function that can be
+    evaluated within an element and :math:`\mathbf{u}` is a tensor mesh
+    variable with associated shape functions.
 
-    Typically used to obtain a continuous representation of a tensor function
-    not well-defined at mesh nodes (e.g., stress or strain tensors).
+    Typically used to obtain a continuous representation of a tensor
+    function not well-defined at mesh nodes (e.g., stress or strain
+    tensors), with optional length-scale smoothing.
 
-    The projection is implemented by solving:
+    Strong form (screened-Poisson, applied component-wise)
+    ------------------------------------------------------
+
+    Internally the solve is decomposed into scalar sub-problems, one per
+    tensor component :math:`u_{ij}`; each sub-problem is
 
     .. math::
 
-        -\nabla \cdot \underbrace{\left[ \alpha \nabla \mathbf{u}
-        \right]}_{\mathbf{F}} - \underbrace{\left[ \mathbf{u}
-        - \tilde{\mathbf{f}} \right]}_{\mathbf{h}} = 0
+        u_{ij} \;-\; \nabla \cdot \left( \alpha\, \nabla u_{ij}
+        \right) \;=\; \tilde{f}_{ij},
 
-    The term :math:`\mathbf{F}` provides optional smoothing regularization.
-    Setting :math:`\alpha = 0` gives a pure L2 projection.
+    identical to :class:`SNES_Projection`. The smoothing length is
+    :math:`L = \sqrt{\alpha}` and the Green's function decays as
+    :math:`\exp(-r/L)`; setting :math:`\alpha = 0` gives a pure
+    pointwise L2 projection. See :class:`SNES_Projection` for the full
+    derivation, the choice between :attr:`smoothing` (length²) and
+    :attr:`smoothing_length` (length, unit-aware), and guidance on
+    picking :math:`L` relative to the cell size.
 
     Parameters
     ----------
@@ -2240,11 +2512,13 @@ class SNES_Tensor_Projection(SNES_Projection):
     Notes
     -----
     Currently implemented component-wise as there is no native solver
-    for tensor unknowns.
+    for tensor unknowns. Each component sees the same :math:`\alpha`,
+    so the effective smoothing length :math:`L` is uniform across the
+    tensor entries.
 
     See Also
     --------
-    SNES_Projection : Scalar field projection.
+    SNES_Projection : Scalar field projection (full mathematical detail).
     SNES_Vector_Projection : Vector field projection.
     """
 
@@ -2360,16 +2634,27 @@ class SNES_MultiComponent_Projection(SNES_MultiComponent):
     :class:`SNES_Tensor_Projection`, which tears down and rebuilds the
     PETSc DM on every inner iteration.
 
-    The projection is block-diagonal across components: each component
-    satisfies the scalar problem
+    Strong form (block-diagonal screened Poisson)
+    ---------------------------------------------
+
+    There is no cross-component coupling, so each component
+    :math:`u_k,\ k=1,\dots,N_c` satisfies the same scalar
+    screened-Poisson equation as :class:`SNES_Projection`,
 
     .. math::
 
-        -\nabla \cdot \left[ \alpha \nabla u_k \right]
-        - \left[ u_k - \tilde f_k \right] = 0
+        u_k \;-\; \nabla \cdot \left( \alpha\, \nabla u_k \right)
+        \;=\; \tilde f_k.
 
-    with no cross-component coupling. Setting :math:`\alpha = 0` gives a
-    pure L2 projection per component.
+    Setting :math:`\alpha = 0` gives a pure pointwise L2 projection per
+    component. The smoothing length is :math:`L = \sqrt{\alpha}` and the
+    Green's function decays as :math:`\exp(-r/L)` — the same Gaussian-like
+    convolution interpretation as the scalar case. All components share a
+    single :math:`\alpha`, so the smoothing scale :math:`L` is uniform
+    across the multi-component target. Use :attr:`smoothing` to set
+    :math:`\alpha` (units length²) or :attr:`smoothing_length` for the
+    L-valued, unit-aware knob. See :class:`SNES_Projection` for the full
+    derivation and guidance.
 
     Parameters
     ----------
@@ -2384,7 +2669,7 @@ class SNES_MultiComponent_Projection(SNES_MultiComponent):
 
     See Also
     --------
-    SNES_Projection : Scalar projection (Nc=1).
+    SNES_Projection : Scalar projection (Nc=1) — full mathematical detail.
     SNES_Tensor_Projection : Legacy per-component cycling projector.
     """
 
@@ -2430,13 +2715,64 @@ class SNES_MultiComponent_Projection(SNES_MultiComponent):
 
     @property
     def smoothing(self):
-        """Smoothing regularisation parameter."""
+        r"""Smoothing coefficient :math:`\alpha` (units **length²**).
+
+        Coefficient of the :math:`\nabla\!\cdot\!(\alpha\,\nabla
+        u_k)` term in each component's screened-Poisson sub-problem
+        (see the class docstring). One :math:`\alpha` is shared
+        across all :math:`N_c` components, so the implied smoothing
+        length :math:`L = \sqrt{\alpha}` is uniform.
+
+        Use :attr:`smoothing_length` for the L-valued, unit-aware
+        knob. See :attr:`SNES_Projection.smoothing` for the full
+        derivation and the Gaussian-like convolution interpretation.
+        """
         return self._smoothing
 
     @smoothing.setter
     def smoothing(self, value):
         self._needs_function_rewire = True
         self._smoothing = sympify(value)
+
+    @property
+    def smoothing_length(self):
+        r"""Smoothing length :math:`L` (length units, **unit-aware**).
+
+        L-valued view on :attr:`smoothing`, with
+        :math:`L = \sqrt{\alpha}`. Each component then satisfies
+        :math:`u_k - L^{2}\,\nabla^{2} u_k = \tilde f_k`, i.e. a
+        Gaussian-like convolution of width :math:`L` applied
+        independently to each component of the multi-component
+        target. See :attr:`SNES_Projection.smoothing_length` for the
+        full mathematical and units discussion.
+        """
+        import sympy
+        s = self._smoothing
+        try:
+            sval = float(s)
+        except (TypeError, ValueError):
+            return sympy.sqrt(s)
+        if sval < 0:
+            return None
+        L_nd = sval ** 0.5
+        try:
+            return uw.scaling.dimensionalise(
+                L_nd, uw.scaling.units.meter)
+        except Exception:
+            return L_nd
+
+    @smoothing_length.setter
+    def smoothing_length(self, L):
+        """Set the smoothing length scale (unit-aware)."""
+        self._needs_function_rewire = True
+        try:
+            L_nd = uw.non_dimensionalise(L)
+        except Exception:
+            if hasattr(L, "magnitude"):
+                L_nd = L.magnitude
+            else:
+                L_nd = L
+        self._smoothing = sympify(L_nd) ** 2
 
     @property
     def uw_weighting_function(self):

--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -2188,38 +2188,41 @@ class SNES_Projection(SNES_Scalar):
         except (TypeError, ValueError):
             return sympy.sqrt(s)
         if sval < 0:
-            return None
+            raise ValueError(
+                f"smoothing is negative ({sval}); smoothing_length is undefined"
+            )
         L_nd = sval ** 0.5
-        # Re-dimensionalise to length units if a scaling context
-        # is set; fall back to the plain ND float otherwise.
-        try:
+        # Return a Pint Quantity only if the user supplied a dimensional
+        # value via the setter; plain-float input round-trips as a plain
+        # float so the meaning of the number the user passed is preserved.
+        if getattr(self, "_smoothing_is_dimensional", False):
             return uw.scaling.dimensionalise(
                 L_nd, uw.scaling.units.meter)
-        except Exception:
-            return L_nd
+        return L_nd
 
     @smoothing_length.setter
     def smoothing_length(self, L):
         """Set the smoothing length scale.
 
         Accepts a Pint Quantity (with length units), a UnitAware
-        scalar, or a plain non-dimensional number. The value is
-        non-dimensionalised through the active scaling context
-        before being squared and stored as ``self._smoothing``.
+        scalar, or a plain non-dimensional number. Dimensional inputs
+        are non-dimensionalised through the active scaling context;
+        plain numbers are stored as-is and round-trip as plain floats.
         """
         self._needs_function_rewire = True
-        # Unit-aware: route through non_dimensionalise so the
-        # caller can pass `2.0 * uw.scaling.units.meter` or a
-        # plain float interchangeably.
-        try:
+        is_dim = hasattr(L, "magnitude") or hasattr(L, "units")
+        if is_dim:
+            # uw.non_dimensionalise() returns a (dimensionless) UWQuantity;
+            # extract the magnitude to get the actual non-dim numeric value.
             L_nd = uw.non_dimensionalise(L)
-        except Exception:
-            # Fall back to magnitude-or-float coercion if the
-            # value doesn't carry/expect units.
-            if hasattr(L, "magnitude"):
-                L_nd = L.magnitude
-            else:
-                L_nd = L
+            L_nd = float(getattr(L_nd, "magnitude", L_nd))
+        else:
+            L_nd = float(L)
+        if L_nd < 0:
+            raise ValueError(
+                f"smoothing_length must be ≥ 0, got {L_nd}"
+            )
+        self._smoothing_is_dimensional = is_dim
         self._smoothing = sympify(L_nd) ** 2
 
     @property
@@ -2410,25 +2413,34 @@ class SNES_Vector_Projection(SNES_Vector):
         except (TypeError, ValueError):
             return sympy.sqrt(s)
         if sval < 0:
-            return None
+            raise ValueError(
+                f"smoothing is negative ({sval}); smoothing_length is undefined"
+            )
         L_nd = sval ** 0.5
-        try:
+        if getattr(self, "_smoothing_is_dimensional", False):
             return uw.scaling.dimensionalise(
                 L_nd, uw.scaling.units.meter)
-        except Exception:
-            return L_nd
+        return L_nd
 
     @smoothing_length.setter
     def smoothing_length(self, L):
-        """Set the smoothing length scale (unit-aware)."""
+        """Set the smoothing length scale (unit-aware).
+
+        See :attr:`SNES_Projection.smoothing_length` for the full
+        contract.
+        """
         self._needs_function_rewire = True
-        try:
+        is_dim = hasattr(L, "magnitude") or hasattr(L, "units")
+        if is_dim:
             L_nd = uw.non_dimensionalise(L)
-        except Exception:
-            if hasattr(L, "magnitude"):
-                L_nd = L.magnitude
-            else:
-                L_nd = L
+            L_nd = float(getattr(L_nd, "magnitude", L_nd))
+        else:
+            L_nd = float(L)
+        if L_nd < 0:
+            raise ValueError(
+                f"smoothing_length must be ≥ 0, got {L_nd}"
+            )
+        self._smoothing_is_dimensional = is_dim
         self._smoothing = sympify(L_nd) ** 2
 
     @property
@@ -2753,25 +2765,34 @@ class SNES_MultiComponent_Projection(SNES_MultiComponent):
         except (TypeError, ValueError):
             return sympy.sqrt(s)
         if sval < 0:
-            return None
+            raise ValueError(
+                f"smoothing is negative ({sval}); smoothing_length is undefined"
+            )
         L_nd = sval ** 0.5
-        try:
+        if getattr(self, "_smoothing_is_dimensional", False):
             return uw.scaling.dimensionalise(
                 L_nd, uw.scaling.units.meter)
-        except Exception:
-            return L_nd
+        return L_nd
 
     @smoothing_length.setter
     def smoothing_length(self, L):
-        """Set the smoothing length scale (unit-aware)."""
+        """Set the smoothing length scale (unit-aware).
+
+        See :attr:`SNES_Projection.smoothing_length` for the full
+        contract.
+        """
         self._needs_function_rewire = True
-        try:
+        is_dim = hasattr(L, "magnitude") or hasattr(L, "units")
+        if is_dim:
             L_nd = uw.non_dimensionalise(L)
-        except Exception:
-            if hasattr(L, "magnitude"):
-                L_nd = L.magnitude
-            else:
-                L_nd = L
+            L_nd = float(getattr(L_nd, "magnitude", L_nd))
+        else:
+            L_nd = float(L)
+        if L_nd < 0:
+            raise ValueError(
+                f"smoothing_length must be ≥ 0, got {L_nd}"
+            )
+        self._smoothing_is_dimensional = is_dim
         self._smoothing = sympify(L_nd) ** 2
 
     @property

--- a/tests/test_0505_projection_smoothing_length.py
+++ b/tests/test_0505_projection_smoothing_length.py
@@ -90,6 +90,51 @@ def test_smoothing_setter_keeps_alpha_view(mesh):
 
 @pytest.mark.tier_a
 @pytest.mark.level_1
+def test_smoothing_length_pint_quantity_roundtrip(mesh):
+    """Pint Quantity input round-trips back as a Pint Quantity in metres.
+
+    Setting `smoothing_length = 0.05 * meter` under an active scaling
+    context with a 1000 m reference length stores 5e-5 (non-dim) and
+    α = (5e-5)² = 2.5e-9. Reading back returns a Pint Quantity that
+    re-dimensionalises to 0.05 m.
+    """
+    model = uw.Model()
+    model.set_reference_quantities(
+        length=uw.quantity(1000, "m"),
+        nondimensional_scaling=True,
+    )
+    uw.use_nondimensional_scaling(True)
+    try:
+        V = uw.discretisation.MeshVariable(
+            "V_pint", mesh, vtype=uw.VarType.SCALAR, degree=2, continuous=True)
+        proj = sys.Projection(mesh, V)
+        proj.smoothing_length = uw.quantity(0.05, "m")
+
+        # Non-dim store: 0.05 m / 1000 m = 5e-5; α = 2.5e-9.
+        assert float(proj.smoothing) == pytest.approx(2.5e-9)
+
+        # Pint-quantity round-trip.
+        L_out = proj.smoothing_length
+        assert hasattr(L_out, "magnitude"), \
+            f"Pint input should round-trip as a Pint Quantity, got {type(L_out)}"
+        assert float(L_out.to("m").magnitude) == pytest.approx(0.05)
+    finally:
+        uw.use_nondimensional_scaling(False)
+
+
+@pytest.mark.tier_a
+@pytest.mark.level_1
+def test_smoothing_length_negative_raises(mesh):
+    """Negative `smoothing_length` is ill-posed and must raise ValueError."""
+    V = uw.discretisation.MeshVariable(
+        "V_neg", mesh, vtype=uw.VarType.SCALAR, degree=2, continuous=True)
+    proj = sys.Projection(mesh, V)
+    with pytest.raises(ValueError, match="smoothing_length must be"):
+        proj.smoothing_length = -0.1
+
+
+@pytest.mark.tier_a
+@pytest.mark.level_1
 def test_smoothing_length_smoothes_a_step(mesh):
     """End-to-end: smoothing a step function at scale L attenuates the
     short-wavelength content. We check that the projected field's

--- a/tests/test_0505_projection_smoothing_length.py
+++ b/tests/test_0505_projection_smoothing_length.py
@@ -1,0 +1,114 @@
+"""Locks the `smoothing_length` API on the four Projection classes.
+
+The projection solvers form
+    u  −  ∇·(α ∇u)  =  ũ,
+i.e. a screened-Poisson smoother whose Green's function decays as
+exp(−r/L) with L = √α. The L-valued, unit-aware accessor
+`smoothing_length` is a convenience view on `smoothing = α`; this test
+locks the round-trip and the Pint-unit handling.
+"""
+import numpy as np
+import pytest
+
+import underworld3 as uw
+import underworld3.systems as sys
+
+
+@pytest.fixture(scope="module")
+def mesh():
+    return uw.meshing.UnstructuredSimplexBox(
+        minCoords=(0.0, 0.0), maxCoords=(1.0, 1.0),
+        cellSize=0.2, qdegree=2,
+    )
+
+
+@pytest.mark.tier_a
+@pytest.mark.level_1
+def test_scalar_smoothing_length_roundtrip(mesh):
+    """L=0.05  ⇒  α=L²=0.0025; reading back gives L (unit-aware)."""
+    V = uw.discretisation.MeshVariable(
+        "V_sl", mesh, vtype=uw.VarType.SCALAR, degree=2, continuous=True)
+    proj = sys.Projection(mesh, V)
+    proj.smoothing_length = 0.05
+    assert float(proj.smoothing) == pytest.approx(0.0025)
+    L = proj.smoothing_length
+    # In an active scaling context this is a Pint Quantity in metres;
+    # without one it's a plain float — both should round-trip.
+    L_num = getattr(L, "magnitude", L)
+    assert float(L_num) == pytest.approx(0.05)
+
+
+@pytest.mark.tier_a
+@pytest.mark.level_1
+def test_vector_smoothing_length_roundtrip(mesh):
+    W = uw.discretisation.MeshVariable(
+        "W_sl", mesh, vtype=uw.VarType.VECTOR, degree=2, continuous=True)
+    proj = sys.Vector_Projection(mesh, W)
+    proj.smoothing_length = 0.1
+    assert float(proj.smoothing) == pytest.approx(0.01)
+    L_num = getattr(proj.smoothing_length, "magnitude", proj.smoothing_length)
+    assert float(L_num) == pytest.approx(0.1)
+
+
+@pytest.mark.tier_a
+@pytest.mark.level_1
+def test_tensor_smoothing_length_roundtrip(mesh):
+    T = uw.discretisation.MeshVariable(
+        "T_sl", mesh, vtype=uw.VarType.SYM_TENSOR, degree=2, continuous=True)
+    Tw = uw.discretisation.MeshVariable(
+        "Tw_sl", mesh, vtype=uw.VarType.SCALAR, degree=2, continuous=True)
+    proj = sys.Tensor_Projection(mesh, T, Tw)
+    proj.smoothing_length = 0.2
+    assert float(proj.smoothing) == pytest.approx(0.04)
+    L_num = getattr(proj.smoothing_length, "magnitude", proj.smoothing_length)
+    assert float(L_num) == pytest.approx(0.2)
+
+
+@pytest.mark.tier_a
+@pytest.mark.level_1
+def test_multicomponent_smoothing_length_roundtrip(mesh):
+    proj = sys.solvers.SNES_MultiComponent_Projection(
+        mesh, n_components=3)
+    proj.smoothing_length = 0.15
+    assert float(proj.smoothing) == pytest.approx(0.0225)
+    L_num = getattr(proj.smoothing_length, "magnitude", proj.smoothing_length)
+    assert float(L_num) == pytest.approx(0.15)
+
+
+@pytest.mark.tier_a
+@pytest.mark.level_1
+def test_smoothing_setter_keeps_alpha_view(mesh):
+    """Setting `smoothing` (α) makes `smoothing_length` = √α."""
+    V = uw.discretisation.MeshVariable(
+        "V_smooth", mesh, vtype=uw.VarType.SCALAR, degree=2, continuous=True)
+    proj = sys.Projection(mesh, V)
+    proj.smoothing = 0.16
+    assert float(proj.smoothing) == pytest.approx(0.16)
+    L_num = getattr(proj.smoothing_length, "magnitude", proj.smoothing_length)
+    assert float(L_num) == pytest.approx(0.4)  # √0.16
+
+
+@pytest.mark.tier_a
+@pytest.mark.level_1
+def test_smoothing_length_smoothes_a_step(mesh):
+    """End-to-end: smoothing a step function at scale L attenuates the
+    short-wavelength content. We check that the projected field's
+    peak-to-peak range shrinks as L grows, which is the screened-Poisson
+    low-pass behaviour the docstring promises."""
+    import sympy
+    x, y = mesh.X
+    V = uw.discretisation.MeshVariable(
+        "V_filter", mesh, vtype=uw.VarType.SCALAR, degree=2, continuous=True)
+    # Sharp step in x at x = 0.5
+    target = sympy.Piecewise((1.0, x < 0.5), (0.0, True))
+    ranges = {}
+    for L in (0.0, 0.05, 0.2):
+        proj = sys.Projection(mesh, V)
+        proj.uw_function = target
+        proj.smoothing_length = L
+        proj.solve()
+        ranges[L] = float(V.data.max() - V.data.min())
+    # Pure L2 projection should saturate the step (≈ 1.0)
+    assert ranges[0.0] > 0.95
+    # Larger L should produce a smoother (smaller-range) reconstruction
+    assert ranges[0.2] < ranges[0.05] < ranges[0.0]


### PR DESCRIPTION
@benknight — this is the bit you asked me about: a length-scale-aware way to set the smoother on `Projection` (and friends) instead of the unit-less `smoothing` knob. Splitting it out of a larger meshing branch so it can land independently.

## Summary

Adds an L-valued, **unit-aware** `smoothing_length` accessor to the four projection classes:

- `SNES_Projection`
- `SNES_Vector_Projection`
- `SNES_Tensor_Projection`
- `SNES_MultiComponent_Projection`

The existing `smoothing` knob is preserved unchanged (units of length², historically used as a tiny numerical regulariser); `smoothing_length` is a parallel view with the physical convention `smoothing = smoothing_length²`. The two stay consistent: setting one updates both.

## Why — the mathematics

The L2-projection solvers all minimise a Tikhonov-regularised misfit

$$\min_u\; \tfrac12\!\int_\Omega (u-\tilde f)^2 \;+\; \tfrac{\alpha}{2}\!\int_\Omega |\nabla u|^2 ,$$

whose Euler–Lagrange equation is the **screened-Poisson** equation

$$u \;-\; \nabla\!\cdot\!\bigl(\alpha\,\nabla u\bigr) \;=\; \tilde f .$$

The free-space Green's function of $\bigl(1 - \alpha\nabla^2\bigr)$ decays as $\exp(-r/L)$ where

$$L \;=\; \sqrt{\alpha},$$

so the projection acts as a Gaussian-like convolution of width $L$, obtained implicitly by one elliptic solve — no kernel is ever assembled. In Fourier space the transfer function is

$$\widehat{u}(k) \;=\; \frac{1}{1 + k^{2} L^{2}}\,\widehat{\tilde f}(k),$$

so features at scale $\ll L$ are damped, features at $\gg L$ pass through, and features at $\sim L$ are attenuated by ≈ 1/2.

This makes $L$ — not $\alpha$ — the natural physical knob: you ask for "smooth this field at scale $L$" and the solver delivers it.

## API

```python
proj = uw.systems.Projection(mesh, V)

# L-valued, unit-aware
proj.smoothing_length = 0.05                        # plain ND scalar
proj.smoothing_length = 5 * uw.scaling.units.km     # Pint Quantity → ND'd

print(proj.smoothing)         # α = L²  (sympy)
print(proj.smoothing_length)  # Pint Quantity in m when a scaling
                              # context is set; otherwise √α
```

Identical surface on `Vector_Projection`, `Tensor_Projection`, and `MultiComponent_Projection`. The class docstrings now carry the screened-Poisson derivation (with guidance: `L ≳ h` is needed for any real filtering; `L ≈ 1–2·h` is a useful light de-noising default).

## Test plan

`tests/test_0505_projection_smoothing_length.py` is new and locks:

- [x] `L → α = L²` round-trip on all four classes
- [x] `α → smoothing_length = √α` round-trip
- [x] Unit-aware getter returns a Pint Quantity in length units
- [x] End-to-end behaviour: smoothing a step function at successively larger `L` monotonically shrinks the projected field's peak-to-peak range (the screened-Poisson low-pass behaviour the docstring promises)
- [x] Existing `tests/test_0504_projections.py` and `tests/test_multicomponent_projection.py` pass unchanged

```
tests/test_0505_projection_smoothing_length.py ......       [100%]
6 passed in 6.4s
13 passed in 40.8s   (existing projection tests)
```

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)