### PR TITLE
fix(meshing): extract_region no longer raises (#197)

### DIFF
--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -1914,9 +1914,21 @@ class Mesh(Stateful, uw_object):
         if hasattr(self, "_vertex_map") and self._vertex_map is not None:
             return self._vertex_map
 
-        # Use cached KDTree from coordinate variable
-        tree = self.X._get_kdtree()
-        dists, indices = tree.query(self.parent.X.coords_nd, sqr_dists=False)
+        # Build a KDTree directly on the coordinate arrays rather than
+        # ``self.X._get_kdtree()`` — ``mesh.X`` is a CoordinateSystem, which has
+        # no ``_get_kdtree`` (that lives on MeshVariable/swarm vars), so the old
+        # call raised AttributeError on every extract_region (UW3 issue #197).
+        # This mirrors the proven inline path in ``extract_surface``: submesh
+        # vertices are an exact subset of the parent's, so the 1e-10 coincidence
+        # match is bit-exact.
+        import underworld3 as _uw
+
+        sub_coords = numpy.asarray(self._coords)
+        parent_coords = numpy.asarray(self.parent._coords)
+        tree = _uw.kdtree.KDTree(sub_coords)
+        dists, indices = tree.query(parent_coords, sqr_dists=False)
+        dists = numpy.asarray(dists).reshape(-1)
+        indices = numpy.asarray(indices).reshape(-1)
         matched = dists < 1.0e-10
 
         # parent_rows[i] -> sub_rows[i]: matched vertex pairs

--- a/tests/test_0771_extract_region.py
+++ b/tests/test_0771_extract_region.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Regression test: Mesh.extract_region (codim-0 region submesh) — serial.
+
+extract_region was only covered by the parallel suite (test_0770); the serial
+path raised ``AttributeError: 'CoordinateSystem' object has no attribute
+'_get_kdtree'`` from ``_build_vertex_map`` (UW3 issue #197). ``mesh.X`` is a
+CoordinateSystem, which has no ``_get_kdtree`` — that method lives on
+MeshVariable / swarm variables. The fix builds the vertex-coincidence KDTree
+directly on the coordinate arrays, mirroring ``extract_surface``.
+"""
+import numpy as np
+import pytest
+
+import underworld3 as uw
+
+pytestmark = pytest.mark.level_1
+
+
+@pytest.fixture
+def shell():
+    return uw.meshing.AnnulusInternalBoundary(
+        radiusInner=0.4, radiusInternal=0.7, radiusOuter=1.0, cellSize=0.3
+    )
+
+
+def test_extract_region_does_not_raise(shell):
+    """The headline #197 symptom: extract_region must not raise."""
+    sub = shell.extract_region("Inner")
+    cStart, cEnd = sub.dm.getHeightStratum(0)
+    assert cEnd - cStart > 0, "Inner region submesh has no cells"
+
+
+def test_extract_region_vertex_map_is_consistent(shell):
+    """The vertex map pairs each matched submesh vertex with a parent vertex."""
+    sub = shell.extract_region("Inner")
+    sub_rows, parent_rows = sub._build_vertex_map()
+    assert len(sub_rows) == len(parent_rows)
+    assert len(sub_rows) > 0
+    # Matched pairs are bit-exact coincident coordinates (submesh ⊂ parent).
+    sub_coords = np.asarray(sub._coords)
+    parent_coords = np.asarray(shell._coords)
+    assert np.allclose(
+        sub_coords[sub_rows], parent_coords[parent_rows], atol=1.0e-10
+    )
+
+
+def test_extract_region_inner_radii_bounded(shell):
+    """The Inner region lies within [radiusInner, radiusInternal]."""
+    sub = shell.extract_region("Inner")
+    r = np.linalg.norm(np.asarray(sub._coords), axis=1)
+    # small tolerance for the faceted boundary
+    assert r.min() >= 0.4 - 0.05
+    assert r.max() <= 0.7 + 0.05


### PR DESCRIPTION
## Summary
`Mesh.extract_region()` raised `AttributeError: 'CoordinateSystem' object has no attribute '_get_kdtree'` on every call (issue #197). `_build_vertex_map` called `self.X._get_kdtree()`, but `mesh.X` is a `CoordinateSystem` — `_get_kdtree` lives on `MeshVariable`/swarm variables, not on it.

## Fix
Build the vertex-coincidence KDTree directly on the coordinate arrays, mirroring the proven inline path already used by `extract_surface` (which carried a comment explicitly flagging this same #197 breakage). Submesh vertices are an exact subset of the parent's, so the 1e-10 coincidence match is bit-exact.

## Why it shipped
`extract_region` had **only parallel coverage** (`test_0770`), which skips without `--with-mpi` and was red-but-not-gating (the branch has no required status checks). This PR adds **serial** regression tests (`test_0771_extract_region.py`).

## Verification (local, amr-dev env)
- serial repro on `AnnulusInternalBoundary` → fixed
- `test_0771_extract_region.py` → **3 passed**
- `test_0772_surface_extract.py` → **7 passed, 1 pre-existing xfail** (no regression)
- `test_0770_submesh_extract_mpi.py --with-mpi -np 2` → **6 passed**

Closes #197.

Underworld development team with AI support from Claude Code