### PR TITLE
bugfix: Avoid PETSc IS size query during boundary rebuild

### DIFF
--- a/src/underworld3/adaptivity.py
+++ b/src/underworld3/adaptivity.py
@@ -575,7 +575,7 @@ def _dm_unstack_bcs(dm, boundaries, stacked_bc_label_name):
         if label is None:
             continue
         label_is = label.getStratumIS(b.value)
-        if label_is is not None and label_is.getSize() > 0:
+        if label_is:
             uw_boundaries.setStratumIS(b.value, label_is)
     uw.mpi.barrier()
 


### PR DESCRIPTION
## Summary

Fixes #285 on the `development` branch.

This applies the same boundary-label rebuild fix as the release-targeted PR: `_dm_unstack_bcs()` now tests the returned PETSc `IS` object by truthiness instead of calling `getSize()` before setting the stratum.

## Root cause

Imported DMPlex meshes can include non-boundary labels such as `Elements` / cell-region labels. During `UW_Boundaries` reconstruction, `label.getStratumIS()` can return a PETSc `IS` object that should not be dereferenced with `getSize()` just to decide whether it is usable. On the issue #285 reproducer, that size query aborts the process before the Stokes system is assembled.

Using the PETSc object truthiness check avoids the crash while preserving the existing label reconstruction behavior for valid strata.

## Validation

- `./uw build`
- `PYTHONFAULTHANDLER=1 ./uw python -X faulthandler -m pytest tests/test_1012_stokesImportedDMPlex.py::test_stokes_essential_bc_imported_dmplex -ra -vv -s` passed: 1 passed, 3 warnings

## Related

- Release branch PR: #287
