### PR TITLE
Old-frame semi-Lagrangian reach-back for moving meshes (SLCN/SL-BDF2)

### DIFF
--- a/docs/advanced/index.md
+++ b/docs/advanced/index.md
@@ -50,6 +50,13 @@ Dynamic remeshing and adaptive refinement strategies.
 
 **[→ Mesh Adaptation](mesh-adaptation.md)**
 
+### Semi-Lagrangian Time Integration (SLCN / SL-BDF2)
+How `AdvDiffusionSLCN` discretizes advection–diffusion in time: the BDF
+time-derivative and Adams-Moulton/θ flux knobs, and how to pair them
+(SLCN vs SL-BDF2).
+
+**[→ Semi-Lagrangian Time Integration](semi-lagrangian-time-integration.md)**
+
 ### Porous Media Flow
 Darcy flow, Richards equation, and variably-saturated groundwater modelling.
 
@@ -98,6 +105,7 @@ vep-transverse-isotropy-faults
 custom-meshes
 curved-boundary-conditions
 mesh-adaptation
+semi-lagrangian-time-integration
 porous-flow
 snapshot-restore
 troubleshooting

--- a/docs/advanced/semi-lagrangian-time-integration.md
+++ b/docs/advanced/semi-lagrangian-time-integration.md
@@ -1,0 +1,136 @@
+---
+title: "Semi-Lagrangian Time Integration (SLCN / SL-BDF2)"
+---
+
+# Semi-Lagrangian time integration: SLCN and SL-BDF2
+
+`AdvDiffusionSLCN` (and the `SemiLagrangian` history operator behind it)
+solves advection–diffusion
+
+$$\frac{\partial u}{\partial t} + \mathbf{v}\cdot\nabla u
+   - \nabla\cdot(\kappa\nabla u) = f$$
+
+by tracing characteristics backward in time for the advective part and
+treating diffusion implicitly. This page explains the **two independent
+order knobs** in the scheme and how to pair them correctly — the common
+pitfall is mixing them.
+
+## The scheme has two time-integration choices
+
+The discrete residual assembled by the solver is
+
+$$\underbrace{\frac{c_0\,u^{n+1} + c_1\,u^{*} + c_2\,u^{**} + \cdots}{\Delta t}}_{\textbf{time derivative — BDF}}
+  \;=\;
+  \nabla\cdot\underbrace{\big[a_0\,\mathbf{F}^{n+1} + a_1\,\mathbf{F}^{*} + \cdots\big]}_{\textbf{flux — Adams–Moulton / }\theta}
+  \;+\; f$$
+
+where $u^{*}, u^{**}, \mathbf{F}^{*}$ are quantities sampled at the
+**departure points** of the characteristics (one step, two steps, …
+upstream).
+
+These two sides are controlled separately:
+
+| term | operator | knob | meaning |
+|------|----------|------|---------|
+| time derivative $\mathrm{D}u/\mathrm{D}t$ | `DuDt` | **BDF `order`** | backward-difference stencil along the characteristic |
+| diffusive flux | `DFDt` | **`theta`** (Adams–Moulton) | time-centring of the flux |
+
+`DuDt` and `DFDt` are both `SemiLagrangian` operators, reachable as
+`adv_diff.DuDt` and `adv_diff.DFDt`.
+
+:::{important}
+**BDF** (backward differentiation) and **Adams–Moulton/θ** are *distinct*
+linear-multistep families. A BDF stencil is one-sided implicit and expects
+the flux evaluated **at $n+1$ only**; the trapezoidal (Crank–Nicolson) flux
+is *centred* between $n$ and $n+1$ and pairs with a single-step difference.
+They must be chosen as a **matched pair**.
+:::
+
+## The two standard schemes
+
+### SLCN — Semi-Lagrangian Crank–Nicolson (default)
+
+`order = 1`, `theta = 0.5`:
+
+$$\frac{u^{n+1} - u^{*}}{\Delta t}
+  = \tfrac12\,\nabla\cdot(\mathbf{F}^{n+1} + \mathbf{F}^{*}) + f .$$
+
+This is the classic scheme of Spiegelman & Katz (2006). Although the
+stencil and the departure point are formally first order, the
+trapezoidal-along-the-trajectory structure recovers **second-order**
+accuracy. It is A-stable but not L-stable, so it can ring on stiff,
+under-resolved gradients (see `theta` below).
+
+```python
+adv = uw.systems.AdvDiffusionSLCN(mesh, u_Field=T, V_fn=v.sym, order=1)
+# theta defaults to 0.5 (Crank-Nicolson)
+```
+
+### SL-BDF2 — Semi-Lagrangian BDF2
+
+`DuDt` BDF `order = 2`, flux **`theta = 1.0`**:
+
+$$\frac{\tfrac32 u^{n+1} - 2u^{*} + \tfrac12 u^{**}}{\Delta t}
+  = \nabla\cdot\mathbf{F}^{n+1} + f .$$
+
+BDF2 uses **two** departure points and evaluates the flux **implicitly at
+$n+1$** (hence `theta = 1.0`, not Crank–Nicolson). It is also second-order
+accurate but, unlike CN, avoids the spurious resonance / sign-flip ringing
+CN can show on stiff modes (Bonaventura et al., 2021).
+
+Because the internally-built `DuDt` is fixed at BDF order 1, SL-BDF2 is
+selected by supplying an explicit order-2 `DuDt` and setting the flux
+`theta`:
+
+```python
+duDt = uw.systems.ddt.SemiLagrangian(
+    mesh, T.sym, v.sym,
+    vtype=uw.VarType.SCALAR, degree=T.degree,
+    continuous=T.continuous, order=2,          # BDF2 stencil
+)
+adv = uw.systems.AdvDiffusionSLCN(mesh, u_Field=T, V_fn=v.sym, DuDt=duDt, order=1)
+adv.DFDt.theta = 1.0                           # flux implicit at n+1
+```
+
+:::{warning}
+**Do not mix a BDF2 stencil with a Crank–Nicolson flux** (`order=2` +
+`theta=0.5`). The left side is centred at $n+1$ while the right side is
+centred at $n+\tfrac12$; the combination is *not* a consistent second-order
+scheme. Use SLCN (`order=1`, `theta=0.5`) **or** SL-BDF2 (`order=2`,
+`theta=1.0`), not a hybrid.
+:::
+
+## `theta` — Crank–Nicolson vs Backward Euler (flux)
+
+For the order-1 flux integrator the Adams–Moulton coefficients are
+$[\theta,\,1-\theta]$:
+
+- `theta = 0.5` — **Crank–Nicolson** (trapezoidal): second-order, A-stable.
+  The default. Can ring on stiff, under-resolved diffusion.
+- `theta = 1.0` — **Backward Euler**: L-stable and monotone for diffusion,
+  first-order on its own — and the correct flux centring for SL-BDF2.
+
+`theta` is settable after construction: `adv_diff.DFDt.theta = 1.0`.
+
+## Related options
+
+- **`monotone_mode`** (`"clamp"` / `"pick"`) bounds the semi-Lagrangian
+  trace-back to the local data range, curing FE-overshoot ("pepper")
+  speckles in cells with sharp gradients. Forwarded to both `DuDt` and
+  `DFDt`. See the `AdvDiffusionSLCN` docstring.
+- **`old_frame_traceback`** samples the history on the *previous-step*
+  mesh geometry rather than the new one — the cure for the semi-Lagrangian
+  blow-up on a moving (free-surface or adapting) mesh. It is order-agnostic
+  (works for SLCN and SL-BDF2 alike). See
+  [`docs/developer/design/lagged-clone-sl-history.md`](../developer/design/lagged-clone-sl-history.md).
+
+## References
+
+- Spiegelman, M., & Katz, R. F. (2006). *A semi-Lagrangian Crank–Nicolson
+  algorithm for the numerical solution of advection–diffusion problems.*
+  Geochemistry, Geophysics, Geosystems, 7(4).
+  <https://doi.org/10.1029/2005GC001073>
+- Bonaventura, L., Calzola, E., Carlini, E., & Ferretti, R. (2021).
+  *Second order fully semi-Lagrangian discretizations of
+  advection–diffusion–reaction systems.* Journal of Scientific Computing,
+  88, 23. <https://doi.org/10.1007/s10915-021-01518-8>

