### PR TITLE
Fix spherical shell labels and add Stokes residual diagnostics

### DIFF
--- a/src/underworld3/cython/petsc_compat.h
+++ b/src/underworld3/cython/petsc_compat.h
@@ -51,7 +51,7 @@ PetscErrorCode UW_PetscDSGetBoundaryWeakForm(PetscDS ds, PetscInt bd, PetscWeakF
     return PETSC_SUCCESS;
 }
 
-PetscErrorCode UW_DMPlexComputeResidualByKeyVolumeOnly(DM dm, PetscFormKey key, IS cellIS, PetscReal time, Vec locX, Vec locX_t, PetscReal t, Vec locF, PetscCtx ctx)
+PetscErrorCode UW_DMPlexComputeResidualByKeyVolumeOnly(DM dm, PetscFormKey key, IS cellIS, PetscReal time, Vec locX, Vec locX_t, PetscReal t, Vec locF, void *ctx)
 {
     DM vdm = NULL;
     PetscSection section = NULL;

--- a/src/underworld3/cython/petsc_compat.h
+++ b/src/underworld3/cython/petsc_compat.h
@@ -51,6 +51,33 @@ PetscErrorCode UW_PetscDSGetBoundaryWeakForm(PetscDS ds, PetscInt bd, PetscWeakF
     return PETSC_SUCCESS;
 }
 
+PetscErrorCode UW_DMPlexComputeResidualByKeyVolumeOnly(DM dm, PetscFormKey key, IS cellIS, PetscReal time, Vec locX, Vec locX_t, PetscReal t, Vec locF, PetscCtx ctx)
+{
+    DM vdm = NULL;
+    PetscSection section = NULL;
+    PetscSection global_section = NULL;
+    PetscDS ds = NULL;
+    PetscDS vds = NULL;
+    Vec aux = NULL;
+
+    PetscCall(DMClone(dm, &vdm));
+    PetscCall(DMGetLocalSection(dm, &section));
+    PetscCall(DMSetLocalSection(vdm, section));
+    PetscCall(DMGetGlobalSection(dm, &global_section));
+    PetscCall(DMSetGlobalSection(vdm, global_section));
+    PetscCall(DMCopyFields(dm, PETSC_DETERMINE, PETSC_DETERMINE, vdm));
+    PetscCall(DMCreateDS(vdm));
+    PetscCall(DMGetDS(dm, &ds));
+    PetscCall(DMGetDS(vdm, &vds));
+    PetscCall(PetscDSCopyConstants(ds, vds));
+    PetscCall(PetscDSCopyEquations(ds, vds));
+    PetscCall(DMGetAuxiliaryVec(dm, key.label, key.value, key.part, &aux));
+    if (aux) PetscCall(DMSetAuxiliaryVec(vdm, key.label, key.value, key.part, aux));
+    PetscCall(DMPlexComputeResidualByKey(vdm, key, cellIS, time, locX, locX_t, t, locF, ctx));
+    PetscCall(DMDestroy(&vdm));
+    return PETSC_SUCCESS;
+}
+
 // copy paste function signitures from $PETSC_DIR/include/petscds.h - would be nice to automate this.
 #define UW_SIG_F0 PetscInt, PetscInt, PetscInt, const PetscInt[], const PetscInt[], const PetscScalar[], const PetscScalar[], const PetscScalar[], const PetscInt[], const PetscInt[], const PetscScalar[], const PetscScalar[], const PetscScalar[], PetscReal, const PetscReal[], const PetscReal[], PetscInt, const PetscScalar[], PetscScalar[]
 #define UW_SIG_G0 PetscInt, PetscInt, PetscInt, const PetscInt[], const PetscInt[], const PetscScalar[], const PetscScalar[], const PetscScalar[], const PetscInt[], const PetscInt[], const PetscScalar[], const PetscScalar[], const PetscScalar[], PetscReal, PetscReal, const PetscReal[], const PetscReal[], PetscInt, const PetscScalar[], PetscScalar[]

--- a/src/underworld3/cython/petsc_compat.h
+++ b/src/underworld3/cython/petsc_compat.h
@@ -45,6 +45,12 @@ PetscErrorCode DMSetAuxiliaryVec_UW(DM dm, DMLabel label, PetscInt value, PetscI
     return DMSetAuxiliaryVec(dm, label, value, part, aux);
 }
 
+PetscErrorCode UW_PetscDSGetBoundaryWeakForm(PetscDS ds, PetscInt bd, PetscWeakForm *wf)
+{
+    PetscCall(PetscDSGetBoundary(ds, bd, wf, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL));
+    return PETSC_SUCCESS;
+}
+
 // copy paste function signitures from $PETSC_DIR/include/petscds.h - would be nice to automate this.
 #define UW_SIG_F0 PetscInt, PetscInt, PetscInt, const PetscInt[], const PetscInt[], const PetscScalar[], const PetscScalar[], const PetscScalar[], const PetscInt[], const PetscInt[], const PetscScalar[], const PetscScalar[], const PetscScalar[], PetscReal, const PetscReal[], const PetscReal[], PetscInt, const PetscScalar[], PetscScalar[]
 #define UW_SIG_G0 PetscInt, PetscInt, PetscInt, const PetscInt[], const PetscInt[], const PetscScalar[], const PetscScalar[], const PetscScalar[], const PetscInt[], const PetscInt[], const PetscScalar[], const PetscScalar[], const PetscScalar[], PetscReal, PetscReal, const PetscReal[], const PetscReal[], PetscInt, const PetscScalar[], PetscScalar[]

--- a/src/underworld3/cython/petsc_extras.pxi
+++ b/src/underworld3/cython/petsc_extras.pxi
@@ -44,6 +44,7 @@ cdef extern from "petsc_compat.h":
     PetscErrorCode PetscDSAddBoundary_UW( PetscDM, DMBoundaryConditionType, const char[], const char[] , PetscInt, PetscInt, PetscInt *, void (*)(), void (*)(), PetscInt, const PetscInt *, void *)
     PetscErrorCode DMSetAuxiliaryVec_UW(PetscDM, PetscDMLabel, PetscInt, PetscInt, PetscVec)
     PetscErrorCode UW_PetscDSGetBoundaryWeakForm(PetscDS, PetscInt, PetscWeakForm *)
+    PetscErrorCode UW_DMPlexComputeResidualByKeyVolumeOnly( PetscDM, PetscFormKey, PetscIS, PetscReal, PetscVec, PetscVec, PetscReal, PetscVec, void *)
     # PetscErrorCode UW_PetscDSSetBdResidual(PetscDS, PetscDMLabel, PetscInt, PetscInt, PetscInt, PetscInt, void*, PetscInt, void*)
 
     PetscErrorCode UW_PetscDSSetBdResidual(PetscDS, PetscDMLabel, PetscInt, PetscInt, PetscInt, PetscInt, void*, void*)

--- a/src/underworld3/cython/petsc_extras.pxi
+++ b/src/underworld3/cython/petsc_extras.pxi
@@ -32,6 +32,7 @@ cdef CHKERRQ(PetscErrorCode ierr):
     if ierr != 0: raise RuntimeError(f"PETSc error code '{interr}' was encountered.\nhttps://www.mcs.anl.gov/petsc/petsc-current/include/petscerror.h.html")
 
 cdef extern from "petscdstypes.h":
+    ctypedef void *PetscWeakForm "PetscWeakForm"
     ctypedef struct PetscFormKey:
         PetscDMLabel label
         PetscInt value
@@ -42,6 +43,7 @@ cdef extern from "petsc_compat.h":
 
     PetscErrorCode PetscDSAddBoundary_UW( PetscDM, DMBoundaryConditionType, const char[], const char[] , PetscInt, PetscInt, PetscInt *, void (*)(), void (*)(), PetscInt, const PetscInt *, void *)
     PetscErrorCode DMSetAuxiliaryVec_UW(PetscDM, PetscDMLabel, PetscInt, PetscInt, PetscVec)
+    PetscErrorCode UW_PetscDSGetBoundaryWeakForm(PetscDS, PetscInt, PetscWeakForm *)
     # PetscErrorCode UW_PetscDSSetBdResidual(PetscDS, PetscDMLabel, PetscInt, PetscInt, PetscInt, PetscInt, void*, PetscInt, void*)
 
     PetscErrorCode UW_PetscDSSetBdResidual(PetscDS, PetscDMLabel, PetscInt, PetscInt, PetscInt, PetscInt, void*, void*)
@@ -61,6 +63,7 @@ cdef extern from "petsc.h" nogil:
     PetscErrorCode DMPlexSNESComputeBoundaryFEM( PetscDM, void *, void *)
     PetscErrorCode DMPlexSNESComputeResidualFEM( PetscDM, PetscVec, PetscVec, void *)
     PetscErrorCode DMPlexComputeResidualByKey( PetscDM, PetscFormKey, PetscIS, PetscReal, PetscVec, PetscVec, PetscReal, PetscVec, void *)
+    PetscErrorCode DMPlexComputeBdResidualSingle( PetscDM, PetscWeakForm, PetscFormKey, PetscVec, PetscVec, PetscReal, PetscVec )
     # PetscErrorCode DMPlexSetSNESLocalFEM( PetscDM, void *, void *, void *)
     # PetscErrorCode DMPlexSetSNESLocalFEM( PetscDM, PetscBool, void *)
     PetscErrorCode DMPlexComputeGeometryFVM( PetscDM dm, PetscVec *cellgeom, PetscVec *facegeom)
@@ -71,6 +74,7 @@ cdef extern from "petsc.h" nogil:
     PetscErrorCode PetscDSSetJacobian( PetscDS, PetscInt, PetscInt, PetscDSJacobianFn, PetscDSJacobianFn, PetscDSJacobianFn, PetscDSJacobianFn)
     PetscErrorCode PetscDSSetJacobianPreconditioner( PetscDS, PetscInt, PetscInt, PetscDSJacobianFn, PetscDSJacobianFn, PetscDSJacobianFn, PetscDSJacobianFn)
     PetscErrorCode PetscDSSetResidual( PetscDS, PetscInt, PetscDSResidualFn, PetscDSResidualFn )
+    PetscErrorCode PetscDSGetWeakForm( PetscDS, PetscWeakForm * )
     
     PetscErrorCode PetscDSSetBdJacobian( PetscDS, PetscInt, PetscInt, PetscDSBdJacobianFn, PetscDSBdJacobianFn, PetscDSBdJacobianFn, PetscDSBdJacobianFn)
     PetscErrorCode PetscDSSetBdJacobianPreconditioner( PetscDS, PetscInt, PetscInt, PetscDSBdJacobianFn, PetscDSBdJacobianFn, PetscDSBdJacobianFn, PetscDSBdJacobianFn)
@@ -92,6 +96,7 @@ cdef extern from "petsc.h" nogil:
     PetscErrorCode DMGetRegionDS(PetscDM dm, PetscDMLabel label, PetscIS *fields, PetscDS *ds, PetscDS *dsIn)
     PetscErrorCode DMGetRegionNumDS(PetscDM dm, PetscInt num, PetscDMLabel *label, PetscIS *fields, PetscDS *ds, PetscDS *dsIn)
     PetscErrorCode DMSetRegionNumDS(PetscDM dm, PetscInt num, PetscDMLabel label, PetscIS fields, PetscDS ds, PetscDS dsIn)
+    PetscErrorCode DMGetDS(PetscDM dm, PetscDS *ds)
     PetscErrorCode DMGetNumDS(PetscDM dm, PetscInt *num)
     PetscErrorCode DMGetCellDS(PetscDM dm, PetscInt point, PetscDS *ds, PetscDS *dsIn)
     PetscErrorCode PetscDSSetCoordinateDimension(PetscDS ds, PetscInt dim)

--- a/src/underworld3/cython/petsc_extras.pxi
+++ b/src/underworld3/cython/petsc_extras.pxi
@@ -31,6 +31,13 @@ cdef CHKERRQ(PetscErrorCode ierr):
     cdef int interr = <int>ierr
     if ierr != 0: raise RuntimeError(f"PETSc error code '{interr}' was encountered.\nhttps://www.mcs.anl.gov/petsc/petsc-current/include/petscerror.h.html")
 
+cdef extern from "petscdstypes.h":
+    ctypedef struct PetscFormKey:
+        PetscDMLabel label
+        PetscInt value
+        PetscInt field
+        PetscInt part
+
 cdef extern from "petsc_compat.h":
 
     PetscErrorCode PetscDSAddBoundary_UW( PetscDM, DMBoundaryConditionType, const char[], const char[] , PetscInt, PetscInt, PetscInt *, void (*)(), void (*)(), PetscInt, const PetscInt *, void *)
@@ -52,6 +59,8 @@ cdef extern from "petsc_compat.h":
 cdef extern from "petsc.h" nogil:
     PetscErrorCode PetscDSSetConstants(PetscDS, PetscInt, const PetscScalar[])
     PetscErrorCode DMPlexSNESComputeBoundaryFEM( PetscDM, void *, void *)
+    PetscErrorCode DMPlexSNESComputeResidualFEM( PetscDM, PetscVec, PetscVec, void *)
+    PetscErrorCode DMPlexComputeResidualByKey( PetscDM, PetscFormKey, PetscIS, PetscReal, PetscVec, PetscVec, PetscReal, PetscVec, void *)
     # PetscErrorCode DMPlexSetSNESLocalFEM( PetscDM, void *, void *, void *)
     # PetscErrorCode DMPlexSetSNESLocalFEM( PetscDM, PetscBool, void *)
     PetscErrorCode DMPlexComputeGeometryFVM( PetscDM dm, PetscVec *cellgeom, PetscVec *facegeom)

--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -6582,19 +6582,27 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
         if uw.mpi.rank == 0 and self.verbose:
             print(f"Region DS: inactive region '{label_name}' gets trivial DS", flush=True)
 
-    def compute_volume_residual_fields(self, time=None, verbose=False, cell_indices=None, residual_field_id=None):
+    def compute_volume_residual_fields(
+        self,
+        time=None,
+        verbose=False,
+        cell_indices=None,
+        residual_field_id=None,
+        include_boundary_terms=False,
+    ):
         """Return PETSc FEM residual fields in each solver field's local layout.
 
         This is a low-level diagnostic hook for post-processing derived
         boundary quantities such as consistent-boundary-flux traction. By
         default it calls PETSc's ``DMPlexSNESComputeResidualFEM`` directly. If
         ``cell_indices`` is supplied, it instead calls
-        ``DMPlexComputeResidualByKey`` on those local cells and the requested
-        test field. PETSc's keyed residual path also appends registered
-        boundary residuals, so this is a total residual diagnostic, not a
-        volume-only CBF recovery. The returned arrays are local to each rank
-        and have the same flat layout as the corresponding MeshVariable PETSc
-        vector.
+        a UW wrapper around ``DMPlexComputeResidualByKey`` on a cloned DM with
+        a copied ``PetscDS`` that has no registered boundary objects, so the
+        selected-cell path returns volume terms only. Set
+        ``include_boundary_terms=True`` to call PETSc's original keyed
+        residual behavior, which appends registered boundary residuals. The
+        returned arrays are local to each rank and have the same flat layout as
+        the corresponding MeshVariable PETSc vector.
         """
         cdef DM _time_dm_residual
         cdef DM dm
@@ -6602,6 +6610,8 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
         cdef Vec fvec
         cdef PetscFormKey key
         cdef IS ccell_is
+        cdef PetscReal residual_time = 0.0
+        cdef PetscReal implicit_form_time = <PetscReal>-1.7976931348623157e308
 
         self._build(verbose, False, None)
 
@@ -6612,6 +6622,7 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
                 t_nd = float(time)
             _time_dm_residual = self.dm
             UW_DMSetTime(_time_dm_residual.dm, t_nd)
+            residual_time = <PetscReal>t_nd
 
         self.mesh.update_lvec()
         self.dm.setAuxiliaryVec(self.mesh.lvec, None)
@@ -6650,10 +6661,16 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
                     key.value = 0
                     key.field = <PetscInt>residual_field_id
                     key.part = 0
-                    CHKERRQ(DMPlexComputeResidualByKey(
-                        dm.dm, key, ccell_is.iset, <PetscReal>-1.7976931348623157e308,
-                        xvec.vec, NULL, 0.0, fvec.vec, NULL,
-                    ))
+                    if include_boundary_terms:
+                        CHKERRQ(DMPlexComputeResidualByKey(
+                            dm.dm, key, ccell_is.iset, implicit_form_time,
+                            xvec.vec, NULL, residual_time, fvec.vec, NULL,
+                        ))
+                    else:
+                        CHKERRQ(UW_DMPlexComputeResidualByKeyVolumeOnly(
+                            dm.dm, key, ccell_is.iset, implicit_form_time,
+                            xvec.vec, NULL, residual_time, fvec.vec, NULL,
+                        ))
                 finally:
                     cell_is.destroy()
 

--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -6703,6 +6703,131 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
             self.dm.restoreLocalVec(xlocal)
             self.dm.restoreGlobalVec(gvec)
 
+    def compute_boundary_residual_fields(self, boundary, time=None, verbose=False, residual_field_id=0):
+        """Return the registered FEM boundary residual for one named boundary.
+
+        This is a low-level diagnostic hook for weak-boundary-condition
+        debugging. It assembles PETSc's boundary residual terms registered on
+        ``boundary`` through ``DMPlexComputeBdResidualSingle``. For Nitsche
+        free slip, this includes the full registered weak boundary residual,
+        not only the scalar penalty term. The returned arrays are local to each
+        rank and have the same flat layout as the corresponding MeshVariable
+        PETSc vector.
+        """
+        cdef DM _time_dm_boundary_residual
+        cdef DM dm
+        cdef Vec xvec
+        cdef Vec fvec
+        cdef PetscFormKey key
+        cdef PetscDS ds
+        cdef PetscWeakForm wf
+        cdef DMLabel c_label
+
+        self._build(verbose, False, None)
+
+        boundary_bc = None
+        for bc in self.natural_bcs:
+            if bc.boundary == boundary and bc.f_id == residual_field_id:
+                boundary_bc = bc
+                break
+        if boundary_bc is None:
+            raise ValueError(
+                f"No natural/Nitsche boundary residual is registered for "
+                f"boundary '{boundary}' and field {residual_field_id}."
+            )
+
+        if time is not None:
+            if hasattr(time, 'magnitude') or hasattr(time, '_pint_qty'):
+                t_nd = float(uw.non_dimensionalise(time))
+            else:
+                t_nd = float(time)
+            _time_dm_boundary_residual = self.dm
+            UW_DMSetTime(_time_dm_boundary_residual.dm, t_nd)
+
+        self.mesh.update_lvec()
+        self.dm.setAuxiliaryVec(self.mesh.lvec, None)
+        self._update_constants()
+
+        gvec = self.dm.getGlobalVec()
+        xlocal = self.dm.getLocalVec()
+        flocal = self.dm.getLocalVec()
+        gvec.setArray(0.0)
+        xlocal.setArray(0.0)
+        flocal.setArray(0.0)
+
+        try:
+            for name, var in self.fields.items():
+                sgvec = gvec.getSubVector(self._subdict[name][0])
+                subdm = self._subdict[name][1]
+                subdm.localToGlobal(var.vec, sgvec)
+                gvec.restoreSubVector(self._subdict[name][0], sgvec)
+
+            self.dm.globalToLocal(gvec, xlocal)
+
+            dm = self.dm
+            xvec = xlocal
+            fvec = flocal
+            CHKERRQ(DMGetDS(dm.dm, &ds))
+            CHKERRQ(UW_PetscDSGetBoundaryWeakForm(
+                ds, <PetscInt>boundary_bc.PETScID, &wf,
+            ))
+
+            c_label = self.dm.getLabel("UW_Boundaries")
+            key.label = c_label.dmlabel
+            key.value = <PetscInt>boundary_bc.boundary_label_val
+            key.field = <PetscInt>residual_field_id
+            key.part = 0
+            CHKERRQ(DMPlexComputeBdResidualSingle(
+                dm.dm, wf, key, xvec.vec, NULL, 0.0, fvec.vec,
+            ))
+
+            local_section = self.dm.getLocalSection()
+            pStart, pEnd = local_section.getChart()
+            out = {}
+
+            for name, var in self.fields.items():
+                field_id = getattr(var, "_solver_field_id", None)
+                if field_id is None:
+                    field_id = getattr(var, "field_id", None)
+                if field_id is None:
+                    continue
+
+                is_field = None
+                created_is_field = False
+                if name == "velocity" and getattr(self, "_velocity_is", None) is not None:
+                    is_field = self._velocity_is
+                elif name == "pressure" and getattr(self, "_pressure_is", None) is not None:
+                    is_field = self._pressure_is
+                elif getattr(self, "_multiplier_is", None) is not None and name in self._multiplier_is:
+                    is_field = self._multiplier_is[name]
+                else:
+                    indices = []
+                    for point in range(pStart, pEnd):
+                        dof = local_section.getFieldDof(point, field_id)
+                        if dof > 0:
+                            offset = local_section.getFieldOffset(point, field_id)
+                            for i in range(dof):
+                                indices.append(offset + i)
+
+                    is_field = PETSc.IS().createGeneral(indices, comm=PETSc.COMM_SELF)
+                    created_is_field = True
+
+                try:
+                    subvec = flocal.getSubVector(is_field)
+                    try:
+                        out[name] = np.array(subvec.array, copy=True)
+                    finally:
+                        flocal.restoreSubVector(is_field, subvec)
+                finally:
+                    if created_is_field:
+                        is_field.destroy()
+
+            return out
+        finally:
+            self.dm.restoreLocalVec(flocal)
+            self.dm.restoreLocalVec(xlocal)
+            self.dm.restoreGlobalVec(gvec)
+
     @timing.routine_timer_decorator
     def solve(self,
               zero_init_guess: bool = True,

--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -6582,6 +6582,127 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
         if uw.mpi.rank == 0 and self.verbose:
             print(f"Region DS: inactive region '{label_name}' gets trivial DS", flush=True)
 
+    def compute_volume_residual_fields(self, time=None, verbose=False, cell_indices=None, residual_field_id=None):
+        """Return the volume-only FEM residual in each solver field's local layout.
+
+        This is a low-level diagnostic hook for post-processing derived
+        boundary quantities such as consistent-boundary-flux traction. By
+        default it calls PETSc's ``DMPlexSNESComputeResidualFEM`` directly. If
+        ``cell_indices`` is supplied, it instead calls
+        ``DMPlexComputeResidualByKey`` on those local cells and the requested
+        test field. Boundary residuals registered through natural, Nitsche, or
+        multiplier boundary terms are not included. The returned arrays are
+        local to each rank and have the same flat layout as the corresponding
+        MeshVariable PETSc vector.
+        """
+        cdef DM _time_dm_residual
+        cdef DM dm
+        cdef Vec xvec
+        cdef Vec fvec
+        cdef PetscFormKey key
+        cdef IS ccell_is
+
+        self._build(verbose, False, None)
+
+        if time is not None:
+            if hasattr(time, 'magnitude') or hasattr(time, '_pint_qty'):
+                t_nd = float(uw.non_dimensionalise(time))
+            else:
+                t_nd = float(time)
+            _time_dm_residual = self.dm
+            UW_DMSetTime(_time_dm_residual.dm, t_nd)
+
+        self.mesh.update_lvec()
+        self.dm.setAuxiliaryVec(self.mesh.lvec, None)
+        self._update_constants()
+
+        gvec = self.dm.getGlobalVec()
+        xlocal = self.dm.getLocalVec()
+        flocal = self.dm.getLocalVec()
+        gvec.setArray(0.0)
+        xlocal.setArray(0.0)
+        flocal.setArray(0.0)
+
+        try:
+            for name, var in self.fields.items():
+                sgvec = gvec.getSubVector(self._subdict[name][0])
+                subdm = self._subdict[name][1]
+                subdm.localToGlobal(var.vec, sgvec)
+                gvec.restoreSubVector(self._subdict[name][0], sgvec)
+
+            self.dm.globalToLocal(gvec, xlocal)
+
+            dm = self.dm
+            xvec = xlocal
+            fvec = flocal
+            if cell_indices is None:
+                CHKERRQ(DMPlexSNESComputeResidualFEM(dm.dm, xvec.vec, fvec.vec, NULL))
+            else:
+                if residual_field_id is None:
+                    residual_field_id = 0
+                cell_is = PETSc.IS().createGeneral(
+                    list(cell_indices), comm=PETSc.COMM_SELF
+                )
+                try:
+                    ccell_is = cell_is
+                    key.label = NULL
+                    key.value = 0
+                    key.field = <PetscInt>residual_field_id
+                    key.part = 0
+                    CHKERRQ(DMPlexComputeResidualByKey(
+                        dm.dm, key, ccell_is.iset, <PetscReal>-1.7976931348623157e308,
+                        xvec.vec, NULL, 0.0, fvec.vec, NULL,
+                    ))
+                finally:
+                    cell_is.destroy()
+
+            local_section = self.dm.getLocalSection()
+            pStart, pEnd = local_section.getChart()
+            out = {}
+
+            for name, var in self.fields.items():
+                field_id = getattr(var, "_solver_field_id", None)
+                if field_id is None:
+                    field_id = getattr(var, "field_id", None)
+                if field_id is None:
+                    continue
+
+                is_field = None
+                created_is_field = False
+                if name == "velocity" and getattr(self, "_velocity_is", None) is not None:
+                    is_field = self._velocity_is
+                elif name == "pressure" and getattr(self, "_pressure_is", None) is not None:
+                    is_field = self._pressure_is
+                elif getattr(self, "_multiplier_is", None) is not None and name in self._multiplier_is:
+                    is_field = self._multiplier_is[name]
+                else:
+                    indices = []
+                    for point in range(pStart, pEnd):
+                        dof = local_section.getFieldDof(point, field_id)
+                        if dof > 0:
+                            offset = local_section.getFieldOffset(point, field_id)
+                            for i in range(dof):
+                                indices.append(offset + i)
+
+                    is_field = PETSc.IS().createGeneral(indices, comm=PETSc.COMM_SELF)
+                    created_is_field = True
+
+                try:
+                    subvec = flocal.getSubVector(is_field)
+                    try:
+                        out[name] = np.array(subvec.array, copy=True)
+                    finally:
+                        flocal.restoreSubVector(is_field, subvec)
+                finally:
+                    if created_is_field:
+                        is_field.destroy()
+
+            return out
+        finally:
+            self.dm.restoreLocalVec(flocal)
+            self.dm.restoreLocalVec(xlocal)
+            self.dm.restoreGlobalVec(gvec)
+
     @timing.routine_timer_decorator
     def solve(self,
               zero_init_guess: bool = True,

--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -6583,17 +6583,18 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
             print(f"Region DS: inactive region '{label_name}' gets trivial DS", flush=True)
 
     def compute_volume_residual_fields(self, time=None, verbose=False, cell_indices=None, residual_field_id=None):
-        """Return the volume-only FEM residual in each solver field's local layout.
+        """Return PETSc FEM residual fields in each solver field's local layout.
 
         This is a low-level diagnostic hook for post-processing derived
         boundary quantities such as consistent-boundary-flux traction. By
         default it calls PETSc's ``DMPlexSNESComputeResidualFEM`` directly. If
         ``cell_indices`` is supplied, it instead calls
         ``DMPlexComputeResidualByKey`` on those local cells and the requested
-        test field. Boundary residuals registered through natural, Nitsche, or
-        multiplier boundary terms are not included. The returned arrays are
-        local to each rank and have the same flat layout as the corresponding
-        MeshVariable PETSc vector.
+        test field. PETSc's keyed residual path also appends registered
+        boundary residuals, so this is a total residual diagnostic, not a
+        volume-only CBF recovery. The returned arrays are local to each rank
+        and have the same flat layout as the corresponding MeshVariable PETSc
+        vector.
         """
         cdef DM _time_dm_residual
         cdef DM dm

--- a/src/underworld3/meshing/spherical.py
+++ b/src/underworld3/meshing/spherical.py
@@ -580,96 +580,97 @@ def SphericalShellInternalBoundary(
         gmsh.option.setNumber("General.Verbosity", gmsh_verbosity)
         gmsh.model.add("SphereShell_with_Internal_Surface")
 
-        # Create three concentric spheres and use OCC fragment to split
-        # into two non-overlapping shell volumes sharing the internal surface
-        ball_outer = gmsh.model.occ.addSphere(0, 0, 0, radiusOuter)
-        ball_internal = gmsh.model.occ.addSphere(0, 0, 0, radiusInternal)
-        ball_inner = gmsh.model.occ.addSphere(0, 0, 0, radiusInner)
+        # Create the spherical shell volume.
+        outer = gmsh.model.occ.addSphere(0.0, 0.0, 0.0, radiusOuter)
+        inner = gmsh.model.occ.addSphere(0.0, 0.0, 0.0, radiusInner)
+        gmsh.model.occ.cut(
+            [(3, outer)],
+            [(3, inner)],
+            removeObject=True,
+            removeTool=True,
+        )
 
-        # Fragment creates non-overlapping pieces from the boolean intersection
-        out_dimtags, out_map = gmsh.model.occ.fragment(
-            [(3, ball_outer)],
-            [(3, ball_internal), (3, ball_inner)],
+        # Create an internal shell only to obtain a clean spherical surface at
+        # radiusInternal. That surface is embedded into the shell volume below;
+        # the duplicate volume and duplicate lower surface are removed before
+        # meshing.
+        internal = gmsh.model.occ.addSphere(0.0, 0.0, 0.0, radiusInternal)
+        inner_copy = gmsh.model.occ.addSphere(0.0, 0.0, 0.0, radiusInner)
+        gmsh.model.occ.cut(
+            [(3, internal)],
+            [(3, inner_copy)],
+            removeObject=True,
+            removeTool=True,
         )
 
         gmsh.model.occ.synchronize()
         gmsh.option.setNumber("Mesh.CharacteristicLengthMax", cellSize)
 
-        # Identify volumes and surfaces by bounding box
-        # For a sphere, bbox diagonal = sqrt(3) * radius
-        volumes = gmsh.model.getEntities(3)
-        surfaces = gmsh.model.getEntities(2)
-
         def bbox_radius(dimtag):
-            """Estimate the sphere radius from a bounding box diagonal."""
+            """Estimate a concentric sphere radius from the bounding box."""
             bb = gmsh.model.get_bounding_box(dimtag[0], dimtag[1])
             return np.sqrt(bb[3]**2 + bb[4]**2 + bb[5]**2) / np.sqrt(3.0)
 
-        inner_vols = []
-        outer_vols = []
-        solid_ball_vols = []  # r < radiusInner — to be removed
-
-        for vol in volumes:
-            r_est = bbox_radius(vol)
-            if np.isclose(r_est, radiusInner, atol=cellSize):
-                solid_ball_vols.append(vol)
-            elif np.isclose(r_est, radiusInternal, atol=cellSize):
-                inner_vols.append(vol)
-            elif np.isclose(r_est, radiusOuter, atol=cellSize):
-                outer_vols.append(vol)
-
-        # Remove the solid inner ball (r < radiusInner)
-        if solid_ball_vols:
-            gmsh.model.occ.remove(solid_ball_vols, recursive=True)
-            gmsh.model.occ.synchronize()
-
-        # Re-query after removal
         volumes = gmsh.model.getEntities(3)
-        surfaces = gmsh.model.getEntities(2)
+        shell_vols = [vol for vol in volumes if np.isclose(bbox_radius(vol), radiusOuter, atol=cellSize * 0.5)]
+        duplicate_vols = [vol for vol in volumes if np.isclose(bbox_radius(vol), radiusInternal, atol=cellSize * 0.5)]
 
-        # Classify surfaces by bounding box radius
-        for surface in surfaces:
+        if len(shell_vols) != 1:
+            raise RuntimeError(
+                "Could not identify the spherical-shell volume while building "
+                "SphericalShellInternalBoundary."
+            )
+
+        shell_vol = shell_vols[0]
+        shell_boundary = {
+            dimtag[1]
+            for dimtag in gmsh.model.getBoundary([shell_vol], oriented=False, recursive=False)
+            if dimtag[0] == 2
+        }
+
+        lower_surface_tags = []
+        internal_surface_tags = []
+        upper_surface_tags = []
+        duplicate_lower_tags = []
+
+        for surface in gmsh.model.getEntities(2):
+            surface_tag = surface[1]
             r_est = bbox_radius(surface)
             if np.isclose(r_est, radiusInner, atol=cellSize * 0.5):
-                gmsh.model.addPhysicalGroup(
-                    surface[0], [surface[1]],
-                    boundaries.Lower.value, name=boundaries.Lower.name,
-                )
+                if surface_tag in shell_boundary:
+                    lower_surface_tags.append(surface_tag)
+                else:
+                    duplicate_lower_tags.append(surface_tag)
             elif np.isclose(r_est, radiusOuter, atol=cellSize * 0.5):
-                gmsh.model.addPhysicalGroup(
-                    surface[0], [surface[1]],
-                    boundaries.Upper.value, name=boundaries.Upper.name,
-                )
+                upper_surface_tags.append(surface_tag)
             elif np.isclose(r_est, radiusInternal, atol=cellSize * 0.5):
-                gmsh.model.addPhysicalGroup(
-                    surface[0], [surface[1]],
-                    boundaries.Internal.value, name=boundaries.Internal.name,
-                )
+                internal_surface_tags.append(surface_tag)
 
-        # Classify remaining volumes into Inner and Outer
-        inner_vol_tags = [v[1] for v in inner_vols if v not in solid_ball_vols]
-        outer_vol_tags = [v[1] for v in outer_vols]
-        # Re-classify from current volumes in case tags changed after removal
-        inner_vol_tags = []
-        outer_vol_tags = []
-        for vol in volumes:
-            r_est = bbox_radius(vol)
-            if r_est < radiusInternal + cellSize * 0.5:
-                inner_vol_tags.append(vol[1])
-            else:
-                outer_vol_tags.append(vol[1])
+        if not lower_surface_tags or not upper_surface_tags or not internal_surface_tags:
+            raise RuntimeError(
+                "Could not identify Lower, Internal, and Upper spherical surfaces "
+                "while building SphericalShellInternalBoundary."
+            )
 
-        # Region physical groups
-        if inner_vol_tags:
-            gmsh.model.addPhysicalGroup(3, inner_vol_tags,
-                                        regions.Inner.value, name=regions.Inner.name)
-        if outer_vol_tags:
-            gmsh.model.addPhysicalGroup(3, outer_vol_tags,
-                                        regions.Outer.value, name=regions.Outer.name)
+        gmsh.model.mesh.embed(2, internal_surface_tags, shell_vol[0], shell_vol[1])
 
-        # Combined elements group
-        all_vol_tags = inner_vol_tags + outer_vol_tags
-        gmsh.model.addPhysicalGroup(3, all_vol_tags, 99999, "Elements")
+        remove_dimtags = duplicate_vols + [(2, tag) for tag in duplicate_lower_tags]
+        if remove_dimtags:
+            gmsh.model.remove_entities(remove_dimtags, recursive=False)
+            gmsh.model.occ.remove(remove_dimtags, recursive=False)
+            gmsh.model.occ.synchronize()
+
+        gmsh.model.addPhysicalGroup(
+            2, lower_surface_tags, boundaries.Lower.value, name=boundaries.Lower.name
+        )
+        gmsh.model.addPhysicalGroup(
+            2, internal_surface_tags, boundaries.Internal.value, name=boundaries.Internal.name
+        )
+        gmsh.model.addPhysicalGroup(
+            2, upper_surface_tags, boundaries.Upper.value, name=boundaries.Upper.name
+        )
+
+        gmsh.model.addPhysicalGroup(shell_vol[0], [shell_vol[1]], 99999, "Elements")
 
         gmsh.model.mesh.generate(3)
         gmsh.write(uw_filename)

--- a/src/underworld3/meshing/spherical.py
+++ b/src/underworld3/meshing/spherical.py
@@ -557,9 +557,13 @@ def SphericalShellInternalBoundary(
         Internal = 12
         Upper = 13
 
-    class regions(Enum):
-        Inner = 101
-        Outer = 102
+    # NOTE: this generator builds a SINGLE shell volume [radiusInner, radiusOuter]
+    # with the radiusInternal sphere *embedded* as a conformal internal surface
+    # (the `Internal` boundary). Unlike the old occ.fragment approach it does NOT
+    # split the volume into Inner/Outer region sub-volumes, so no Inner/Outer
+    # region physical groups exist and `mesh.regions` is left as None — region
+    # extraction is intentionally unsupported here (use the `Internal` boundary
+    # label for the internal interface). See PR #242.
 
     import gmsh
 
@@ -741,7 +745,9 @@ def SphericalShellInternalBoundary(
 
     # boundary_normals deprecated — use mesh.Gamma_P1 for boundary normals
 
-    new_mesh.regions = regions
+    # Single-volume embed design (see note above): no Inner/Outer region groups
+    # exist on the DM, so leave mesh.regions as None rather than advertising
+    # labels that extract_region() cannot resolve.
 
     # Full spherical shell with internal boundary: 3 rigid rotation modes
     x, y, z = new_mesh.X

--- a/src/underworld3/meshing/spherical.py
+++ b/src/underworld3/meshing/spherical.py
@@ -571,9 +571,13 @@ def SphericalShellInternalBoundary(
     else:
         uw_filename = filename
 
-    # Check if r_i is greater than 0
     if radiusInner <= 0:
         raise ValueError("The inner radius must be greater than 0.")
+    if not radiusInner < radiusInternal < radiusOuter:
+        raise ValueError(
+            "SphericalShellInternalBoundary requires "
+            "radiusInner < radiusInternal < radiusOuter."
+        )
 
     if uw.mpi.rank == 0:
         gmsh.initialize()
@@ -612,8 +616,16 @@ def SphericalShellInternalBoundary(
             return np.sqrt(bb[3]**2 + bb[4]**2 + bb[5]**2) / np.sqrt(3.0)
 
         volumes = gmsh.model.getEntities(3)
-        shell_vols = [vol for vol in volumes if np.isclose(bbox_radius(vol), radiusOuter, atol=cellSize * 0.5)]
-        duplicate_vols = [vol for vol in volumes if np.isclose(bbox_radius(vol), radiusInternal, atol=cellSize * 0.5)]
+        shell_vols = [
+            vol
+            for vol in volumes
+            if np.isclose(bbox_radius(vol), radiusOuter, atol=cellSize * 0.5)
+        ]
+        duplicate_vols = [
+            vol
+            for vol in volumes
+            if np.isclose(bbox_radius(vol), radiusInternal, atol=cellSize * 0.5)
+        ]
 
         if len(shell_vols) != 1:
             raise RuntimeError(

--- a/tests/test_0502_boundary_integrals.py
+++ b/tests/test_0502_boundary_integrals.py
@@ -293,6 +293,52 @@ def test_bd_integral_annulus_internal_normal_tangential():
     assert abs(value) < 0.05, f"Expected ~0, got {value}"
 
 
+# --- Spherical shell internal boundary tests ---
+
+from underworld3.meshing import SphericalShellInternalBoundary
+
+_R_SHELL_INNER = 0.55
+_R_SHELL_INTERNAL = 0.775
+_R_SHELL_OUTER = 1.0
+_mesh_spherical_internal = None
+
+
+def _get_spherical_internal_mesh():
+    global _mesh_spherical_internal
+    if _mesh_spherical_internal is None:
+        _mesh_spherical_internal = SphericalShellInternalBoundary(
+            radiusOuter=_R_SHELL_OUTER,
+            radiusInternal=_R_SHELL_INTERNAL,
+            radiusInner=_R_SHELL_INNER,
+            cellSize=0.25,
+            degree=1,
+            qdegree=2,
+        )
+        uw.discretisation.MeshVariable(
+            "T_spherical_internal", _mesh_spherical_internal, 1, degree=1
+        )
+    return _mesh_spherical_internal
+
+
+def test_bd_integral_spherical_internal_boundary_areas():
+    """SphericalShellInternalBoundary preserves Lower/Internal/Upper labels."""
+
+    mesh_spherical = _get_spherical_internal_mesh()
+    expected_areas = {
+        "Lower": 4.0 * np.pi * _R_SHELL_INNER**2,
+        "Internal": 4.0 * np.pi * _R_SHELL_INTERNAL**2,
+        "Upper": 4.0 * np.pi * _R_SHELL_OUTER**2,
+    }
+
+    for boundary, expected in expected_areas.items():
+        value = uw.maths.BdIntegral(mesh_spherical, fn=1.0, boundary=boundary).evaluate()
+        relative_error = abs(value - expected) / expected
+        assert relative_error < 0.06, (
+            f"{boundary} area should be close to {expected:.4f}; "
+            f"got {value:.4f} (relative error {relative_error:.3f})"
+        )
+
+
 def _build_spherical_shell_for_integrals():
     from underworld3.meshing import SphericalShell
 

--- a/tests/test_0502_boundary_integrals.py
+++ b/tests/test_0502_boundary_integrals.py
@@ -320,8 +320,15 @@ def _get_spherical_internal_mesh():
     return _mesh_spherical_internal
 
 
+@pytest.mark.level_2
+@pytest.mark.tier_b
 def test_bd_integral_spherical_internal_boundary_areas():
-    """SphericalShellInternalBoundary preserves Lower/Internal/Upper labels."""
+    """SphericalShellInternalBoundary preserves Lower/Internal/Upper labels.
+
+    Overrides the module-level level_1/tier_a marks: this builds a full 3D
+    gmsh+embed mesh (not a seconds-scale level_1 op), and the embed generator
+    is not yet production-soaked for tier_a. See PR #242 review.
+    """
 
     mesh_spherical = _get_spherical_internal_mesh()
     expected_areas = {

--- a/tests/test_1064_constrained_spherical_shell_response.py
+++ b/tests/test_1064_constrained_spherical_shell_response.py
@@ -111,6 +111,16 @@ def solve_response(method, solver_mode):
         stokes.petsc_options["pc_type"] = "lu"
         stokes.petsc_options["pc_factor_mat_solver_type"] = "mumps"
         stokes.petsc_options["pc_use_amat"] = None
+    elif solver_mode == "fieldsplit_exact":
+        if method != "constrained":
+            raise ValueError(
+                "fieldsplit_exact mode is only defined for constrained runs"
+            )
+        stokes.petsc_options["pc_fieldsplit_schur_precondition"] = "selfp"
+        stokes.petsc_options["fieldsplit_velocity_ksp_type"] = "preonly"
+        stokes.petsc_options["fieldsplit_velocity_pc_type"] = "lu"
+        stokes.petsc_options["fieldsplit_1_ksp_type"] = "preonly"
+        stokes.petsc_options["fieldsplit_1_pc_type"] = "lu"
     elif solver_mode == "fast_schur":
         if method != "constrained":
             raise ValueError("fast_schur mode is only defined for constrained runs")
@@ -158,6 +168,29 @@ def test_monolithic_constrained_matches_monolithic_nitsche_response():
     constrained_surface, constrained_cmb, constrained_reason = solve_response(
         "constrained",
         "monolithic",
+    )
+
+    assert nitsche_reason > 0
+    assert constrained_reason > 0
+    assert abs(constrained_surface - nitsche_surface) / nitsche_surface < 0.01
+    assert abs(constrained_cmb - nitsche_cmb) / nitsche_cmb < 0.01
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Known constrained field-split algebra failure: exact LU sub-solves in "
+        "the velocity | [p,h] split still do not reproduce monolithic LU."
+    ),
+    strict=True,
+)
+def test_exact_fieldsplit_constrained_matches_monolithic_nitsche_response():
+    nitsche_surface, nitsche_cmb, nitsche_reason = solve_response(
+        "nitsche",
+        "monolithic",
+    )
+    constrained_surface, constrained_cmb, constrained_reason = solve_response(
+        "constrained",
+        "fieldsplit_exact",
     )
 
     assert nitsche_reason > 0

--- a/tests/test_1064_constrained_spherical_shell_response.py
+++ b/tests/test_1064_constrained_spherical_shell_response.py
@@ -1,9 +1,12 @@
 """3-D spherical-shell constrained free-slip response regression.
 
-This test records two facts exposed by the Zhong et al. (2008)-style benchmark:
+This test records facts exposed by the Zhong et al. (2008)-style benchmark:
 
-* with monolithic LU, ``Stokes_Constrained`` and Nitsche free slip solve the same
-  internal-boundary Stokes response to within a tight tolerance;
+* the validated Nitsche/default field-split path reproduces the Zhong velocity
+  scale for this low-resolution response case;
+* a direct-LU diagnostic path gives matching Nitsche and constrained responses,
+  but it does not reproduce the validated Nitsche/default response and should
+  not be treated as the benchmark reference;
 * the practical fast grouped-Schur constrained path currently does not reproduce
   the Zhong velocity response and remains an expected failure.
 
@@ -111,6 +114,8 @@ def solve_response(method, solver_mode):
         stokes.petsc_options["pc_type"] = "lu"
         stokes.petsc_options["pc_factor_mat_solver_type"] = "mumps"
         stokes.petsc_options["pc_use_amat"] = None
+    elif solver_mode == "default":
+        pass
     elif solver_mode == "fieldsplit_exact":
         if method != "constrained":
             raise ValueError(
@@ -160,7 +165,18 @@ def solve_response(method, solver_mode):
     )
 
 
-def test_monolithic_constrained_matches_monolithic_nitsche_response():
+def test_default_nitsche_matches_zhong_velocity_response():
+    surface_velocity, cmb_velocity, snes_reason = solve_response(
+        "nitsche",
+        "default",
+    )
+
+    assert snes_reason > 0
+    assert abs(surface_velocity - ZHONG_SURFACE_VELOCITY) / ZHONG_SURFACE_VELOCITY < 0.05
+    assert abs(cmb_velocity - ZHONG_CMB_VELOCITY) / ZHONG_CMB_VELOCITY < 0.05
+
+
+def test_direct_lu_diagnostic_constrained_matches_direct_lu_diagnostic_nitsche():
     nitsche_surface, nitsche_cmb, nitsche_reason = solve_response(
         "nitsche",
         "monolithic",
@@ -178,15 +194,16 @@ def test_monolithic_constrained_matches_monolithic_nitsche_response():
 
 @pytest.mark.xfail(
     reason=(
-        "Known constrained field-split algebra failure: exact LU sub-solves in "
-        "the velocity | [p,h] split still do not reproduce monolithic LU."
+        "Known constrained field-split failure: LU sub-solves in the "
+        "velocity | [p,h] preconditioner still do not reproduce the validated "
+        "Nitsche/default velocity response."
     ),
     strict=True,
 )
-def test_exact_fieldsplit_constrained_matches_monolithic_nitsche_response():
+def test_lu_subsolve_fieldsplit_constrained_matches_default_nitsche_response():
     nitsche_surface, nitsche_cmb, nitsche_reason = solve_response(
         "nitsche",
-        "monolithic",
+        "default",
     )
     constrained_surface, constrained_cmb, constrained_reason = solve_response(
         "constrained",

--- a/tests/test_1064_constrained_spherical_shell_response.py
+++ b/tests/test_1064_constrained_spherical_shell_response.py
@@ -1,0 +1,184 @@
+"""3-D spherical-shell constrained free-slip response regression.
+
+This test records two facts exposed by the Zhong et al. (2008)-style benchmark:
+
+* with monolithic LU, ``Stokes_Constrained`` and Nitsche free slip solve the same
+  internal-boundary Stokes response to within a tight tolerance;
+* the practical fast grouped-Schur constrained path currently does not reproduce
+  the Zhong velocity response and remains an expected failure.
+
+Run:
+    pixi run -e amr-dev pytest -q tests/test_1064_constrained_spherical_shell_response.py
+"""
+
+from functools import cache
+
+import numpy as np
+import pytest
+import sympy
+
+import underworld3 as uw
+
+pytestmark = [pytest.mark.level_3, pytest.mark.slow, pytest.mark.tier_c]
+
+RADIUS_INNER = 0.55
+RADIUS_INTERNAL = 0.775
+RADIUS_OUTER = 1.0
+CELL_SIZE = 1.0 / 8.0
+HARMONIC_DEGREE = 2
+NITSCHE_GAMMA = 10.0
+
+ZHONG_SURFACE_VELOCITY = 1.006e-2
+ZHONG_CMB_VELOCITY = 1.186e-2
+
+
+@cache
+def solve_response(method, solver_mode):
+    mesh = uw.meshing.SphericalShellInternalBoundary(
+        radiusOuter=RADIUS_OUTER,
+        radiusInternal=RADIUS_INTERNAL,
+        radiusInner=RADIUS_INNER,
+        cellSize=CELL_SIZE,
+        qdegree=2,
+        degree=1,
+    )
+
+    velocity = uw.discretisation.MeshVariable(
+        f"U_{method}_{solver_mode}",
+        mesh,
+        mesh.dim,
+        degree=2,
+        vtype=uw.VarType.VECTOR,
+    )
+    pressure = uw.discretisation.MeshVariable(
+        f"P_{method}_{solver_mode}",
+        mesh,
+        1,
+        degree=1,
+        continuous=True,
+    )
+
+    theta = mesh.CoordinateSystem.xR[1]
+    unit_r = mesh.CoordinateSystem.unit_e_0
+    y_l0 = sympy.assoc_legendre(HARMONIC_DEGREE, 0, sympy.cos(theta))
+    harmonic_norm = 4.0 * np.pi / (2 * HARMONIC_DEGREE + 1)
+
+    if method == "constrained":
+        stokes = uw.systems.Stokes_Constrained(
+            mesh,
+            velocityField=velocity,
+            pressureField=pressure,
+        )
+    elif method == "nitsche":
+        stokes = uw.systems.Stokes(
+            mesh,
+            velocityField=velocity,
+            pressureField=pressure,
+        )
+    else:
+        raise ValueError(f"Unknown response method {method!r}")
+
+    stokes.constitutive_model = uw.constitutive_models.ViscousFlowModel
+    stokes.constitutive_model.Parameters.shear_viscosity_0 = 1.0
+    stokes.bodyforce = sympy.Matrix([0.0, 0.0, 0.0])
+    stokes.add_natural_bc(y_l0 * unit_r, mesh.boundaries.Internal.name)
+
+    if method == "nitsche":
+        stokes.add_nitsche_bc("Upper", normal=unit_r, gamma=NITSCHE_GAMMA)
+        stokes.add_nitsche_bc("Lower", normal=-unit_r, gamma=NITSCHE_GAMMA)
+    else:
+        stokes.add_constraint_bc(
+            "Upper",
+            g=0.0,
+            normal=unit_r,
+            augmentation_base=1.0e4,
+            degree=2,
+        )
+        stokes.add_constraint_bc(
+            "Lower",
+            g=0.0,
+            normal=-unit_r,
+            augmentation_base=1.0e4,
+            degree=2,
+        )
+
+    stokes.petsc_use_nullspace = True
+    stokes.tolerance = 1.0e-7
+    stokes.petsc_options["snes_type"] = "ksponly"
+
+    if solver_mode == "monolithic":
+        stokes.petsc_options["ksp_type"] = "preonly"
+        stokes.petsc_options["pc_type"] = "lu"
+        stokes.petsc_options["pc_factor_mat_solver_type"] = "mumps"
+        stokes.petsc_options["pc_use_amat"] = None
+    elif solver_mode == "fast_schur":
+        if method != "constrained":
+            raise ValueError("fast_schur mode is only defined for constrained runs")
+        stokes.petsc_options["pc_fieldsplit_schur_precondition"] = "selfp"
+        stokes.petsc_options["fieldsplit_1_ksp_type"] = "preonly"
+        stokes.petsc_options["fieldsplit_1_pc_type"] = "gasm"
+    else:
+        raise ValueError(f"Unknown solver mode {solver_mode!r}")
+
+    stokes.solve()
+
+    horizontal_v2 = velocity.sym.dot(velocity.sym) - velocity.sym.dot(unit_r) ** 2
+
+    surface_velocity = np.sqrt(
+        uw.maths.BdIntegral(mesh, horizontal_v2, boundary="Upper").evaluate()
+        / (
+            RADIUS_OUTER**2
+            * HARMONIC_DEGREE
+            * (HARMONIC_DEGREE + 1)
+            * harmonic_norm
+        )
+    )
+    cmb_velocity = np.sqrt(
+        uw.maths.BdIntegral(mesh, horizontal_v2, boundary="Lower").evaluate()
+        / (
+            RADIUS_INNER**2
+            * HARMONIC_DEGREE
+            * (HARMONIC_DEGREE + 1)
+            * harmonic_norm
+        )
+    )
+
+    return (
+        float(surface_velocity),
+        float(cmb_velocity),
+        int(stokes.snes.getConvergedReason()),
+    )
+
+
+def test_monolithic_constrained_matches_monolithic_nitsche_response():
+    nitsche_surface, nitsche_cmb, nitsche_reason = solve_response(
+        "nitsche",
+        "monolithic",
+    )
+    constrained_surface, constrained_cmb, constrained_reason = solve_response(
+        "constrained",
+        "monolithic",
+    )
+
+    assert nitsche_reason > 0
+    assert constrained_reason > 0
+    assert abs(constrained_surface - nitsche_surface) / nitsche_surface < 0.01
+    assert abs(constrained_cmb - nitsche_cmb) / nitsche_cmb < 0.01
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Known fast grouped-Schur constrained response failure for the "
+        "3-D SphericalShellInternalBoundary Zhong-style load."
+    ),
+    strict=True,
+)
+def test_fast_schur_constrained_matches_zhong_velocity_response():
+    surface_velocity, cmb_velocity, snes_reason = solve_response(
+        "constrained",
+        "fast_schur",
+    )
+
+    assert snes_reason > 0
+    assert abs(surface_velocity - ZHONG_SURFACE_VELOCITY) / ZHONG_SURFACE_VELOCITY < 0.05
+    assert abs(cmb_velocity - ZHONG_CMB_VELOCITY) / ZHONG_CMB_VELOCITY < 0.05


### PR DESCRIPTION
## Summary

This PR adds the UW3 support needed to reproduce the spherical-shell Stokes response benchmarks used in Zhong et al. (2008):

- Fix `uw.meshing.SphericalShellInternalBoundary()` so `Lower`, `Internal`, and `Upper` labels are valid DMPlex boundary labels.
- Add low-level Stokes residual diagnostic hooks used for CBF-style dynamic-topography recovery.
- Add constrained/free-slip spherical-shell response regressions that document the current constrained grouped-Schur limitation.
- Keep the production Stokes/Nitsche solve path unchanged; the new residual hooks are diagnostics around the assembled problem.

## Benchmark Theory

Zhong et al. (2008) compare Stokes response functions in a spherical shell with:

- inner radius `r_b = 0.55`, outer radius `r_t = 1.0`;
- radial delta forcing `delta(r-r0) P_l^0(theta) e_r`;
- free slip on the CMB and surface;
- response quantities at the surface and CMB: characteristic horizontal velocity, dynamic topography, and geoid.

In UW3 the delta forcing is represented as the equivalent radial natural traction on an embedded internal spherical boundary at `r0`. This requires `SphericalShellInternalBoundary()` to produce three usable surface labels:

- `Lower`: CMB boundary;
- `Internal`: load boundary;
- `Upper`: surface boundary.

The velocity response is a standard Stokes solve result. Dynamic topography is more delicate: direct pointwise/projected `sigma_rr` is not the same as the consistent-boundary-flux style stress recovery used by strong free-slip benchmark codes. The residual diagnostic hooks in this PR allow the benchmark script to recover boundary reaction/topography from selected Stokes residuals instead of relying only on direct `stokes.stress` post-processing.

## Nitsche Free Slip: What Changed and Why It Matters

This PR does **not** change UW3's production Nitsche weak form.

The important update is diagnostic and validation support around the Nitsche path:

- The benchmark uses Nitsche free slip as the validated production path because it reproduces Zhong characteristic velocities robustly in serial and MPI runs.
- Direct Nitsche `sigma_rr` post-processing was not sufficient for topography/geoid comparison.
- The new residual hooks expose:
  - full FEM residual diagnostics;
  - boundary-specific weak residual diagnostics for registered natural/Nitsche boundary forms;
  - cloned-DM volume-only residual diagnostics for CBF-style recovery without appending registered boundary residuals.

This separation matters because a correct velocity solve and a correct topography recovery are related but not identical checks. The benchmark now confirms that Nitsche gives the correct velocity response, then uses residual-based recovery plus Zhong Appendix A post-processing for dynamic topography and geoid.

## What Changed

### Mesh

- Reworked `SphericalShellInternalBoundary()` geometry construction so the physical shell volume and the embedded internal spherical surface are preserved cleanly.
- Added radius-order validation for `radiusInner < radiusInternal < radiusOuter`.
- Added regression coverage for `Lower`, `Internal`, and `Upper` boundary areas.

### Residual Diagnostics

- Added Stokes FEM residual field extraction.
- Added boundary weak residual extraction through the same boundary weak form registered by UW3.
- Added cloned-DM volume-only residual extraction. The cloned DM copies sections, fields, equations, constants, and auxiliary vectors but has no registered boundary objects, so PETSc does not append boundary residuals to the selected-cell volume residual.
- Fixed the residual diagnostic context signature to use `void *`, matching the Cython declaration and allowing all Cython extension modules to build.

### Regression Tests

- Added `tests/test_1064_constrained_spherical_shell_response.py`.
- The test records:
  - Nitsche/default matches the Zhong velocity scale for the low-resolution response case;
  - direct-LU Nitsche and direct-LU constrained are useful same-path diagnostics but are not the benchmark reference;
  - constrained field-split variants that do not reproduce the validated Nitsche/default response are strict expected failures.

## Benchmark Results

External benchmark repository:

`gthyagi/uw3-mantle-convection-benchmarks`

Benchmark script:

`benchmarks/bench_010_zhong2008_isoviscous_response.py`

Configuration:

- Nitsche free slip;
- Zhong `P_l^0` internal-boundary forcing;
- `volume_residual_cbf_lumped` topography recovery;
- Zhong Appendix A self-gravity/geoid post-processing;
- Table 2 sweep over `l = 2, 5, 8, 15` and depths `0.25d`, `0.5d`, `0.75d`.

### Default `l=2`, `0.5d` Case

Zhong Table 2 analytical values:

| Quantity | Analytical | UW3 8-rank `1/16` | Error |
| --- | ---: | ---: | ---: |
| surface velocity | `1.006e-02` | `1.0076094909651055e-02` | `0.16%` |
| CMB velocity | `1.186e-02` | `1.186556831000749e-02` | `0.05%` |
| surface topography, self-gravity | `4.998e-01` | `4.9577940809588633e-01` | `-0.80%` |
| CMB topography, self-gravity | `9.313e-01` | `9.156930209567329e-01` | `-1.68%` |
| surface geoid, self-gravity | `4.486e-02` | `4.376413039396167e-02` | `-2.44%` |
| CMB geoid, self-gravity | `5.461e-02` | `5.265637036600948e-02` | `-3.58%` |

### Full Table 2 Sweep, 8-rank `1/16`

Errors relative to Zhong Table 2 analytical values:

| depth | l | s err % | b err % | ht err % | hb err % | Ut err % | Ub err % |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 0.25 | 2 | -0.75 | -1.67 | -3.31 | -3.43 | -0.01 | -0.05 |
| 0.25 | 5 | -0.71 | -3.01 | -1.70 | -3.96 | -0.06 | -0.60 |
| 0.25 | 8 | -1.28 | -5.99 | -2.43 | -7.21 | -0.19 | -1.97 |
| 0.25 | 15 | -4.18 | -17.32 | -6.30 | -19.40 | -0.90 | -7.07 |
| 0.5 | 2 | -0.80 | -1.68 | -2.44 | -3.58 | 0.16 | 0.05 |
| 0.5 | 5 | -1.08 | -3.10 | -1.87 | -4.49 | -0.13 | -0.56 |
| 0.5 | 8 | -2.05 | -5.94 | -2.94 | -7.73 | -0.38 | -1.81 |
| 0.5 | 15 | -6.28 | -16.73 | -7.75 | -19.63 | -1.74 | -6.68 |
| 0.75 | 2 | -0.76 | -1.62 | -2.42 | -4.88 | 0.22 | -0.02 |
| 0.75 | 5 | -0.93 | -2.34 | -1.52 | -4.33 | -0.15 | -0.27 |
| 0.75 | 8 | -1.99 | -4.48 | -2.60 | -7.06 | -0.67 | -1.13 |
| 0.75 | 15 | -6.56 | -15.49 | -7.52 | -20.54 | 3.19 | -5.82 |

Interpretation:

- `l <= 8` is reproduced well at `1/16`: velocity errors are below about `2%`, topography errors are mostly below `6%`, and geoid errors are mostly below `8%`.
- `l = 15` remains resolution-sensitive, especially for CMB topography/geoid. This is now a convergence-resolution issue rather than a free-slip or forcing-definition issue.

## Are All Recent Commits Essential?

For a single PR whose goal is “support Zhong-style spherical-shell benchmark reproduction”, yes, the commits are connected:

- `SphericalShellInternalBoundary` fixes are essential. Without them the benchmark cannot reliably integrate/apply loads on `Lower`, `Internal`, and `Upper`.
- Residual diagnostic hooks are essential for the validated topography/geoid path. Direct stress recovery was insufficient; CBF-style residual recovery is what made the Table 2 comparison work.
- The constrained response regression is not needed to run Nitsche itself, but it is important evidence. It documents why Nitsche/default is the current benchmark reference and why constrained grouped-Schur results should not be used as the paper comparison until that solver path is fixed.
- The final `void *` context-signature fix is essential because the shared compatibility header must build in all Cython extension modules.

If maintainers prefer smaller PRs, this branch can still be split into two review units later:

1. mesh-label fix for `SphericalShellInternalBoundary()`;
2. residual diagnostics plus constrained-response regression.

## Validation

Local validation in this branch:

- `./uw build` passed.
- `pixi run -e amr-dev pytest -q tests/test_0502_boundary_integrals.py::test_bd_integral_spherical_internal_boundary_areas` passed: `1 passed in 4.70s`.
- `pixi run -e amr-dev pytest -q tests/test_1064_constrained_spherical_shell_response.py` passed with expected failures: `2 passed, 2 xfailed in 180.38s`.

Representative fixed serial boundary areas at `ri=0.55`, `rint=0.775`, `ro=1.0`, `cellSize=0.25`:

- `Lower = 3.651738570092663`;
- `Internal = 7.402572621636933`;
- `Upper = 12.418895120898583`.

Before the mesh fix, the same benchmark path reported `Lower = 0.0` and failed the boundary-area check.
