### PR TITLE
cleanup(xdmf/snapshot): silence internal write_checkpoint FutureWarning + drop dead cell_dim read (#252)

### DIFF
--- a/src/underworld3/checkpoint/disk_snapshot.py
+++ b/src/underworld3/checkpoint/disk_snapshot.py
@@ -38,6 +38,7 @@ import dataclasses
 import datetime
 import json
 import os
+import warnings
 from typing import Any, Optional
 
 import numpy as np
@@ -311,12 +312,20 @@ def write_snapshot(model, path: str) -> str:
         # path: lazy-allocated vars with _gvec == None have no data.
         mesh_vars = [v for v in mesh_vars if v._gvec is not None]
 
-        mesh.write_checkpoint(
-            mesh_safe,
-            outputPath=bulk_dir,
-            meshVars=mesh_vars,
-            index=0,
-        )
+        # write_checkpoint is user-deprecated in favour of write_timestep, but
+        # the snapshot backend is a legitimate internal user: it relies on the
+        # `{base}.mesh.00000.h5` / `{base}.{var}.00000.h5` filename convention
+        # (consumed by the reload path below). Suppress the FutureWarning for
+        # this internal call rather than spam every snapshot. (Migrating the
+        # snapshot to write_timestep is tracked in #252.)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
+            mesh.write_checkpoint(
+                mesh_safe,
+                outputPath=bulk_dir,
+                meshVars=mesh_vars,
+                index=0,
+            )
 
         mesh_records.append({
             "name": mesh.name,

--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -6039,7 +6039,6 @@ def checkpoint_xdmf(
         )
     numCells = cells.shape[0]
     numCorners = cells.shape[1]
-    cellDim = topo["cells"].attrs["cell_dim"]
     topology_precision = cells.dtype.itemsize
 
     if numCorners <= 1:


### PR DESCRIPTION
Addresses items 1 & 2 of #252 (follow-ups from the #218 review):

1. **Snapshot FutureWarning spam.** `disk_snapshot._write_disk_snapshot` calls the user-deprecated `mesh.write_checkpoint` — but it's a *legitimate internal* user (it depends on the `.mesh.00000.h5`/`.<var>.00000.h5` filename convention its own reload path reads, which `write_timestep` does not produce). Wrapped in `warnings.catch_warnings()` + ignore `FutureWarning` so every persistent snapshot no longer emits a deprecation warning. Full migration to `write_timestep` left as the larger item in #252.
2. **Dead `cell_dim` read.** `checkpoint_xdmf` read `topo["cells"].attrs["cell_dim"]` into `cellDim` but never used it (precision now derives from `cells.dtype.itemsize`). Removed — a needless dependency on a PETSc-internal attr name that could `KeyError`.

**Item 3** (unify the swarmVar HyperSlab XDMF block with the flattened meshVar form) is **deferred** — cosmetic, ParaView-sensitive, no easy local validation. Left open in #252.

## Verification (amr-dev)
- `test_0007`/`test_0008` (snapshot) pass with `-W error::FutureWarning` → 26/26 (confirms the disk path no longer leaks the warning).
- `test_0003` (save/load) + `test_0005` (xdmf) green → 39/39 total.

Underworld development team with AI support from Claude Code