--- a/docs/developer/design/lagged-clone-sl-history.md
+++ b/docs/developer/design/lagged-clone-sl-history.md
@@ -169,3 +169,156 @@ meshes.
 - The **big question** this unblocks: SL height field vs full node movement +
   mmpde. The lagged-clone approach makes SL correct at a moving boundary; the
   comparison is then about cost/robustness, not correctness.
+
+## Stage 0 — landed (2026-06-18): old-frame reach-back, cost/benefit
+
+Stage 0 (a) — *ephemeral old-geometry restore on the working mesh* — is
+implemented and validated as the production cure for the high-Ra free-surface
+SL blow-up. It is the minimal subset of this design: no clone, no mixed-mesh
+evaluator. This section records what it costs, what it leaves on the table, and
+the recommendation on whether to proceed to the rolling clone (Stage 1 (c)) now.
+
+### What landed
+
+`SemiLagrangian.old_frame_traceback` (opt-in, default `False`; forwarded through
+`AdvDiffusionSLCN(..., old_frame_traceback=True)` to the **advective `DuDt`
+only** — the diffusive `DFDt` keeps stock ALE, validated sufficient at Ra=1e5).
+Three hooks in `systems/ddt.py`:
+
+1. `on_remesh` stashes the pre-move geometry (`_oldframe_X = ctx.old_X`, earliest
+   since the last solve) **instead of** a `v_mesh` displacement, and leaves
+   `psi_star` `CARRY`'d.
+2. `update_pre_solve` computes the departure foot from the **physical** velocity
+   (no `v_mesh`; `_ale_active` is `False`), records `psi_star[0]` by **direct
+   nodal carry** (not a re-evaluate on the deformed mesh — see below), skips the
+   new-mesh bounds clamp, and samples `psi_star` inside
+   `with mesh.ephemeral_coords(): mesh._deform_mesh(_oldframe_X); global_evaluate(...)`.
+3. The one-step stash is consumed at the end of `update_pre_solve`.
+
+**De-risked:** a variable's `.data` is bit-identical through a
+`_deform_mesh(old) → _deform_mesh(new)` round-trip (`nuke_coords_and_rebuild`
+rebuilds the DS / DM / DOF-coordinate caches but never touches the solution
+`Vec`), and `_deform_mesh` invalidates `_dminterpolation_cache` + the evaluation
+cache — so the ephemeral sample is correct and not stale. The clone (Stage 1) is
+therefore **not required** for correctness; it is an efficiency / capability
+play.
+
+**Load-bearing detail:** the first real-API run blew up *like the baseline*
+despite old-frame being active, because the standard `store_result` path
+**re-records** `psi_star[0]` by evaluating `psi_fn` on the *deformed* mesh at
+centroid-shifted nodes — injecting boundary-layer interpolation error that grows
+with `h_max` and then rides the old-geometry sample. Recording the history by a
+**direct nodal carry** (reusing the parallel `_record_psi_star_from_field_data`
+path) restores the prototype's exact behaviour. This is the "store primitives,
+not re-derived values" principle of invariant 3, in miniature.
+
+### Validation (Ra=1e5 annulus, res 20, free surface, CN)
+
+| run | worst T over 30 steps |
+|-----|-----------------------|
+| baseline (stock ALE) | `[-311, +333]` — blow-up by ~step 20 |
+| old-frame, **SLCN** (BDF1 + CN flux, θ=0.5) | `[0.000, 1.000]` |
+| old-frame, **SL-BDF2** (BDF2 + flux at n+1, θ=1) | `[0.000, 1.000]` |
+
+`h_max` reaches ~0.067 (surface deformed ~2.3 cells), Nu climbs 12→55 — vigorous,
+not over-diffused. Old-frame is **order-agnostic** — it changes only *where* the
+history is sampled, so both the canonical SLCN and SL-BDF2 schemes hold T∈[0,1].
+(The two scheme knobs must be paired: SLCN = BDF1 time-difference + Crank-Nicolson
+flux; SL-BDF2 = BDF2 time-difference + flux implicit at n+1 — a BDF2 stencil with a
+CN flux is *not* a consistent 2nd-order scheme. See
+[`docs/advanced/semi-lagrangian-time-integration.md`](../../advanced/semi-lagrangian-time-integration.md)
+and Bonaventura et al., 2021.) Unit regression: `tests/test_0855_oldframe_sl_traceback.py`
+(no-op on static mesh bit-identical; geometry restored + stash consumed; samples
+on old geometry not new; bounded on a moving mesh; BDF2) — passes serial and
+np=2; the existing `ddt` suite is unchanged (opt-in, default off).
+
+### Cost of Stage 0 (a)
+
+Measured on the Ra=1e5 res-20 free-surface loop (`oldframe_overhead_bench.py`):
+
+- **`adv_diff.solve`: +166 ms/step (+8 %)** over baseline (2033 → 2199 ms/step),
+  from **+2 `nuke_coords_and_rebuild` per solve** (deform-to-old + restore) for an
+  order-1 `DuDt`. Order *N* wraps the sample per history level → `2N` rebuilds /
+  step (a hoist to one ephemeral block per step is an obvious Stage-0
+  optimisation, deferred).
+- **Hidden churn not in that 8 %:** `_deform_mesh` unconditionally sets
+  `is_setup = False` on *every* registered solver, so each ephemeral round-trip
+  also forces the **Stokes** DM/assembly to rebuild on its next solve — even
+  though the working mesh returns to bit-identical coordinates. This is the real
+  Stage-0 tax at scale (Stokes assembly ≫ a `nuke`), and it is **entirely
+  avoidable**: a guard that skips the `is_setup` invalidation when
+  `ephemeral_coords` restores identical coordinates would remove it without the
+  clone. Recommended as the first Stage-0 follow-up if the tax bites.
+
+### What Stage 0 leaves on the table (the Stage-1 (c) clone)
+
+The rolling clone (DMClone, shared partition, independent coords, refreshed by
+local memcpy; sampled via the **mixed-mesh evaluator**, Phase 1) would:
+
+- **Eliminate both costs above** — the working mesh never moves, so no per-step
+  `nuke` and no solver-rebuild churn; the clone refresh is a local coord memcpy.
+- **Enable old `V` on the clone** → second-order *temporal* reach-back (the
+  current foot uses only the current velocity).
+- **Recompute fluxes / gradients at full FE accuracy** on the clone, retiring the
+  lossy projected histories (`DFDt`, `psi_star_flat`, VE stress projection).
+
+Its build cost is the large piece deliberately excluded from Stage 0: the
+mixed-mesh `global_evaluate` (per-mesh point location + pointwise combine,
+shared-partition fast path) and **verifying derivative/vector `global_evaluate`
+on a non-current DM** (the `scalar_component` wrinkle, invariant 5 / Phase-1 task
+1).
+
+### Recommendation
+
+**Ship Stage 0 (a) now; defer the clone (Stage 1 (c)).** Stage 0 delivers the
+correctness cure with ~8 % on the advection solve and zero new infrastructure,
+and (Task 2 below) is mesh-agnostic — it covers interior-node adaptation on the
+same code path. The clone's payoff is *efficiency and second-order/flux
+capability*, not correctness, and it costs the whole mixed-mesh evaluator. Build
+it when one of these triggers fires, not before:
+
+1. The Stokes-rebuild churn is shown to dominate a production run **and** the
+   cheap `is_setup` guard above does not remove it; or
+2. a feature needs old `V` (second-order temporal reach-back) or full-accuracy
+   flux/stress recompute on a moving mesh (VE on a free surface / adapting mesh);
+   or
+3. the per-step `nuke` cost becomes material at higher order or resolution.
+
+Until then the v_mesh/`CARRY`/i=0-gate apparatus stays as the default path; old-
+frame is the opt-in cure. Retiring that apparatus is gated on unifying the
+adaptation path onto old-frame (Task 2) and is tracked separately.
+
+### Task 2 — old-frame through interior-node adaptation
+
+_(see `~/+Simulations/fs_convection_goal4/oldframe_adapt_comparison.py`;
+no-slip Ra=1e5 res-16 annulus convection, periodic interior adaptation, old-frame
+vs the current `v_mesh` path; gentle `refinement=1.3` — aggressive refinement
+destabilises the **base** convection regardless of transfer mode, so it is not a
+fair test)._
+
+Old-frame is mesh-agnostic: `on_remesh` stashes the old geometry for *any* node
+move (free surface or mmpde/OT interior adaptation), so the same code path
+applies. The comparison (30 steps, 7 adaptation events each):
+
+| mover | v_mesh worst T | old-frame worst T | final Nu (vm / of) | worst q (vm / of) |
+|-------|----------------|-------------------|--------------------|-------------------|
+| `follow_metric` (anisotropic) | **[-6.97, +4.27]** | **[-0.51, +1.07]** | 16.4 / 16.0 | 0.778 / 0.783 |
+| `OT_adapt` | [-0.014, 1.000] | [0.000, 1.000] | 21.8 / 21.7 | 0.762 / 0.762 |
+| `smooth_mesh_interior` | [0, 1] (n_adapts=0) | [0, 1] (n_adapts=0) | 32.3 / 32.1 | 0.826 / 0.826 |
+
+**Conclusion: old-frame MATCHES or BEATS the current `v_mesh` path with no
+regression.** For `follow_metric`'s anisotropic interior motion it is
+*substantially* better bounded — `v_mesh` overshoots to `[-7, +4]` (the same
+new-mesh-frame fold that fails at the free surface), while old-frame holds
+`≈[0, 1]` — at equal Nu and equal-or-better mesh quality. For `OT_adapt` (whose
+internal reset + FE-remap already keeps the history clean) both are bounded, old-
+frame marginally better. `smooth_mesh_interior` on a uniform mesh is a no-op
+(equant cells → no move); the near-identical Nu confirms old-frame does not
+perturb a no-adaptation run.
+
+So old-frame is the **single SL reference for both free surface and adaptation**
+(invariant 6), and is the path to eventually retiring the `v_mesh`/`CARRY`/i=0-
+gate apparatus. That retirement is held back only by sequencing/benchmarking
+discipline (it is the default path today and old-frame is opt-in), not by any
+correctness gap — and is tracked as the unification follow-up.
+

