### PR TITLE
manifest: mark constant_nullspace as a supported feature

### DIFF
--- a/docs/release-notes/feature-manifest.yaml
+++ b/docs/release-notes/feature-manifest.yaml
@@ -105,3 +105,16 @@ features:
         - tests/test_101*.py
       select: "multigrid or fmg or preconditioner"
       markers: "tier_a or tier_b"
+
+  - key: constant-nullspace
+    title: "Constant Nullspace (singular scalar solvers)"
+    owner: "@lmoresi"
+    claim: supported
+    summary: >
+      SNES_Scalar.constant_nullspace returns the minimum-norm solution for
+      pure-Neumann / closed-manifold scalar problems whose operator has a
+      constant kernel (the singular Poisson case).
+    validation:
+      paths:
+        - tests/test_1056_constant_nullspace.py
+      markers: "tier_a or tier_b"


### PR DESCRIPTION
Adds a `constant-nullspace` entry to `docs/release-notes/feature-manifest.yaml` with `claim: supported`, validated by `tests/test_1056_constant_nullspace.py` (the `tier_a` test landed in #235).

The release gate will report it **supported** (non-empty `tier_a` selection that passes), and it drops out of the `check_manifest_coverage` drift list. Declarative-only change; the underlying test was validated by #235's CI.

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)