### PR TITLE
Skip mesh view length-scale test without pyvista

### DIFF
--- a/tests/test_0815_mesh_length_scale.py
+++ b/tests/test_0815_mesh_length_scale.py
@@ -236,6 +236,11 @@ def test_length_units_matches_coordinate_units():
 )
 def test_mesh_view_displays_length_scale():
     """Test that mesh.view() displays length scale information."""
+    pytest.importorskip("pyvista")
+    pytest.importorskip("trame_client")
+    pytest.importorskip("trame_server")
+    pytest.importorskip("trame_vtk")
+
     uw.reset_default_model()
     model = uw.get_default_model()
 


### PR DESCRIPTION
This updates test_mesh_view_displays_length_scale() to skip when optional visualization dependencies are unavailable.

The test exercises mesh.view(), which depends on PyVista/trame visualization support. Without those optional dependencies, the length-scale logic tests pass, but the visualization-specific test fails with ModuleNotFoundError: No module named 'pyvista' or a pyvista[jupyter]/trame dependency error.

No solver or units-system logic is changed.

Tested with:

```bash
pixi run python -m pytest tests/test_0815_mesh_length_scale.py -vv
```

Result:

```text
10 passed, 1 skipped in 2.37s
```