### PR TITLE
fix(meshing): SPD-floor the mmpde metric to stop silent NaN-bail on deformed meshes

### DIFF
--- a/src/underworld3/meshing/smoothing.py
+++ b/src/underworld3/meshing/smoothing.py
@@ -3164,6 +3164,40 @@ def _winslow_mmpde(mesh, metric, pinned_labels, verbose,
     else:
         _eval_M = _eval_M_analytic
 
+    # --- SPD sanitiser on the evaluated metric -------------------------
+    # The MMPDE functional G uses fractional powers that are defined ONLY
+    # for an SPD metric: sqrt(detM), detM**((1-p)/2), and S**q with
+    # S = tr(J M⁻¹ Jᵀ). The metric is a guide field FE-evaluated at the
+    # FIXED reference cloud; once the interior has deformed, a reference
+    # point can fall OUTSIDE the current mesh and the P1 metric field is
+    # then evaluated by FE EXTRAPOLATION (out-of-cell basis functions go
+    # negative), yielding a non-SPD tensor — e.g. a scalar density ρ·I
+    # with ρ<0. Its determinant ρ² stays positive (so a detM>0 test
+    # passes) but M is negative-definite, so S<0 and S**q = NaN → the
+    # energy is non-finite and the mover bails with zero displacement
+    # (no adaptation). Project every evaluated tensor onto SPD with a
+    # small RELATIVE eigenvalue floor: a genuine SPD metric is returned
+    # unchanged (no-op), while extrapolation garbage becomes a benign
+    # "coarsen here" (tiny positive eigenvalues) instead of a NaN.
+    _eval_M_raw = _eval_M
+
+    def _spd_sanitise(M):
+        Ms = 0.5 * (M + np.swapaxes(M, -1, -2))
+        w, Vc = np.linalg.eigh(Ms)
+        if w.size:
+            wmax = float(np.nanmax(w))
+        else:
+            wmax = 1.0
+        floor = max(wmax, 1.0) * 1.0e-8
+        if np.all(np.isfinite(w)) and float(w.min()) >= floor:
+            return Ms                                   # already SPD → no-op
+        w = np.clip(np.nan_to_num(w, nan=floor, posinf=wmax, neginf=floor),
+                    floor, None)
+        return np.einsum('nij,nj,nkj->nik', Vc, w, Vc)
+
+    def _eval_M(pts):
+        return _spd_sanitise(_eval_M_raw(pts))
+
     # Mesh-owned boundary slip is applied per outer iter via mesh.boundary_slip
     # (below). Pre-touch Gamma_P1 here so the projected-normal MeshVariable
     # exists before any DM snapshot (footgun-safe; redundant with the central

--- a/src/underworld3/meshing/smoothing.py
+++ b/src/underworld3/meshing/smoothing.py
@@ -3182,18 +3182,26 @@ def _winslow_mmpde(mesh, metric, pinned_labels, verbose,
     _eval_M_raw = _eval_M
 
     def _spd_sanitise(M):
+        # Symmetrise: the metric is symmetric by construction, so for a valid
+        # tensor this is an exact no-op (M_ij == M_ji bit-for-bit).
         Ms = 0.5 * (M + np.swapaxes(M, -1, -2))
+        if Ms.shape[0] == 0:
+            return Ms                                   # rank owns no cells
         w, Vc = np.linalg.eigh(Ms)
-        if w.size:
-            wmax = float(np.nanmax(w))
-        else:
-            wmax = 1.0
+        wmax = float(np.nanmax(w))
         floor = max(wmax, 1.0) * 1.0e-8
-        if np.all(np.isfinite(w)) and float(w.min()) >= floor:
-            return Ms                                   # already SPD → no-op
-        w = np.clip(np.nan_to_num(w, nan=floor, posinf=wmax, neginf=floor),
-                    floor, None)
-        return np.einsum('nij,nj,nkj->nik', Vc, w, Vc)
+        # Per-tensor SPD test: a cell is "bad" only if one of its OWN
+        # eigenvalues is non-finite or below the floor. Project just those
+        # cells; every already-SPD tensor is returned untouched (bit-identical
+        # to the symmetrised input), so one bad point cannot perturb the rest.
+        bad = ~np.isfinite(w).all(axis=1) | (w.min(axis=1) < floor)
+        if not bad.any():
+            return Ms
+        out = Ms.copy()
+        wf = np.clip(np.nan_to_num(w[bad], nan=floor, posinf=wmax, neginf=floor),
+                     floor, None)
+        out[bad] = np.einsum('nij,nj,nkj->nik', Vc[bad], wf, Vc[bad])
+        return out
 
     def _eval_M(pts):
         return _spd_sanitise(_eval_M_raw(pts))


### PR DESCRIPTION
## Problem

`_winslow_mmpde`'s energy/gradient use fractional powers — `sqrt(detM)`, `detM**((1-p)/2)`, and `S**q` with `S = tr(J·M⁻¹·Jᵀ)` — that are defined **only** for an SPD metric.

The metric is a guide field FE-evaluated at a **fixed reference cloud**. Once the interior deforms, a reference point can fall outside the current mesh and the P1 density is then evaluated by FE **extrapolation**, going negative. A scalar density `ρ<0` gives `M = ρ·I` with `det = ρ² > 0` — so a `detM>0` check passes — but `M` is **negative-definite**, so `S<0` and `S**q = NaN`. The energy becomes non-finite and the mover **bails with zero displacement**.

The effect is intermittent and silent: on an adaptive convection loop roughly half the adapts no-op, the mesh under-resolves, and the symptom is easily misread as an adapt/solver coupling problem or "passive-fault damping."

## Fix

Project every evaluated metric tensor onto SPD with a small **relative** eigenvalue floor at the single `_eval_M` chokepoint:

- a genuinely SPD metric is returned unchanged (short-circuit **no-op**, bit-identical on valid cells);
- extrapolation garbage becomes a benign "coarsen here" (tiny positive eigenvalues) instead of a NaN.

No API change. No behaviour change where the metric is already valid — verified bit-identical on the adapts that previously succeeded.

## Validation

- `test_0762_fault_metric_tensor`, `test_0850_mesh_smoothing`, `test_0750_meshing_follow_metric`, `test_0830_mesh_adapt_variable_transfer`: **33 passed, 5 skipped (MMG), 4 pre-existing xfail**.
- Stagnant-lid adaptive convection driver (Ra 1e6, res 24): with the fix all forced adapts move, T stays in `[0,1]`, vrms bounded over 52 steps (no-fault) and 32 steps (passive fault). Without it, ~half the adapts NaN-bail and the mesh stops adapting.

Underworld development team with AI support from Claude Code