--- a/src/underworld3/systems/ddt.py
+++ b/src/underworld3/systems/ddt.py
@@ -1356,7 +1356,35 @@ class SemiLagrangian(uw_object):
     bcs : list, default=[]
         Boundary conditions for projections.
     order : int, default=1
-        Number of history timesteps (1 for first-order, 2 for second-order).
+        Number of history timesteps and, for the time-derivative operator,
+        the order of the BDF backward-difference stencil taken *along the
+        characteristic*:
+
+        - ``order = 1`` → ``[1, -1]``: single-step difference
+          ``(ψ^{n+1} - ψ*)/Δt``. Paired with a trapezoidal (Crank-Nicolson,
+          ``theta=0.5``) flux this is the standard **SLCN** scheme — second-
+          order accurate even though the stencil and the departure point
+          are first-order, because the trapezoidal-along-the-trajectory
+          structure recovers the order (Spiegelman & Katz, 2006).
+        - ``order = 2`` → ``[3/2, -2, 1/2]``: BDF2 stencil
+          ``(3/2 ψ^{n+1} - 2 ψ* + 1/2 ψ**)/Δt``, using two departure
+          points. This is the **SL-BDF2** scheme. BDF2 is a one-sided
+          implicit method: it expects the *flux evaluated at* ``n+1``
+          only, i.e. a Backward-Euler-centred flux (``theta=1.0``), **not**
+          Crank-Nicolson. SL-BDF2 reaches the same second order as SLCN but
+          avoids the spurious resonance/ringing CN can show on stiff modes
+          (Bonaventura et al., 2021).
+
+        .. important::
+           BDF (time-derivative) and Adams-Moulton/θ (flux) are *distinct*
+           multistep families and must be **paired consistently**: SLCN =
+           ``order=1`` + ``theta=0.5``; SL-BDF2 = ``order=2`` + ``theta=1.0``.
+           Mixing a BDF2 stencil with a Crank-Nicolson flux (``order=2`` +
+           ``theta=0.5``) centres the two sides at different times and is
+           **not** a consistent second-order scheme. In
+           :class:`~underworld3.systems.solvers.SNES_AdvectionDiffusion` the
+           advective ``DuDt`` carries this BDF ``order`` while the diffusive
+           ``DFDt`` carries the θ-method flux — set them as a matched pair.
     smoothing : float, default=0.0
         Smoothing parameter for projections.
     preserve_moments : bool, default=False
