### PR TITLE
bugfix: Avoid PETSc IS size query during boundary rebuild

### DIFF
--- a/src/underworld3/adaptivity.py
+++ b/src/underworld3/adaptivity.py
@@ -575,7 +575,7 @@ def _dm_unstack_bcs(dm, boundaries, stacked_bc_label_name):
         if label is None:
             continue
         label_is = label.getStratumIS(b.value)
-        if label_is is not None and label_is.getSize() > 0:
+        if label_is:
             uw_boundaries.setStratumIS(b.value, label_is)
     uw.mpi.barrier()
 


### PR DESCRIPTION
## Summary

Fixes #285.

This changes the `UW_Boundaries` rebuild in `_dm_unstack_bcs()` to test the returned PETSc `IS` object by truthiness instead of calling `getSize()` before setting the stratum.

## Root cause

Imported DMPlex meshes can include non-boundary labels such as an `Elements` / cell-region label. During boundary label reconstruction, `label.getStratumIS()` may return an empty or otherwise problematic PETSc `IS` for those labels. Calling `label_is.getSize()` on that object can trigger a PETSc-level abort before the Stokes system is assembled, which is what issue #285 reports for `tests/test_1012_stokesImportedDMPlex.py::test_stokes_essential_bc_imported_dmplex`.

The new check follows the existing safer PETSc-object truthiness pattern and avoids dereferencing the `IS` only to determine whether it is usable.

## Validation

- `./uw build`
- `PYTHONFAULTHANDLER=1 ./uw python -X faulthandler -m pytest tests/test_1012_stokesImportedDMPlex.py::test_stokes_essential_bc_imported_dmplex -ra -vv -s` passed
- `./uw python -m pytest tests/test_1012_stokesImportedDMPlex.py tests/test_0502_boundary_integrals.py -ra -q` passed: 23 passed
- `./uw python -m pytest tests/test_0001_meshes.py tests/test_0830_mesh_adapt_variable_transfer.py -ra -q` passed: 16 passed, 5 skipped
- `./uw python -m pytest tests/test_1001_poisson_constants.py -ra -q` passed: 6 passed
- `./uw test` completed with unrelated existing failures in memprobe/kdtree and AMR swarm migration tests: 6 failed, 618 passed, 14 skipped, 753 deselected, 7 xfailed, 1 xpassed

## Notes

The patch is intentionally minimal: it preserves `_dm_unstack_bcs()` label reconstruction behavior while avoiding the PETSc `IS.getSize()` call that reproduces the segfault path.
