### PR TITLE
fix(units): meshvar arithmetic with a UWQuantity operand (#282)

### DIFF
--- a/src/underworld3/utilities/mathematical_mixin.py
+++ b/src/underworld3/utilities/mathematical_mixin.py
@@ -246,6 +246,16 @@ class MathematicalMixin:
             other_sym = other
         elif isinstance(other, MathematicalMixin) and hasattr(other, "sym"):
             other_sym = other.sym
+        elif hasattr(other, "magnitude") and hasattr(other, "units"):
+            # Unit-bearing scalar (UWQuantity / Pint) -> non-dimensional value, so
+            # it composes with the variable's non-dimensional .sym. Compatible
+            # units reduce via the model scaling; sympy cannot operate on the Pint
+            # object directly (UW3 issue #282). Matches the transparent-container
+            # behaviour of variable-variable arithmetic (units derived on demand).
+            import underworld3 as uw
+
+            _nd = uw.non_dimensionalise(other)
+            other_sym = float(_nd.magnitude) if hasattr(_nd, "magnitude") else float(_nd)
         elif hasattr(other, "_sympify_"):
             other_sym = other._sympify_()
         else:
@@ -288,6 +298,16 @@ class MathematicalMixin:
             other_sym = other
         elif isinstance(other, MathematicalMixin) and hasattr(other, "sym"):
             other_sym = other.sym
+        elif hasattr(other, "magnitude") and hasattr(other, "units"):
+            # Unit-bearing scalar (UWQuantity / Pint) -> non-dimensional value, so
+            # it composes with the variable's non-dimensional .sym. Compatible
+            # units reduce via the model scaling; sympy cannot operate on the Pint
+            # object directly (UW3 issue #282). Matches the transparent-container
+            # behaviour of variable-variable arithmetic (units derived on demand).
+            import underworld3 as uw
+
+            _nd = uw.non_dimensionalise(other)
+            other_sym = float(_nd.magnitude) if hasattr(_nd, "magnitude") else float(_nd)
         elif hasattr(other, "_sympify_"):
             other_sym = other._sympify_()
         else:
@@ -322,6 +342,16 @@ class MathematicalMixin:
             other_sym = other
         elif isinstance(other, MathematicalMixin) and hasattr(other, "sym"):
             other_sym = other.sym
+        elif hasattr(other, "magnitude") and hasattr(other, "units"):
+            # Unit-bearing scalar (UWQuantity / Pint) -> non-dimensional value, so
+            # it composes with the variable's non-dimensional .sym. Compatible
+            # units reduce via the model scaling; sympy cannot operate on the Pint
+            # object directly (UW3 issue #282). Matches the transparent-container
+            # behaviour of variable-variable arithmetic (units derived on demand).
+            import underworld3 as uw
+
+            _nd = uw.non_dimensionalise(other)
+            other_sym = float(_nd.magnitude) if hasattr(_nd, "magnitude") else float(_nd)
         elif hasattr(other, "_sympify_"):
             other_sym = other._sympify_()
         else:
@@ -360,6 +390,13 @@ class MathematicalMixin:
             other_sym = other
         elif isinstance(other, MathematicalMixin) and hasattr(other, "sym"):
             other_sym = other.sym
+        elif hasattr(other, "magnitude") and hasattr(other, "units"):
+            # Unit-bearing scalar (UWQuantity / Pint) -> non-dimensional value
+            # (UW3 issue #282); see the note in __add__.
+            import underworld3 as uw
+
+            _nd = uw.non_dimensionalise(other)
+            other_sym = float(_nd.magnitude) if hasattr(_nd, "magnitude") else float(_nd)
         elif hasattr(other, "_sympify_"):
             other_sym = other._sympify_()
         else:
@@ -395,6 +432,16 @@ class MathematicalMixin:
             other_sym = other
         elif isinstance(other, MathematicalMixin) and hasattr(other, "sym"):
             other_sym = other.sym
+        elif hasattr(other, "magnitude") and hasattr(other, "units"):
+            # Unit-bearing scalar (UWQuantity / Pint) -> non-dimensional value, so
+            # it composes with the variable's non-dimensional .sym. Compatible
+            # units reduce via the model scaling; sympy cannot operate on the Pint
+            # object directly (UW3 issue #282). Matches the transparent-container
+            # behaviour of variable-variable arithmetic (units derived on demand).
+            import underworld3 as uw
+
+            _nd = uw.non_dimensionalise(other)
+            other_sym = float(_nd.magnitude) if hasattr(_nd, "magnitude") else float(_nd)
         elif hasattr(other, "_sympify_"):
             other_sym = other._sympify_()
         else:
@@ -420,6 +467,16 @@ class MathematicalMixin:
             other_sym = other
         elif isinstance(other, MathematicalMixin) and hasattr(other, "sym"):
             other_sym = other.sym
+        elif hasattr(other, "magnitude") and hasattr(other, "units"):
+            # Unit-bearing scalar (UWQuantity / Pint) -> non-dimensional value, so
+            # it composes with the variable's non-dimensional .sym. Compatible
+            # units reduce via the model scaling; sympy cannot operate on the Pint
+            # object directly (UW3 issue #282). Matches the transparent-container
+            # behaviour of variable-variable arithmetic (units derived on demand).
+            import underworld3 as uw
+
+            _nd = uw.non_dimensionalise(other)
+            other_sym = float(_nd.magnitude) if hasattr(_nd, "magnitude") else float(_nd)
         elif hasattr(other, "_sympify_"):
             other_sym = other._sympify_()
         else:
@@ -443,6 +500,16 @@ class MathematicalMixin:
             other_sym = other
         elif isinstance(other, MathematicalMixin) and hasattr(other, "sym"):
             other_sym = other.sym
+        elif hasattr(other, "magnitude") and hasattr(other, "units"):
+            # Unit-bearing scalar (UWQuantity / Pint) -> non-dimensional value, so
+            # it composes with the variable's non-dimensional .sym. Compatible
+            # units reduce via the model scaling; sympy cannot operate on the Pint
+            # object directly (UW3 issue #282). Matches the transparent-container
+            # behaviour of variable-variable arithmetic (units derived on demand).
+            import underworld3 as uw
+
+            _nd = uw.non_dimensionalise(other)
+            other_sym = float(_nd.magnitude) if hasattr(_nd, "magnitude") else float(_nd)
         elif hasattr(other, "_sympify_"):
             other_sym = other._sympify_()
         else:
@@ -469,6 +536,16 @@ class MathematicalMixin:
             other_sym = other
         elif isinstance(other, MathematicalMixin) and hasattr(other, "sym"):
             other_sym = other.sym
+        elif hasattr(other, "magnitude") and hasattr(other, "units"):
+            # Unit-bearing scalar (UWQuantity / Pint) -> non-dimensional value, so
+            # it composes with the variable's non-dimensional .sym. Compatible
+            # units reduce via the model scaling; sympy cannot operate on the Pint
+            # object directly (UW3 issue #282). Matches the transparent-container
+            # behaviour of variable-variable arithmetic (units derived on demand).
+            import underworld3 as uw
+
+            _nd = uw.non_dimensionalise(other)
+            other_sym = float(_nd.magnitude) if hasattr(_nd, "magnitude") else float(_nd)
         elif hasattr(other, "_sympify_"):
             other_sym = other._sympify_()
         else:

--- a/tests/test_0756_meshvar_quantity_arithmetic.py
+++ b/tests/test_0756_meshvar_quantity_arithmetic.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Regression: EnhancedMeshVariable arithmetic with a UWQuantity operand (#282).
+
+A mesh variable's ``.sym`` lives in non-dimensional (model-unit) space, so a
+unit-bearing scalar operand (a ``UWQuantity``) must be reduced to its
+non-dimensional value before composing. Previously ``T - uw.quantity(500, "K")``
+raised ``TypeError: Cannot subtract UWQuantity from EnhancedMeshVariable`` even
+for compatible units — blocking buoyancy expressions ``T - T_ref``.
+
+Scope: the variable on the LEFT (``meshvar ± quantity``, ``meshvar * quantity``).
+``quantity - meshvar`` (quantity on the left) is handled by the UWQuantity class
+and is out of scope here.
+"""
+import sympy
+import pytest
+
+import underworld3 as uw
+
+pytestmark = [pytest.mark.level_1, pytest.mark.tier_a]
+
+
+@pytest.fixture
+def units_mesh():
+    uw.reset_default_model()
+    model = uw.get_default_model()
+    model.set_reference_quantities(
+        domain_depth=uw.quantity(1000, "km"),
+        plate_velocity=uw.quantity(5, "cm/year"),
+        mantle_viscosity=uw.quantity(1e21, "Pa*s"),
+        temperature_difference=uw.quantity(1000, "K"),
+    )
+    mesh = uw.meshing.StructuredQuadBox(
+        elementRes=(4, 4), minCoords=(0.0, 0.0), maxCoords=(1000.0, 1000.0), units="km"
+    )
+    T = uw.discretisation.MeshVariable("T", mesh, 1, degree=2, units="K")
+    return mesh, T
+
+
+def _scalar(expr):
+    return expr[0, 0] if hasattr(expr, "shape") else expr
+
+
+def test_meshvar_minus_quantity(units_mesh):
+    """T - quantity[K] composes, and equals T.sym - non_dimensional(quantity)."""
+    _, T = units_mesh
+    result = _scalar(T - uw.quantity(500.0, "K"))
+    # 500 K / 1000 K scale -> 0.5 non-dimensional
+    assert sympy.simplify(result - (T.sym[0, 0] - 0.5)) == 0
+
+
+def test_meshvar_quantity_unit_prefix(units_mesh):
+    """A prefixed unit (kK) is reduced consistently: 0.5 kK == 500 K -> 0.5 ND."""
+    _, T = units_mesh
+    r_kK = _scalar(T - uw.quantity(0.5, "kK"))
+    r_K = _scalar(T - uw.quantity(500.0, "K"))
+    assert sympy.simplify(r_kK - r_K) == 0
+
+
+def test_meshvar_plus_and_times_quantity(units_mesh):
+    """Addition and multiplication with a quantity also compose."""
+    _, T = units_mesh
+    # T + 500K -> T.sym + 0.5
+    assert sympy.simplify(_scalar(T + uw.quantity(500.0, "K")) - (T.sym[0, 0] + 0.5)) == 0
+    # T * 500K -> T.sym * 0.5
+    assert sympy.simplify(_scalar(T * uw.quantity(500.0, "K")) - (T.sym[0, 0] * 0.5)) == 0
+
+
+def test_non_quantity_arithmetic_unchanged(units_mesh):
+    """The fix must not disturb non-quantity operands."""
+    _, T = units_mesh
+    # variable + variable, and scalar multiply, still work
+    _ = T + T
+    assert sympy.simplify(_scalar(T * 2.0) - (T.sym[0, 0] * 2.0)) == 0


### PR DESCRIPTION
## Summary
Fixes #282 — `T - uw.quantity(500, 'K')` (and `+`, `*`) raised `TypeError: Cannot subtract UWQuantity from EnhancedMeshVariable` even for compatible units, blocking the buoyancy form `T - T_ref`.

## Cause
A MeshVariable's `.sym` is **non-dimensional**; the `MathematicalMixin` operators passed a `UWQuantity` (Pint-backed) straight into sympy, which can't operate on it.

## Fix
Add a coercion branch to `__add__/__sub__/__rsub__/__mul__/__rmul__/__truediv__/__rtruediv__`: a unit-bearing scalar (`.magnitude` + `.units`) is reduced to its **non-dimensional value** via `uw.non_dimensionalise` before composing with `.sym`. Behaviour-preserving for all non-quantity operands.

## Verification
- `T ± quantity`, `T * quantity` compose with **exact ND values** (`T - 500K == T.sym - 0.5`); `kK` prefix reduces consistently.
- No regression: `test_0700/0750/0754` unchanged (the `meshvar - sympy_scalar` matrix quirk is **pre-existing**, confirmed on clean development).
- Regression: `tests/test_0756_meshvar_quantity_arithmetic.py`.

**Scope:** variable on the LEFT. `quantity - meshvar` (quantity on the left) raises inside the `UWQuantity` class (doesn't defer to `__rsub__`) — a related but separate gap, noted for follow-up. Helps unblock the buoyancy in #263.

Closes #282.

Underworld development team with AI support from Claude Code