@@ -1393,6 +1421,24 @@ class SemiLagrangian(uw_object):
     - Problems where CFL stability is restrictive
     - Viscoelastic stress advection
 
+    The time-derivative (BDF ``order``) and the diffusive flux integrator
+    (Adams-Moulton ``theta``) are separate choices that must be paired
+    consistently — see ``order`` and ``theta`` above and the discussion in
+    ``docs/advanced/semi-lagrangian-time-integration.md``.
+
+    References
+    ----------
+    Spiegelman, M., & Katz, R. F. (2006). A semi-Lagrangian Crank-Nicolson
+    algorithm for the numerical solution of advection-diffusion problems.
+    *Geochemistry, Geophysics, Geosystems*, 7(4).
+    https://doi.org/10.1029/2005GC001073
+
+    Bonaventura, L., Calzola, E., Carlini, E., & Ferretti, R. (2021).
+    Second order fully semi-Lagrangian discretizations of
+    advection-diffusion-reaction systems. *Journal of Scientific Computing*,
+    88, 23. https://doi.org/10.1007/s10915-021-01518-8 — SL-BDF2 reaches
+    second order while avoiding the spurious resonance of CN-type schemes.
+
     See Also
     --------
     Eulerian : For fixed-mesh time derivatives without advection.
@@ -1419,6 +1465,7 @@ class SemiLagrangian(uw_object):
         with_forcing_history: bool = False,
         monotone_mode: Optional[str] = None,
         theta: float = 0.5,
+        old_frame_traceback: bool = False,
     ):
         super().__init__()
 
@@ -1458,6 +1505,36 @@ class SemiLagrangian(uw_object):
         # Settable after construction:
         #   ``adv_diff.DuDt.theta = 1.0``
         self.theta = float(theta)
+
+        # Old-frame semi-Lagrangian reach-back (Stage 0 of the
+        # lagged-clone design, docs/developer/design/
+        # lagged-clone-sl-history.md). On a moving mesh the standard
+        # ALE trace-back samples the CARRY'd history on the NEW
+        # geometry and subtracts v_mesh = Δx/dt to compensate the node
+        # motion. That fold is lossy at a disequilibrium free surface
+        # (it re-interpolates the new mesh for the exact-by-construction
+        # old nodal value, and leaves a spurious normal component) and
+        # blows up high-Ra free-surface convection (~step 20, Ra=1e5).
+        #
+        # With ``old_frame_traceback=True`` the trace-back instead:
+        #   * computes the departure foot from the PHYSICAL velocity
+        #     only (no v_mesh — V_fn must be the physical velocity, NOT
+        #     v − v_mesh), x_dep = x_new − dt·V(x_new − ½dt·V); and
+        #   * samples ``psi_star`` on the mesh EPHEMERALLY restored to
+        #     the previous-step (old) geometry, where the foot is always
+        #     representable (the old domain covers the vacated layer).
+        # Mesh motion is then exact (known old node positions) and only
+        # the physical advection is approximate, sampled where it is
+        # always interpolable. ``on_remesh`` stashes the old geometry;
+        # ``update_pre_solve`` consumes it. Mesh-agnostic: works for a
+        # free surface or interior-node (mmpde/OT) adaptation alike.
+        #
+        # Settable after construction:
+        #   ``adv_diff.DuDt.old_frame_traceback = True``
+        self.old_frame_traceback = bool(old_frame_traceback)
+        # One-step stash of the previous-step (old) geometry, set by
+        # ``on_remesh`` and consumed (cleared) by ``update_pre_solve``.
+        self._oldframe_X = None
 
         # Forcing-history storage. Allocated only if requested. Populated
         # each step via update_forcing_history(forcing_fn) — used by ETD-2
@@ -1778,10 +1855,23 @@ class SemiLagrangian(uw_object):
                     for v in owned if v in ctx.managed_snapshot}
             remap_var_set(self.mesh, owned,
                           ctx.old_X, ctx.new_X, snap)
-            # The ALE pulse is meaningless on a reset; clear any
-            # pending displacement so the next solve does a plain
-            # trace-back.
+            # The ALE pulse / old-frame reach are meaningless on a
+            # discrete reset; clear any pending state so the next solve
+            # does a plain (current-mesh) trace-back.
             self._pending_v_mesh_disp = None
+            self._oldframe_X = None
+            return
+
+        # Old-frame reach-back: don't build a v_mesh pulse at all.
+        # Stash the geometry the CARRY'd history corresponds to (the
+        # mesh as of the last solve) so the next ``update_pre_solve``
+        # can sample ``psi_star`` on it. The history .data is unchanged
+        # (CARRY), so across multiple adapts before one solve we keep
+        # the EARLIEST old_X — the geometry the data actually belongs
+        # to — rather than overwriting with each intermediate move.
+        if self.old_frame_traceback:
+            if self._oldframe_X is None:
+                self._oldframe_X = np.asarray(ctx.old_X).copy()
             return
 
         # Standard ALE: leave CARRY'd .data alone, accumulate Δx for
@@ -2232,6 +2322,19 @@ class SemiLagrangian(uw_object):
         if not self._history_initialised:
             self.initialise_history()
 
