### PR TITLE
Fix explicit flow grains script run

### DIFF
--- a/docs/examples/porous_flow/advanced/Ex_Explicit_Flow_Grains.py
+++ b/docs/examples/porous_flow/advanced/Ex_Explicit_Flow_Grains.py
@@ -69,6 +69,19 @@ nest_asyncio.apply()
 import numpy as np
 import sympy
 
+
+def in_notebook():
+    try:
+        from IPython import get_ipython
+    except ImportError:
+        return False
+
+    shell = get_ipython()
+    if shell is None:
+        return False
+
+    return shell.__class__.__name__ == "ZMQInteractiveShell"
+
 # %% [markdown]
 """
 ## Configurable Parameters
@@ -265,6 +278,7 @@ pipemesh = uw.discretisation.Mesh(
     refinement_callback=None,
     return_coords_to_bounds=pipemesh_return_coords_to_bounds,
     boundaries=boundaries,
+    coordinate_system_type=uw.coordinates.CoordinateSystemType.CARTESIAN,
     qdegree=3,
 )
 
@@ -279,7 +293,7 @@ y = pipemesh.N.y
 """
 
 # %%
-if uw.mpi.size == 1:
+if uw.mpi.size == 1 and in_notebook():
     import pyvista as pv
     import underworld3.visualisation as vis
 
@@ -489,7 +503,7 @@ with open(f"{expt_name}/Particle_numbers.txt", mode="w") as fp:
 """
 
 # %%
-if uw.mpi.size == 1:
+if uw.mpi.size == 1 and in_notebook():
     import pyvista as pv
     import underworld3.visualisation as vis
 


### PR DESCRIPTION
This updates docs/examples/porous_flow/advanced/Ex_Explicit_Flow_Grains.py so that the explicit grain-flow example runs correctly as a plain Python script.

The example failed during pipemesh.write_timestep(...) with:

AttributeError: 'NoneType' object has no attribute 'name'

The gmsh-created mesh did not have an explicit coordinate system, so self.CoordinateSystemType was None when the mesh writer serialized coordinate-system metadata. This PR sets:

coordinate_system_type=uw.coordinates.CoordinateSystemType.CARTESIAN

in the uw.discretisation.Mesh(...) constructor.

The example also imported PyVista during a terminal run. The visualization blocks are now guarded with a notebook check, so the solve, timestep writing, porosity calculation, and swarm advection path run without optional notebook visualization dependencies.

The gmsh geometry, boundary tags, Stokes setup, pressure projection, swarm advection, and output logic are otherwise unchanged.

Tested with:

pixi run python docs/examples/porous_flow/advanced/Ex_Explicit_Flow_Grains.py

Result:

Explicit grain flow example complete: 556 steps