### PR TITLE
swarm: guard empty-partition reshape in _pack_array_to_data_format (parallel read_timestep crash)

### DIFF
--- a/src/underworld3/swarm.py
+++ b/src/underworld3/swarm.py
@@ -928,6 +928,14 @@ class SwarmVariable(DimensionalityMixin, MathematicalMixin, Stateful, uw_object)
         """Convert array format (N,a,b) back to canonical data format (N,components)"""
         # Use existing pack logic but return numpy array instead of writing to PETSc
         # This is a pure conversion method - no PETSc access
+        # Empty-partition guard: an N=0 array has total size 0, so numpy cannot
+        # infer the -1 component dimension ("cannot reshape array of size 0 into
+        # shape (0,newaxis)"). This bites a rank that owns no local particles
+        # during a parallel read_timestep. Compute the component count from the
+        # trailing dims explicitly.
+        if array_data.size == 0:
+            ncomp = int(np.prod(array_data.shape[1:])) if array_data.ndim > 1 else 1
+            return array_data.reshape(array_data.shape[0], ncomp)
         return array_data.reshape(array_data.shape[0], -1)
 
     # Legacy methods preserved for backward compatibility (now do nothing)


### PR DESCRIPTION
## Problem
On a rank that owns **no local particles**, `SwarmVariable._pack_array_to_data_format` does `array_data.reshape(array_data.shape[0], -1)` on a size-0 array. numpy cannot infer the `-1` component dimension from a 0-element array and raises:
```
ValueError: cannot reshape array of size 0 into shape (0,newaxis)
```
This crashes parallel `read_timestep` of a vector field (e.g. P2 velocity) at `np>=2` whenever a rank lands an empty partition — killing the run at checkpoint load.

## Fix
When the array is empty, compute the component count explicitly from the trailing dims (`prod(shape[1:])`) instead of relying on `-1` inference. Non-empty path unchanged.

## Validation
Parallel (np=4/5) `read_timestep` of velocity from a serial checkpoint now succeeds; reproduced the crash before, gone after. Used throughout the parallel adaptive-convection runs.

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)