+        # Old-frame reach-back (mutually exclusive with the ALE pulse:
+        # ``on_remesh`` stashes ``_oldframe_X`` INSTEAD of a v_mesh disp,
+        # so ``_ale_active`` is False below whenever this is True). When
+        # active the foot is computed from the physical V (no v_mesh) and
+        # ``psi_star`` is sampled on the mesh ephemerally restored to the
+        # old geometry — see the ``global_evaluate`` block in the loop.
+        # Computed up here because it also governs how psi_star[0] is
+        # re-recorded (direct nodal carry, not a lossy re-evaluate on the
+        # deformed mesh).
+        _oldframe_active = (self.old_frame_traceback
+                            and self._oldframe_X is not None)
+        _oldframe_X = self._oldframe_X
+
         # Refresh the source-snapshot variable so the projection's source
         # field captures psi_star[0]'s state from BEFORE this step's solve.
         # Per-step memcpy keeps the snapshot machinery aligned with
@@ -2339,8 +2442,18 @@ class SemiLagrangian(uw_object):
                 # evaluate path bit-identically; non-scalar / expression psi_fn
                 # falls back to evaluate(). Proper fix (remap-on-adapt / ALE)
                 # tracked separately.
+                # Old-frame: record the history by a DIRECT nodal carry
+                # of the field rather than re-evaluating psi_fn at the
+                # (centroid-shifted) nodes of the DEFORMED mesh. The
+                # re-evaluate injects boundary-layer interpolation error
+                # that grows with mesh distortion and then rides the
+                # old-geometry sample below — the exact value we want is
+                # the carried nodal value (cf. the lagged-clone "store
+                # primitives" principle). Reuses the parallel direct-copy
+                # path, which returns None for non-scalar / expression
+                # psi_fn (those fall back to evaluate).
                 _direct = (self._record_psi_star_from_field_data()
-                           if uw.mpi.size > 1 else None)
+                           if (uw.mpi.size > 1 or _oldframe_active) else None)
                 if _direct is not None:
                     eval_result = _direct
                 else:
@@ -2606,8 +2719,16 @@ class SemiLagrangian(uw_object):
             # Calculate upstream coordinates: current position - velocity * timestep
             end_pt_coords = coords - v_at_mid_pts * dt_for_calc
 
-            # Clamp upstream coordinates to the domain boundary
-            if self.mesh.return_coords_to_bounds is not None:
+            # Clamp upstream coordinates to the domain boundary.
+            # Skipped under old-frame: the foot is sampled on the OLD
+            # geometry, whose domain covers the layer the moving surface
+            # vacated; clamping to the new-mesh / construction-time
+            # bounds would pull valid old-domain feet onto the boundary.
+            # The monotone limiter on the sample below bounds any foot
+            # that does fall outside the old mesh (matches the validated
+            # prototype, which omits this clamp).
+            if (self.mesh.return_coords_to_bounds is not None
+                    and not _oldframe_active):
                 end_pt_coords = self.mesh.return_coords_to_bounds(end_pt_coords)
 
             # Extract scalar from (1,1) Matrix for scalar variables
@@ -2631,12 +2752,32 @@ class SemiLagrangian(uw_object):
             # option (uw.function.global_evaluate), so any resampling
             # path can request the same bounded result. monotone_mode is
             # None in the default trajectory → no-op (bit-identical).
-            value_at_end_points = uw.function.global_evaluate(
-                expr_to_evaluate,
-                end_pt_coords,
-                evalf=evalf,
-                monotone=monotone_mode,
-            )
+            # Old-frame: sample psi_star on the mesh ephemerally
+            # restored to the previous-step (old) geometry. The foot
+            # (end_pt_coords) was computed in the current frame from the
+            # physical velocity; the old mesh covers the old domain so
+            # the foot is representable there with no extrapolation.
+            # ``ephemeral_coords`` snapshots the current (new) geometry
+            # and restores it on exit; ``_deform_mesh`` only rebuilds the
+            # DS / DOF-coordinate caches, leaving every variable's nodal
+            # .data untouched (de-risked: bit-identical round-trip), so
+            # psi_star realises "the old field on the old geometry".
+            if _oldframe_active:
+                with self.mesh.ephemeral_coords():
+                    self.mesh._deform_mesh(_oldframe_X)
+                    value_at_end_points = uw.function.global_evaluate(
+                        expr_to_evaluate,
+                        end_pt_coords,
+                        evalf=evalf,
+                        monotone=monotone_mode,
+                    )
+            else:
+                value_at_end_points = uw.function.global_evaluate(
+                    expr_to_evaluate,
+                    end_pt_coords,
+                    evalf=evalf,
+                    monotone=monotone_mode,
+                )
 
             # CRITICAL FIX (2025-11-27): If psi_star has units, ensure the assigned
             # value also has units. global_evaluate may return plain arrays.
@@ -2691,6 +2832,12 @@ class SemiLagrangian(uw_object):
         # consumption clears the lot.
         if _ale_active:
             self._consume_ale_pulse()
+
+        # Old-frame: consume the one-step old-geometry stash. The next
+        # adapt re-stashes; a non-adapting step sees None and traces
+        # back on the current mesh (old geom == new geom).
+        if _oldframe_active:
+            self._oldframe_X = None
 
         return
 

--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -3192,7 +3192,34 @@ class SNES_AdvectionDiffusion(SNES_Scalar):
     V_fn : MeshVariable or sympy.Basic
         Velocity field for advection.
     order : int, default=1
-        Time integration order (1 or 2).
+        Time integration order. Note the scheme has **two** order knobs that
+        must be paired consistently (see ``theta``):
+
+        - the advective time-derivative ``DuDt`` carries the **BDF** order of
+          the backward difference along the characteristic;
+        - the diffusive flux ``DFDt`` carries the **Adams-Moulton/θ** flux
+          integrator.
+
+        When ``DuDt`` is built internally (``DuDt=None``) it is fixed at BDF
+        order 1, so this ``order`` raises only the *flux* AM order — i.e.
+        ``order=1, theta=0.5`` is the canonical **SLCN** (BDF1 difference +
+        Crank-Nicolson flux), the standard second-order scheme. To run
+        **SL-BDF2** (BDF2 difference + Backward-Euler-centred flux, second
+        order without CN's spurious resonance) supply an explicit order-2
+        ``DuDt`` and set ``theta=1.0`` on the flux:
+
+        .. code-block:: python
+
+           duDt = uw.systems.ddt.SemiLagrangian(
+               mesh, T.sym, V_fn, vtype=uw.VarType.SCALAR,
+               degree=T.degree, continuous=T.continuous, order=2)
+           adv = uw.systems.AdvDiffusionSLCN(mesh, T, V_fn, DuDt=duDt, order=1)
+           adv.DFDt.theta = 1.0   # flux implicit at n+1 (BDF2-consistent)
+
+        A BDF2 stencil with a Crank-Nicolson flux (``order=2`` + ``theta=0.5``)
+        centres the two sides at different times and is **not** a consistent
+        second-order scheme. See
+        ``docs/advanced/semi-lagrangian-time-integration.md``.
     restore_points_func : callable, optional
         Function to restore particles to valid domain.
     verbose : bool, default=False
@@ -3237,6 +3264,23 @@ class SNES_AdvectionDiffusion(SNES_Scalar):
           SLCN+CN ringing dominates the discretisation error.
         - ``0.0``: Forward Euler — unstable for stiff diffusion;
           included for completeness.
+    old_frame_traceback : bool, default=False
+        Use the old-frame semi-Lagrangian reach-back for the advective
+        ``DuDt`` history on a moving mesh (free surface or interior-node
+        adaptation). Forwarded to the internally-constructed ``DuDt``
+        only — the diffusive ``DFDt`` keeps the standard ALE path
+        (validated sufficient at Ra=1e5; the unstable mode rides the
+        advective scalar, not the dissipative flux).
+
+        When ``True``, the trace-back computes the departure foot from
+        the PHYSICAL velocity and samples ``psi_star`` on the mesh
+        ephemerally restored to the previous-step geometry, instead of
+        the lossy ``v_mesh = Δx/dt`` fold on the new mesh. This cures the
+        high-Ra free-surface convection blow-up (T leaves [0,1] ~step 20
+        at Ra=1e5). **Contract:** pass the physical velocity as
+        ``V_fn`` (NOT ``v − v_mesh``) — the old-frame trace-back must not
+        double-compensate the mesh motion. See
+        ``docs/developer/design/lagged-clone-sl-history.md``.
 
     Notes
     -----
@@ -3249,6 +3293,11 @@ class SNES_AdvectionDiffusion(SNES_Scalar):
     algorithm for the numerical solution of advection-diffusion problems.
     *Geochemistry, Geophysics, Geosystems*, 7(4).
     https://doi.org/10.1029/2005GC001073
+
+    Bonaventura, L., Calzola, E., Carlini, E., & Ferretti, R. (2021). Second
+    order fully semi-Lagrangian discretizations of advection-diffusion-reaction
+    systems. *Journal of Scientific Computing*, 88, 23.
+    https://doi.org/10.1007/s10915-021-01518-8 (SL-BDF2 vs SL-CN).
 
     See Also
     --------
@@ -3279,6 +3328,7 @@ class SNES_AdvectionDiffusion(SNES_Scalar):
         DFDt: Union[SemiLagrangian_DDt, Lagrangian_DDt] = None,
         monotone_mode: Optional[str] = None,
         theta: float = 0.5,
+        old_frame_traceback: bool = False,
     ):
         ## Parent class will set up default values etc
         super().__init__(
@@ -3326,6 +3376,7 @@ class SNES_AdvectionDiffusion(SNES_Scalar):
                 smoothing=0.0,
                 monotone_mode=monotone_mode,
                 theta=theta,
+                old_frame_traceback=old_frame_traceback,
             )
 
         else:

--- a/tests/test_0855_oldframe_sl_traceback.py
+++ b/tests/test_0855_oldframe_sl_traceback.py
@@ -1,0 +1,256 @@
+"""Regression tests for the old-frame semi-Lagrangian reach-back.
+
+On a moving mesh the standard ALE trace-back samples the CARRY'd SL
+history on the NEW geometry and subtracts ``v_mesh = Δx/dt`` to
+compensate the node motion. That fold is lossy at a disequilibrium free
+surface and blows up high-Ra free-surface convection. The cure
+(``DuDt.old_frame_traceback = True``) computes the departure foot from
+the physical velocity and samples ``psi_star`` on the mesh EPHEMERALLY
+restored to the previous-step (old) geometry — where the foot is always
+representable.
+
+These lock the *mechanism* (Stage 0 of the lagged-clone design):
+
+* no-op when the mesh does not move (bit-identical to the standard path);
+* the working mesh geometry is restored after each step (the old-geometry
+  sampling is genuinely ephemeral) and the one-step stash is consumed;
+* the history is sampled on the OLD geometry, not the new one;
+* the field stays bounded on a moving mesh (with the monotone limiter);
+* BDF2 (order-2, two history levels) runs and stays bounded.
+
+The full high-Ra free-surface convection cure (T∈[0,1] at Ra=1e5) is
+validated end-to-end by a heavier driver script
+(``~/+Simulations/fs_convection_goal4/oldframe_release_validation.py``);
+it is too slow for the unit suite.
+
+See ``docs/developer/design/lagged-clone-sl-history.md``.
+"""
+
+import numpy as np
+import pytest
+
+import underworld3 as uw
+
+pytestmark = [pytest.mark.level_1, pytest.mark.tier_a]
+
+_OMEGA = 0.6  # solid-body rotation rate for the (divergence-free) velocity
+
+
+def _build(old_frame, order=1, res=8, kappa=1.0e-2, monotone_mode="clamp",
+           flux_theta=0.5):
+    """A small annulus carrying a rotation velocity and an advected scalar.
+
+    No Stokes solve — the velocity is a prescribed solid-body rotation
+    (divergence-free, tangential to the annulus boundaries) so the tests
+    are fast and isolate the SL trace-back.
+    """
+    mesh = uw.meshing.Annulus(
+        radiusInner=0.5, radiusOuter=1.0, cellSize=1.0 / res, qdegree=3)
+
+    T = uw.discretisation.MeshVariable("T", mesh, 1, degree=3)
+    v = uw.discretisation.MeshVariable("v", mesh, mesh.dim, degree=2)
+
+    # Solid-body rotation v = Ω (−y, x): divergence-free, v·n̂ = 0 on the
+    # circular arcs, so it neither compresses T nor pushes it across the
+    # boundary — T stays bounded under exact advection.
+    vc = np.asarray(v.coords)
+    v.data[:, 0] = -_OMEGA * vc[:, 1]
+    v.data[:, 1] = _OMEGA * vc[:, 0]
+
+    # Smooth initial scalar bump, strictly inside [0, 1].
+    tc = np.asarray(T.coords)
+    r2 = (tc[:, 0] - 0.72) ** 2 + tc[:, 1] ** 2
+    T.data[:, 0] = np.exp(-r2 / 0.05)
+
+    # Always build the DuDt explicitly so the ONLY difference between the
+    # old_frame on/off cases is the flag (the default solver path hardcodes
+    # order 1 and uses different projection bcs, which would confound the
+    # bit-identical comparison). An explicit DuDt also lets BDF2 genuinely
+    # allocate two history levels.
+    #
+    # The advective DuDt carries the BDF order; the diffusive DFDt is kept
+    # as the order-1 Adams-Moulton θ-method flux (so the two scheme knobs
+    # are paired explicitly, not coupled). SLCN = order 1 + flux_theta 0.5;
+    # SL-BDF2 = order 2 + flux_theta 1.0 (flux implicit at n+1 — a BDF2
+    # stencil with a CN flux is inconsistent).
+    duDt = uw.systems.ddt.SemiLagrangian(
+        mesh, T.sym, v.sym,
+        vtype=uw.VarType.SCALAR, degree=T.degree,
+        continuous=T.continuous, varsymbol=T.symbol,
+        bcs=[], order=order, smoothing=0.0,
+        monotone_mode=monotone_mode, theta=0.5,
+        old_frame_traceback=old_frame,
+    )
+    adv_diff = uw.systems.AdvDiffusionSLCN(
+        mesh, u_Field=T, V_fn=v.sym, DuDt=duDt, order=1)
+    adv_diff.DFDt.theta = flux_theta
+
+    adv_diff.constitutive_model = uw.constitutive_models.DiffusionModel
+    adv_diff.constitutive_model.Parameters.diffusivity = kappa
+    return mesh, T, v, adv_diff
+
+
+def _wobble(X0, amp, phase=0.0):
+    """A smooth mode-3 radial perturbation of the annulus INTERIOR.
+
+    Computed from a FIXED reference geometry ``X0`` (not the current,
+    already-moved coordinates) so repeated calls do not compound into a
+    tangled mesh. ``phase`` rotates the mode-3 pattern so successive
+    steps genuinely move the nodes. Tapered to zero at BOTH boundaries
+    (peak at mid-annulus), so the arcs stay put and the tangential
+    rotation velocity keeps v·n̂ = 0 — no throughflow. Moves only
+    interior nodes: also the interior-node (mmpde/OT) adaptation regime
+    of Task 2, and the cleanest setting to isolate the SL trace-back
+    from boundary BC effects.
+    """
+    c = np.asarray(X0)
+    r = np.sqrt((c ** 2).sum(1))
+    th = np.arctan2(c[:, 1], c[:, 0])
+    s = np.clip((r - 0.5) / 0.5, 0.0, 1.0)  # 0 at inner, 1 at outer
+    bump = np.sin(np.pi * s)                # 0 at both boundaries
+    rad = r + amp * bump * np.cos(3.0 * th - phase)
+    out = c.copy()
+    nz = r > 1.0e-12
+    out[nz, 0] = rad[nz] * np.cos(th[nz])
+    out[nz, 1] = rad[nz] * np.sin(th[nz])
+    return out
+
+
+def _gmin_gmax(field_col):
+    """Mesh-global (parallel-safe) min/max of a 1-D nodal column."""
+    comm = uw.mpi.comm
+    field_col = np.asarray(field_col)
+    lo = field_col.min() if field_col.size else np.inf
+    hi = field_col.max() if field_col.size else -np.inf
+    return (comm.allreduce(lo, op=uw.mpi._MPI.MIN),
+            comm.allreduce(hi, op=uw.mpi._MPI.MAX))
+
+
+def test_oldframe_noop_on_static_mesh_is_bit_identical():
+    """With no mesh motion, old_frame never fires (no on_remesh) so the
+    trajectory is bit-identical to the standard trace-back."""
+    dt = 0.01
+
+    _, T_off, _, ad_off = _build(old_frame=False)
+    for _ in range(4):
+        ad_off.solve(timestep=dt)
+    ref = T_off.data.copy()
+
+    _, T_on, _, ad_on = _build(old_frame=True)
+    for _ in range(4):
+        ad_on.solve(timestep=dt)
+    got = T_on.data.copy()
+
+    assert np.array_equal(ref, got), (
+        "old_frame must be a no-op on a non-moving mesh "
+        f"(max|Δ|={np.abs(ref - got).max():.3e})")
+
+
+def test_oldframe_restores_geometry_and_consumes_stash():
+    """The old-geometry sampling is ephemeral: after a deform+solve the
+    mesh sits at the committed (new) geometry and the one-step stash is
+    cleared."""
+    dt = 0.01
+    mesh, T, v, adv_diff = _build(old_frame=True)
+
+    target = _wobble(np.asarray(mesh.X.coords), amp=0.03)
+    mesh.deform(target, dt=dt)
+    assert adv_diff.DuDt._oldframe_X is not None, (
+        "on_remesh should stash the old geometry for old_frame")
+
+    adv_diff.solve(timestep=dt)
+
+    after = np.asarray(mesh.X.coords)
+    assert np.allclose(after, target, atol=1.0e-12), (
+        "ephemeral old-geometry sampling must restore the committed "
+        f"geometry (max|Δ|={np.abs(after - target).max():.3e})")
+    assert adv_diff.DuDt._oldframe_X is None, (
+        "the one-step old-geometry stash must be consumed by update_pre_solve")
+
+
+def test_oldframe_samples_on_old_geometry_not_new():
+    """The history is sampled on the previous-step geometry.
+
+    Drive ``update_pre_solve`` directly with ``store_result=False`` (so
+    the history is advected, not re-recorded — isolating the trace-back
+    sample) at ``dt=0`` (foot == node coords). The resulting ``psi_star``
+    must match an independent OLD-geometry sample of the (carried)
+    history at the foot, and must differ from the NEW-geometry sample —
+    proving the ephemeral restore samples the previous-step geometry.
+    """
+    mesh, T, v, adv_diff = _build(old_frame=True, kappa=0.0)
+    duDt = adv_diff.DuDt
+    duDt.initialise_history()  # psi_star[0] := T on the initial (old) geometry
+
+    old_X = np.asarray(mesh.X.coords).copy()  # geometry the history belongs to
+    new_X = _wobble(old_X, amp=0.05)
+    mesh.deform(new_X, dt=1.0)  # on_remesh stashes old_X; psi_star CARRY'd
+    assert duDt._oldframe_X is not None
+
+    psi0 = duDt.psi_star[0]
+    foot = np.asarray(psi0.coords).copy()  # dt=0 → departure foot == nodes
+
+    # Independent references: sample the (unmodified) history at `foot` on
+    # each geometry, BEFORE update_pre_solve overwrites psi_star[0].
+    with mesh.ephemeral_coords():
+        mesh._deform_mesh(old_X)
+        ref_old = np.asarray(
+            uw.function.global_evaluate(psi0.sym[0], foot, monotone="clamp")
+        ).flatten()
+    ref_new = np.asarray(
+        uw.function.global_evaluate(psi0.sym[0], foot, monotone="clamp")
+    ).flatten()
+
+    duDt.update_pre_solve(0.0, store_result=False)
+    got = np.asarray(psi0.data[:, 0]).copy()
+
+    assert np.allclose(got, ref_old, atol=1.0e-9), (
+        "old_frame psi_star must match the OLD-geometry sample "
+        f"(max|Δ|={np.abs(got - ref_old).max():.3e})")
+    # The two geometries genuinely differ where the interior moved, so
+    # the old/new samples must not be identical (else the test proves
+    # nothing). Check GLOBALLY — under MPI the moved region may live on a
+    # single rank, so a per-rank check would spuriously coincide.
+    local_diff = float(np.abs(ref_old - ref_new).max()) if ref_old.size else 0.0
+    global_diff = uw.mpi.comm.allreduce(local_diff, op=uw.mpi._MPI.MAX)
+    assert global_diff > 1.0e-6, (
+        "test setup error: old and new geometry samples coincide globally")
+
+
+def test_oldframe_keeps_field_bounded_on_moving_mesh():
+    """Advect-and-deform for several steps; with the monotone limiter the
+    old-frame trace-back keeps the scalar inside its physical range."""
+    dt = 0.01
+    mesh, T, v, adv_diff = _build(old_frame=True, monotone_mode="clamp")
+
+    X0 = np.asarray(mesh.X.coords).copy()
+    lo0, hi0 = _gmin_gmax(T.data[:, 0])
+    for s in range(6):
+        mesh.deform(_wobble(X0, amp=0.03, phase=0.6 * s), dt=dt)
+        adv_diff.solve(timestep=dt)
+        lo, hi = _gmin_gmax(T.data[:, 0])
+        # The decisive property is boundedness: the standard ALE fold
+        # diverges to O(100) on the violent high-Ra free surface, while
+        # old-frame stays in range. Allow modest SLCN/CN ringing.
+        assert lo > -1.0e-2, f"step {s}: undershoot {lo:.3e} (divergence?)"
+        assert hi < hi0 + 1.0e-2, f"step {s}: overshoot {hi:.3e} (init {hi0:.3e})"
+
+
+def test_oldframe_sl_bdf2_runs_and_stays_bounded():
+    """Proper SL-BDF2 (BDF2 time-difference + flux implicit at n+1, θ=1):
+    order-2 allocates two history levels; the 'one clone, any order'
+    reach-back keeps the field bounded."""
+    dt = 0.01
+    mesh, T, v, adv_diff = _build(old_frame=True, order=2, monotone_mode="clamp",
+                                  flux_theta=1.0)  # SL-BDF2 flux centring
+    assert len(adv_diff.DuDt.psi_star) == 2, "BDF2 must allocate two history levels"
+    assert adv_diff.DFDt.theta == 1.0, "SL-BDF2 flux must be implicit at n+1 (θ=1)"
+
+    X0 = np.asarray(mesh.X.coords).copy()
+    _, hi0 = _gmin_gmax(T.data[:, 0])
+    for s in range(6):
+        mesh.deform(_wobble(X0, amp=0.03, phase=0.6 * s), dt=dt)
+        adv_diff.solve(timestep=dt)
+        lo, hi = _gmin_gmax(T.data[:, 0])
+        assert lo > -1.0e-2, f"BDF2 step {s}: undershoot {lo:.3e} (divergence?)"
+        assert hi < hi0 + 1.0e-2, f"BDF2 step {s}: overshoot {hi:.3e}"


### PR DESCRIPTION
## Summary

Cures the high-Ra free-surface semi-Lagrangian blow-up by sampling the SL history on the **previous-step mesh geometry** instead of the lossy `v_mesh = Δx/dt` fold on the new mesh. This is **Stage 0** of the lagged-clone design (`docs/developer/design/lagged-clone-sl-history.md`) — the minimal subset that delivers the correctness fix with no new infrastructure (no mesh clone, no mixed-mesh evaluator).

**Opt-in, default off** — the standard ALE path is bit-unchanged. Builds on the already-merged capability gate / `Mesh.deform` / `ephemeral_coords` / SL-field CARRY auto-stamp (#246) and the design note (#249).

## Mechanism (`systems/ddt.py` `SemiLagrangian`)

`old_frame_traceback=True` (forwarded via `AdvDiffusionSLCN(..., old_frame_traceback=True)` to the advective `DuDt` only — the diffusive `DFDt` keeps stock ALE):

1. `on_remesh` stashes the old geometry instead of a `v_mesh` pulse; leaves `psi_star` CARRY'd.
2. `update_pre_solve` computes the departure foot from the **physical** velocity, records `psi_star` by **direct nodal carry**, and samples it inside `with mesh.ephemeral_coords(): mesh._deform_mesh(old_X); global_evaluate(...)`.
3. The one-step stash is consumed at end of step.

**Contract:** when enabled, pass the physical velocity as `V_fn` (not `v − v_mesh`).

## Validation

| run | worst T over 30 steps (Ra=1e5, res-20, free surface) |
|-----|------|
| baseline (stock ALE) | `[-311, +333]` — blow-up by ~step 20 |
| old-frame **SLCN** (BDF1 + CN, θ=0.5) | `[0.000, 1.000]` |
| old-frame **SL-BDF2** (BDF2 + flux at n+1, θ=1) | `[0.000, 1.000]` |

`h_max → 0.067`, Nu 12→55 (vigorous, not over-diffused). Through interior-node adaptation (`follow_metric`/`OT_adapt`) old-frame **matches or beats** the current `v_mesh` path with no regression (dramatically better bounded for anisotropic `follow_metric`).

`tests/test_0855_oldframe_sl_traceback.py` (5 tests: static-mesh no-op bit-identical; geometry restored + stash consumed; samples-on-old-geometry-not-new; bounded on a moving mesh; SL-BDF2) — passes **serial and np=2**. Existing `ddt` suite unchanged (opt-in, default off).

## Docs

- Documents the **SLCN vs SL-BDF2** time-integration pairing (BDF time-derivative + Adams–Moulton/θ flux must be matched; BDF2+CN is inconsistent) in the `SemiLagrangian` and `SNES_AdvectionDiffusion` docstrings, with references (Spiegelman & Katz 2006; Bonaventura et al. 2021).
- New `docs/advanced/semi-lagrangian-time-integration.md` (in the toctree; docs build verified).
- Appends a Stage-0 cost/benefit + recommendation to the lagged-clone design note: **ship Stage-0, defer the clone** (overhead +8% on the advection solve; the clone's payoff is efficiency / 2nd-order-temporal, not correctness).

## ⚠️ Do not merge yet

Per @lmoresi: hold until a full **RK4 convection movie** demonstration is ready. Opening for review.

## Follow-ups (separate sessions)

1. Convection model with **free surface AND mmpde adaptive meshing** together.
2. Evaluation of the **exponential integrator** with the free-slip / free-surface pairing.

Underworld development team with AI support from Claude Code