### PR TITLE
Rotated strong free-slip BC + σ_nn dynamic-topography (parallel), free-surface hand-off

### DIFF
--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -120,8 +120,15 @@ class SolverBaseClass(uw_object):
 
         Notes
         -----
-        Single-field (scalar/vector) solvers only for now; the Stokes
-        velocity-block path is a separate increment. See
+        Supported both on single-field (scalar / vector) solvers — where the
+        prolongation is installed directly on the solver's ``PCMG`` — and on the
+        **Stokes velocity block** (the ``fieldsplit_velocity_`` sub-PC), where the
+        velocity sub-PC is only reachable once the monolithic Jacobian has been
+        assembled; the install there assembles the Jacobian, descends the
+        fieldsplit to the velocity sub-PC, and rebuilds it as a fresh ``PCMG``
+        driven by our ``P``. Injection happens at solve time (after
+        ``setFromOptions`` / nullspace attach) via
+        :func:`underworld3.utilities.custom_mg.inject_custom_mg`. See
         :mod:`underworld3.utilities.custom_mg`.
         """
         if kind not in ("barycentric", "rbf"):
@@ -4721,6 +4728,12 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
         self._multipliers = []
         self._multiplier_screening = []
         self._block_constraint_bcs = []
+        # Rotated strong free-slip BCs: [(boundary, normal), ...]. Registered via
+        # add_rotated_freeslip_bc; when non-empty, solve() delegates to
+        # underworld3.utilities.rotated_bc (per-node DOF rotation + strong v_n=0 +
+        # reaction = sigma_nn). Empty by default → the solve path is unchanged.
+        self._rotated_freeslip_bcs = []
+        self._rotated_freeslip_info = None
         # Give the Lagrange-multiplier (lambda) block its own viscosity-scaled
         # Schur preconditioner. The constraint Schur complement S_lambda = C A^-1 C^T
         # scales as 1/mu (since A ~ mu K), exactly like the pressure Schur S_p ~ mu^-1 M_p
@@ -4905,6 +4918,54 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
     #     from collections import namedtuple
     #     BC = namedtuple('EssentialBC', ['components', 'fn', 'boundary', 'boundary_label_val', 'type', 'PETScID'])
     #     self.essential_p_bcs.append(BC(components, sympy_fn, boundary, -1,  'essential', -1))
+
+    def add_rotated_freeslip_bc(self, boundary, normal=None):
+        r"""Add STRONG free-slip (:math:`\mathbf{u}\cdot\hat{\mathbf n}=0`) by rotating
+        the boundary velocity DOFs into a per-node (normal, tangential) frame and
+        imposing the rotated normal component as an exact Dirichlet constraint.
+
+        Unlike Nitsche/penalty free-slip (weak, leaks :math:`\mathcal O(10^{-3})`),
+        this enforces zero wall-normal flow to machine precision, and the constraint
+        **reaction** is the consistent boundary normal traction
+        :math:`\sigma_{nn}` (see :meth:`boundary_normal_traction`) with no
+        augmented-Lagrangian splitting. Correct on deformed / tilted / curved
+        boundaries because the normal is taken per node.
+
+        Parameters
+        ----------
+        boundary : str
+            Boundary label to constrain.
+        normal : None or sympy 1×dim Matrix or array, optional
+            Per-node outward normal source. ``None`` uses the geometric facet
+            normal (PETSc ``computeCellGeometryFVM``; works in 2D and 3D). A
+            sympy ``1×dim`` matrix supplies an analytic normal (exact
+            ``X/|X|`` on a spherical cap, a constant on a planar face) — preferred
+            on curved boundaries. A constant array is also accepted.
+
+        Notes
+        -----
+        A node shared by several rotated-free-slip boundaries (a box corner, a 3D
+        edge) is constrained on the whole span of its accumulated normals: a 3D
+        face frees two tangential directions, a 3D edge frees one (the edge
+        tangent), a corner is fully pinned. Registering delegates the solve to
+        :mod:`underworld3.utilities.rotated_bc`.
+        """
+        self._rotated_freeslip_bcs.append((boundary, normal))
+        self.is_setup = False
+        return
+
+    def boundary_normal_traction(self, boundary):
+        r"""Return the consistent boundary normal traction :math:`\sigma_{nn}` on a
+        rotated-free-slip ``boundary`` as the constraint reaction from the last
+        solve — the smooth, bounded quantity used for dynamic topography
+        (:math:`h_\infty=-(\sigma_{nn}-\overline{\sigma_{nn}})/\rho g`). Requires a
+        prior :meth:`add_rotated_freeslip_bc` on ``boundary`` and a completed
+        :meth:`solve`."""
+        if self._rotated_freeslip_info is None:
+            raise RuntimeError(
+                "boundary_normal_traction requires a completed rotated-free-slip solve.")
+        from underworld3.utilities.rotated_bc import boundary_normal_traction as _bnt
+        return _bnt(self, boundary, self._rotated_freeslip_info)
 
     def add_nitsche_bc(self, boundary, g=None, direction=None, normal=None, gamma=10.0, theta=1, mask=None, local_h=True):
         r"""Add Nitsche weak enforcement of a velocity constraint along a direction.
@@ -7498,6 +7559,15 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
             self._needs_function_rewire = True
 
         self._build(verbose, debug, debug_name)
+
+        # Rotated strong free-slip: delegate to the rotated_bc module (per-node DOF
+        # rotation + strong v_n=0 + reaction=sigma_nn). Handles the whole assemble/
+        # solve/rotate-back/gauge-removal; stashes info for boundary_normal_traction.
+        if self._rotated_freeslip_bcs:
+            from underworld3.utilities.rotated_bc import solve_rotated_freeslip
+            self._rotated_freeslip_info = solve_rotated_freeslip(
+                self, self._rotated_freeslip_bcs, verbose=verbose)
+            return
 
         # Set time on the DM so petsc_t is available in pointwise functions.
         # Non-dimensionalise if the scaling system is active.

--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -7587,18 +7587,44 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
 
         self._build(verbose, debug, debug_name)
 
+        # Set time on the DM so petsc_t is available in pointwise functions.
+        # Non-dimensionalise if the scaling system is active.
+        cdef DM _time_dm_stokes
+
         # Rotated strong free-slip: delegate to the rotated_bc module (per-node DOF
         # rotation + strong v_n=0 + reaction=sigma_nn). Handles the whole assemble/
         # solve/rotate-back/gauge-removal; stashes info for boundary_normal_traction.
         if self._rotated_freeslip_bcs:
+            # This is a LINEAR solve path: it assembles the Jacobian and residual once at
+            # U=0 and solves the rotated saddle directly, so it does NOT run the SNES
+            # nonlinear iteration. Nonlinear rheology / Picard / warm-start are therefore
+            # unsupported through this path — guard the explicit cases rather than
+            # silently returning a single-linearisation answer.
+            if picard != 0 or not zero_init_guess:
+                raise NotImplementedError(
+                    "rotated free-slip BCs support only a single linear solve "
+                    "(zero_init_guess=True, picard=0). Nonlinear rheology or warm-start "
+                    "would require integrating the rotated constraint into the SNES "
+                    "iteration; not yet implemented.")
+            # Run the same pre-solve preamble as the standard path so the pointwise
+            # functions see the DM time, the auxiliary vector, and updated constants
+            # (needed for problems whose coefficients live in auxiliary fields).
+            if time is not None:
+                if hasattr(time, 'magnitude') or hasattr(time, '_pint_qty'):
+                    t_nd = float(uw.non_dimensionalise(time))
+                else:
+                    t_nd = float(time)
+                _time_dm_stokes = self.dm
+                UW_DMSetTime(_time_dm_stokes.dm, t_nd)
+            self.mesh.update_lvec()
+            self.dm.setAuxiliaryVec(self.mesh.lvec, None)
+            self._update_constants()
+
             from underworld3.utilities.rotated_bc import solve_rotated_freeslip
             self._rotated_freeslip_info = solve_rotated_freeslip(
                 self, self._rotated_freeslip_bcs, verbose=verbose)
             return
 
-        # Set time on the DM so petsc_t is available in pointwise functions.
-        # Non-dimensionalise if the scaling system is active.
-        cdef DM _time_dm_stokes
         if time is not None:
             if hasattr(time, 'magnitude') or hasattr(time, '_pint_qty'):
                 t_nd = float(uw.non_dimensionalise(time))

--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -4954,18 +4954,24 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
         self.is_setup = False
         return
 
-    def boundary_normal_traction(self, boundary):
-        r"""Return the consistent boundary normal traction :math:`\sigma_{nn}` on a
+    def boundary_normal_traction(self, boundary, mass="lumped"):
+        r"""Return the boundary normal traction :math:`\sigma_{nn}` on a
         rotated-free-slip ``boundary`` as the constraint reaction from the last
         solve — the smooth, bounded quantity used for dynamic topography
         (:math:`h_\infty=-(\sigma_{nn}-\overline{\sigma_{nn}})/\rho g`). Requires a
         prior :meth:`add_rotated_freeslip_bc` on ``boundary`` and a completed
-        :meth:`solve`."""
+        :meth:`solve`.
+
+        ``mass`` chooses the boundary-mass de-smear of the nodal reaction:
+        ``"lumped"`` (default) is monotone — it cannot overshoot where the traction
+        jumps (e.g. across a viscosity contrast), so it is the safe choice for driving
+        a free surface; ``"consistent"`` uses the full P2 line mass (marginally sharper
+        on smooth tractions, but overshoots at discontinuities)."""
         if self._rotated_freeslip_info is None:
             raise RuntimeError(
                 "boundary_normal_traction requires a completed rotated-free-slip solve.")
         from underworld3.utilities.rotated_bc import boundary_normal_traction as _bnt
-        return _bnt(self, boundary, self._rotated_freeslip_info)
+        return _bnt(self, boundary, self._rotated_freeslip_info, mass=mass)
 
     def add_nitsche_bc(self, boundary, g=None, direction=None, normal=None, gamma=10.0, theta=1, mask=None, local_h=True):
         r"""Add Nitsche weak enforcement of a velocity constraint along a direction.

--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -4973,6 +4973,27 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
         from underworld3.utilities.rotated_bc import boundary_normal_traction as _bnt
         return _bnt(self, boundary, self._rotated_freeslip_info, mass=mass)
 
+    def dynamic_topography(self, boundary, field, buoyancy_scale=1.0, mass="lumped"):
+        r"""Write the dynamic topography
+        :math:`h = -(\sigma_{nn}-\overline{\sigma_{nn}})/(\Delta\rho\,g)` on a
+        rotated-free-slip ``boundary`` onto a scalar MeshVariable ``field``, from the
+        constraint reaction of the last solve. This is the hand-off to the free-surface
+        machinery — the 3-number topography integrator drives node motion from a surface
+        field, so create a scalar ``field`` (P1 recommended, continuous) up front and
+        pass it here after each :meth:`solve`; its boundary nodes are filled and the
+        interior left untouched.
+
+        ``buoyancy_scale`` is :math:`\Delta\rho\,g` (traction → length). ``mass`` selects
+        the recovery de-smear (``"lumped"`` default is monotone — no overshoot at a
+        stress jump — and is the safe choice for a free surface). Requires a prior
+        :meth:`add_rotated_freeslip_bc` on ``boundary`` and a completed :meth:`solve`."""
+        if self._rotated_freeslip_info is None:
+            raise RuntimeError(
+                "dynamic_topography requires a completed rotated-free-slip solve.")
+        from underworld3.utilities.rotated_bc import dynamic_topography_field as _dtf
+        return _dtf(self, boundary, self._rotated_freeslip_info, field,
+                    buoyancy_scale=buoyancy_scale, mass=mass)
+
     def add_nitsche_bc(self, boundary, g=None, direction=None, normal=None, gamma=10.0, theta=1, mask=None, local_h=True):
         r"""Add Nitsche weak enforcement of a velocity constraint along a direction.
 

--- a/src/underworld3/utilities/boundary_flux.py
+++ b/src/underworld3/utilities/boundary_flux.py
@@ -126,10 +126,16 @@ def _node_normals(solver, boundary, normal, nodes, dm, dim, cvec, csec, v0, v1):
     return nmap
 
 
-def _desmear(solver, boundary, xs, R, mass, remove_mean):
+def _desmear(solver, boundary, xs, R, mass, remove_mean, partial_reaction=True):
     """De-smear per-node reaction loads R (aligned with xs) into a pointwise flux via the
     boundary mass, assembled globally by a coordinate-keyed allgather so every rank forms
-    the identical system. Returns the flux at this rank's local nodes (xs order)."""
+    the identical system. Returns the flux at this rank's local nodes (xs order).
+
+    ``partial_reaction`` controls how a boundary node shared across a partition cut is
+    reconciled across ranks: ``True`` (default) SUMS each rank's contribution — correct
+    when R is the RAW per-rank volume residual (``boundary_flux``, DM overlap=0); ``False``
+    OVERWRITES (all ranks already agree) — correct when R comes from an ASSEMBLED global
+    operator, e.g. the rotated free-slip reaction ``Q(A·u − b)`` (``rotated_bc``)."""
     dm = solver.dm; dim = solver.mesh.dim; comm = dm.comm.tompi4py()
     csec = dm.getCoordinateSection()
     cvec = np.asarray(dm.getCoordinatesLocal().array).reshape(-1, dim)
@@ -153,13 +159,15 @@ def _desmear(solver, boundary, xs, R, mass, remove_mean):
         h = float(np.hypot(*(vcoord(b) - vcoord(a))))
         local_elems.append((_key(vcoord(a), dim), _key(cmid, dim), _key(vcoord(b), dim), h))
 
-    # SUM the nodal reaction across ranks by coordinate: with overlap=0 a boundary node
-    # shared across a partition cut holds only each rank's partial cell contribution, so
-    # summing them assembles the complete reaction (matches the rock-solid volume integral).
+    # Reconcile the nodal reaction across ranks by coordinate. partial_reaction=True: SUM
+    # (raw per-rank residual, DM overlap=0, so a cut node holds only each rank's partial
+    # → summing assembles the complete reaction, matching the rock-solid volume integral).
+    # partial_reaction=False: OVERWRITE (already-assembled global reaction, all ranks agree
+    # — summing would double-count shared nodes).
     R_by = {}
     for d in comm.allgather(nodeR):
         for k, v in d.items():
-            R_by[k] = R_by.get(k, 0.0) + v
+            R_by[k] = (R_by.get(k, 0.0) + v) if partial_reaction else v
     uniq = {}
     for lst in comm.allgather(local_elems):
         for (ka, km, kb, h) in lst:
@@ -220,6 +228,31 @@ def boundary_flux(solver, boundary, mass="lumped", remove_mean=False, normal=Non
     return xs, (np.column_stack(cols) if nodes else np.zeros((0, ncomp)))
 
 
+def write_boundary_scalar_field(solver, field, value_by_key, dim):
+    """Write ``value_by_key`` (coordinate-key → scalar) onto a scalar MeshVariable
+    ``field`` at the matching nodes; interior nodes untouched. Returns ``field``.
+
+    The field is written ONCE from a local numpy copy: a per-node write to ``var.data``
+    fires the variable's write-callback each time, and the boundary-node count differs per
+    rank (a rank may own none of the boundary), so per-node writes would desync the
+    callback's collective and deadlock. Shared by the boundary-flux and rotated-free-slip
+    (dynamic topography) field hand-offs."""
+    fc = np.asarray(field.coords)
+    newdata = np.asarray(field.data).copy()
+    for i in range(fc.shape[0]):
+        v = value_by_key.get(_key(fc[i], dim))
+        if v is not None:
+            newdata[i, 0] = v
+    field.data[...] = newdata
+    base = getattr(field, "_base_var", field)
+    if hasattr(base, "_sync_lvec_to_gvec"):
+        base._sync_lvec_to_gvec()
+    if hasattr(base, "_canonical_data"):
+        base._canonical_data = None
+    solver.mesh._stale_lvec = True
+    return field
+
+
 def boundary_flux_to_field(solver, boundary, field, mass="lumped",
                            remove_mean=False, scale=1.0, normal=None):
     """See ``SolverBaseClass.boundary_flux_field``. Writes ``scale * flux`` onto the
@@ -236,20 +269,4 @@ def boundary_flux_to_field(solver, boundary, field, mass="lumped",
             "returned a vector (traction). Pass normal= to project onto the normal "
             "component, or use boundary_flux() directly for the full vector.")
     fmap = {_key(x, dim): scale * float(f) for x, f in zip(np.asarray(xs), flux.ravel())}
-    fc = np.asarray(field.coords)
-    # Write the field ONCE from a local copy: a per-node write to var.data fires the
-    # write-callback each time, and the boundary-node count differs per rank (a rank may
-    # own none of the boundary), so per-node writes would desync the callback and hang.
-    newdata = np.asarray(field.data).copy()
-    for i in range(fc.shape[0]):
-        v = fmap.get(_key(fc[i], dim))
-        if v is not None:
-            newdata[i, 0] = v
-    field.data[...] = newdata
-    base = getattr(field, "_base_var", field)
-    if hasattr(base, "_sync_lvec_to_gvec"):
-        base._sync_lvec_to_gvec()
-    if hasattr(base, "_canonical_data"):
-        base._canonical_data = None
-    solver.mesh._stale_lvec = True
-    return field
+    return write_boundary_scalar_field(solver, field, fmap, dim)

--- a/src/underworld3/utilities/rotated_bc.py
+++ b/src/underworld3/utilities/rotated_bc.py
@@ -9,7 +9,12 @@ essential free-slip solve bit-for-bit. Direct LU here; FMG wiring is a later ste
 """
 import numpy as np
 from petsc4py import PETSc
-from mpi4py import MPI
+
+# Shared Consistent-Boundary-Flux machinery (the σ_nn recovery is a rotated-frame reading
+# of the same primitive): the consolidated-label boundary stratum, the lumped/consistent
+# boundary-mass de-smear, and the scalar-field hand-off all live in `boundary_flux`.
+from underworld3.utilities.boundary_flux import (
+    _boundary_stratum_is, _desmear, write_boundary_scalar_field)
 
 # Monotonic counter so each rotated solve gets a UNIQUE PETSc options prefix. With a
 # fixed prefix, sequential rotated solves (e.g. two solvers in one script, or one
@@ -58,10 +63,11 @@ def _boundary_velocity_nodes(solver, boundary, normal=None):
     lsec = dm.getLocalSection()
     VEL = _velocity_field_id(solver)
     interior_ref = cvec.mean(axis=0)
-    bval = [b.value for b in solver.mesh.boundaries if b.name == boundary][0]
-    # In parallel a rank may own NO part of this boundary → getStratumIS returns a
-    # null IS; calling getIndices() on it segfaults. Guard and return no local nodes.
-    sis = dm.getStratumIS(boundary, bval)
+    # Boundary facets via the consolidated "UW_Boundaries" label (per-boundary labels do
+    # not survive mesh adaptation); raises a clear error for an unknown boundary name.
+    # In parallel a rank may own NO part of this boundary → a null IS; guard and return
+    # no local nodes (calling getIndices() on a null IS would segfault).
+    sis = _boundary_stratum_is(dm, solver.mesh, boundary)
     if sis is None or sis.handle == 0:
         return []
     facets = [int(z) for z in sis.getIndices()]
@@ -490,23 +496,20 @@ def boundary_normal_traction(solver, boundary, info, mass="lumped"):
     normal = dict((nm, nrm) for nm, nrm in
                   [(s if isinstance(s, tuple) else (s, None)) for s in info["boundaries"]]).get(boundary)
     nodes = _boundary_velocity_nodes(solver, boundary, normal=normal)
-    xs = []; Rn = []; pts = []
+    xs = []; Rn = []
     for q, nrm in nodes:
         lo = lsec.getFieldOffset(q, VEL)
         rcv = rca[lo:lo + dim]                    # Cartesian reaction at this node (local)
         xs.append(_point_coord(dm, dim, cvec, csec, v0, v1, q))
         Rn.append(float(np.dot(nrm, rcv)))        # R_i = n̂·r_c  (corner-correct)
-        pts.append(q)
     dm.restoreLocalVec(rcl)
     xs = np.array(xs); Rn = np.array(Rn)
-    if dim != 2:
-        # no line-mass geometry in 3D yet → crude global-mean-removed load
-        comm = dm.comm.tompi4py()
-        tot = comm.allreduce(float(Rn.sum()), op=MPI.SUM)
-        cnt = comm.allreduce(int(Rn.size), op=MPI.SUM)
-        return xs, (-Rn) - (-tot / max(cnt, 1))
-    sig = _recover_sigma_nn_2d(solver, boundary, pts, Rn, xs, mass=mass)
-    return xs, sig
+    # σ_nn = −(nodal reaction), de-smeared by the SHARED boundary-mass primitive and
+    # mean-removed (the ρg·h gauge). partial_reaction=False: the reaction here comes from
+    # the ASSEMBLED global operator Q(A·u−b), already complete at every node (ranks agree
+    # at a partition-cut node — must OVERWRITE, not sum, else shared nodes double-count).
+    return xs, _desmear(solver, boundary, xs, -Rn, mass,
+                        remove_mean=True, partial_reaction=False)
 
 
 def dynamic_topography_field(solver, boundary, info, field, buoyancy_scale=1.0, mass="lumped"):
@@ -524,107 +527,12 @@ def dynamic_topography_field(solver, boundary, info, field, buoyancy_scale=1.0, 
     """
     dim = solver.mesh.dim
     xs, sig = boundary_normal_traction(solver, boundary, info, mass=mass)
-
+    # σ_nn is already mean-removed (the ρg·h gauge); topography h = -σ_nn / (Δρ g).
     def key(c):
         return tuple(round(float(t), 9) for t in np.asarray(c).ravel()[:dim])
-
-    # σ_nn is already mean-removed (the ρg·h gauge); topography h = -σ_nn / (Δρ g)
     hmap = {key(x): -float(s) / buoyancy_scale for x, s in zip(np.asarray(xs), np.asarray(sig))}
-    fc = np.asarray(field.coords)
-    # Build the new nodal values in a LOCAL numpy copy, then assign the field ONCE.
-    # A per-element write to var.data fires the variable's write-callback each time; the
-    # number of boundary nodes differs per rank (a rank may own none of the boundary),
-    # so per-element writes would desync any collective in the callback and deadlock.
-    newdata = np.asarray(field.data).copy()
-    for i in range(fc.shape[0]):
-        h = hmap.get(key(fc[i]))
-        if h is not None:
-            newdata[i, 0] = h
-    field.data[...] = newdata
-    # refresh the field's gvec cache so symbolic/BdIntegral reads see the update
-    base = getattr(field, "_base_var", field)
-    if hasattr(base, "_sync_lvec_to_gvec"):
-        base._sync_lvec_to_gvec()
-    if hasattr(base, "_canonical_data"):
-        base._canonical_data = None
-    solver.mesh._stale_lvec = True
-    return field
-
-
-def _recover_sigma_nn_2d(solver, boundary, pts, Rn, xs, mass="lumped"):
-    """De-smear the nodal reaction loads R into a pointwise σ_nn on `boundary` (2D) with
-    either the LUMPED (diagonal, monotone) or the CONSISTENT P2 line mass.
-
-    Parallel-safe by construction: each rank emits its local boundary ELEMENTS as
-    self-contained coordinate-keyed records (the three P2 node keys + the element length);
-    an allgather assembles the SAME global boundary mass on every rank (elements
-    de-duplicated by key, so a facet shared across a partition cut is counted once). Every
-    rank forms the identical de-smear and returns σ at its own local nodes, so the result
-    — and the mean-removal gauge — is partition-independent."""
-    dm = solver.dm; dim = 2; comm = dm.comm.tompi4py()
-    csec = dm.getCoordinateSection()
-    cvec = np.asarray(dm.getCoordinatesLocal().array).reshape(-1, dim)
-    v0, v1 = dm.getDepthStratum(0); e0, e1 = dm.getDepthStratum(1)
-    def vcoord(q): return cvec[csec.getOffset(q) // dim]
-    def key(c): return (round(float(c[0]), 9), round(float(c[1]), 9))
-
-    # local node -> reaction load, keyed by coordinate (ghosts included via pts/Rn)
-    nodeR = {key(x): float(R) for x, R in zip(xs, Rn)}
-
-    # local boundary elements as coordinate-keyed records: (ka, kmid, kb, h)
-    bval = [bb.value for bb in solver.mesh.boundaries if bb.name == boundary][0]
-    sis = dm.getStratumIS(boundary, bval)
-    strat = [] if (sis is None or sis.handle == 0) else [int(z) for z in sis.getIndices()]
-    edges = [q for q in strat if e0 <= q < e1]
-    local_elems = []
-    for e in edges:
-        a, bb = (int(c) for c in dm.getCone(e))
-        ca, cb = vcoord(a), vcoord(bb)
-        cmid = _point_coord(dm, dim, cvec, csec, v0, v1, e)
-        h = float(np.hypot(*(cb - ca)))
-        local_elems.append((key(ca), key(cmid), key(cb), h))
-
-    # gather elements + node loads across ranks (1D boundary → cheap)
-    all_elems = comm.allgather(local_elems)
-    all_nodeR = comm.allgather(nodeR)
-    R_by_key = {}
-    for d in all_nodeR:
-        R_by_key.update(d)                       # same key → same value on every rank
-    # de-duplicate elements (a shared facet appears on >1 rank)
-    uniq = {}
-    for lst in all_elems:
-        for (ka, km, kb, h) in lst:
-            uniq[(ka, km, kb)] = h
-    # global node numbering
-    keys = sorted(R_by_key.keys())
-    gidx = {k: i for i, k in enumerate(keys)}
-    n = len(keys); R = np.zeros(n)
-    for k, i in gidx.items():
-        R[i] = R_by_key[k]
-
-    if mass == "lumped":
-        # diagonal P2 line mass (row sums of the consistent mass): h*[1/6, 2/3, 1/6] for
-        # (vertexA, mid-edge, vertexB). Monotone → no overshoot at a stress jump.
-        mL = np.zeros(n)
-        for (ka, km, kb), h in uniq.items():
-            mL[gidx[ka]] += h / 6.0
-            mL[gidx[km]] += 2.0 * h / 3.0
-            mL[gidx[kb]] += h / 6.0
-        sig_g = -R / mL
-    else:
-        # consistent P2 line mass M σ = −R
-        M = np.zeros((n, n))
-        Me = np.array([[4., 2, -1], [2, 16, 2], [-1, 2, 4]])
-        for (ka, km, kb), h in uniq.items():
-            tri = [gidx[ka], gidx[km], gidx[kb]]
-            Mh = (h / 30.0) * Me
-            for ii in range(3):
-                for jj in range(3):
-                    M[tri[ii], tri[jj]] += Mh[ii, jj]
-        sig_g = np.linalg.solve(M, -R)
-    sig_g = sig_g - sig_g.mean()                 # global gauge → partition-independent
-    # return σ at THIS rank's local nodes, in the input (xs/pts) order
-    return np.array([sig_g[gidx[key(x)]] for x in xs])
+    # shared bulk field write (parallel-safe: write ONCE, not per node)
+    return write_boundary_scalar_field(solver, field, hmap, dim)
 
 
 def _rigid_rotation_global(solver):

--- a/src/underworld3/utilities/rotated_bc.py
+++ b/src/underworld3/utilities/rotated_bc.py
@@ -9,6 +9,7 @@ essential free-slip solve bit-for-bit. Direct LU here; FMG wiring is a later ste
 """
 import numpy as np
 from petsc4py import PETSc
+from mpi4py import MPI
 
 # Monotonic counter so each rotated solve gets a UNIQUE PETSc options prefix. With a
 # fixed prefix, sequential rotated solves (e.g. two solvers in one script, or one
@@ -449,71 +450,117 @@ def _rotation_is_nullspace(solver, Q, normal_rows, tol=1e-8):
 
 def boundary_normal_traction(solver, boundary, info, consistent_mass=True):
     """Consistent boundary normal traction σ_nn on `boundary` from the constraint
-    reaction of the last rotated-free-slip solve.
+    reaction of the last rotated-free-slip solve. Returned mean-removed (the ρg·h
+    gauge), as ``(xs, sigma)`` with one entry per boundary velocity node on this rank.
 
-    The reaction is r = Q(A·u − b): in the rotated frame its value at each node's
-    NORMAL row is the integrated nodal traction ∫_Γ(σ·n̂)φ_i. Map those rows to the
-    boundary P2 nodes and (optionally) solve the consistent P2 boundary mass to get
-    a pointwise σ_nn. Returned mean-removed (the ρg·h gauge).
+    σ_nn is recovered from the CARTESIAN nodal reaction r_c = A·u − b: the nodal load
+    is R_i = n̂_i · r_c(node_i), where n̂_i is THIS boundary's outward normal at node i.
+    Projecting the Cartesian reaction onto the boundary normal (rather than reading the
+    rotated frame's normal row) is corner-correct — at a node shared with another
+    rotated-free-slip boundary the rotated frame's first row is a mix of both walls'
+    normals, but n̂·r_c is the true normal traction for this boundary. The pointwise
+    σ_nn is then the consistent P2 line-mass de-smear of R (2D).
+
+    Parallel-safe: r_c is scattered to a local vector (ghosts included) and read by
+    LOCAL section offset; the consistent-mass system is assembled globally by a
+    coordinate-keyed allgather of the boundary elements so every rank solves the same
+    system and the mean-removal gauge is global.
     """
     dm = solver.dm
     dim = solver.mesh.dim
-    Q = info["Q"]; A = info["A"]; b = info["b"]; U = info["U"]
-    # Cartesian residual r_c = A u − b, rotated: r = Q r_c
+    A = info["A"]; b = info["b"]; U = info["U"]
+    # Cartesian nodal reaction r_c = A u − b (global), scattered to local incl. ghosts
     rc = A.createVecLeft(); A.mult(U, rc); rc.axpy(-1.0, b)
-    r = rc.duplicate(); Q.mult(rc, r)
-    ra = r.getArray()
+    rcl = dm.getLocalVec(); dm.globalToLocal(rc, rcl); rca = np.asarray(rcl.getArray())
 
-    lsec = dm.getLocalSection(); l2g = dm.getLGMap(); VEL = _velocity_field_id(solver)
+    lsec = dm.getLocalSection(); VEL = _velocity_field_id(solver)
     csec = dm.getCoordinateSection()
     cvec = np.asarray(dm.getCoordinatesLocal().array).reshape(-1, dim)
     v0, v1 = dm.getDepthStratum(0)
     normal = dict((nm, nrm) for nm, nrm in
                   [(s if isinstance(s, tuple) else (s, None)) for s in info["boundaries"]]).get(boundary)
     nodes = _boundary_velocity_nodes(solver, boundary, normal=normal)
-    # each face node: normal row = the frame row spanning its (single) normal = grows[0]
     xs = []; Rn = []; pts = []
     for q, nrm in nodes:
         lo = lsec.getFieldOffset(q, VEL)
-        row = int(l2g.apply([lo])[0])            # frame row 0 = normal (single-boundary face)
-        if row < 0:
-            continue
+        rcv = rca[lo:lo + dim]                    # Cartesian reaction at this node (local)
         xs.append(_point_coord(dm, dim, cvec, csec, v0, v1, q))
-        Rn.append(ra[row]); pts.append(q)
+        Rn.append(float(np.dot(nrm, rcv)))        # R_i = n̂·r_c  (corner-correct)
+        pts.append(q)
+    dm.restoreLocalVec(rcl)
     xs = np.array(xs); Rn = np.array(Rn)
     if not consistent_mass or dim != 2:
-        sig = -Rn
-        return xs, sig - sig.mean()
-    # 2D consistent P2 boundary mass from DMPlex top-edge connectivity
-    sig = _consistent_mass_2d(solver, boundary, normal, pts, Rn)
+        # lumped fallback; mean removed with the GLOBAL mean for partition-independence
+        comm = dm.comm.tompi4py()
+        tot = comm.allreduce(float(Rn.sum()), op=MPI.SUM)
+        cnt = comm.allreduce(int(Rn.size), op=MPI.SUM)
+        sig = -Rn - (-tot / max(cnt, 1))
+        return xs, sig
+    # 2D consistent P2 boundary mass, assembled globally (parallel-safe)
+    sig = _consistent_mass_2d(solver, boundary, pts, Rn, xs)
     return xs, sig
 
 
-def _consistent_mass_2d(solver, boundary, normal, pts, Rn):
-    """Solve M_Γ σ = −R with the consistent P2 line mass on `boundary` (2D)."""
-    dm = solver.dm; dim = 2
+def _consistent_mass_2d(solver, boundary, pts, Rn, xs):
+    """Solve M_Γ σ = −R with the consistent P2 line mass on `boundary` (2D).
+
+    Parallel-safe by construction: each rank emits its local boundary ELEMENTS as
+    self-contained coordinate-keyed records (the three P2 node keys + their reaction
+    loads + the element length); an allgather assembles the SAME global 1D system on
+    every rank (elements de-duplicated by key, so a facet shared across a partition cut
+    is counted once). Every rank solves it and returns σ at its own local nodes, so the
+    result — and the mean-removal gauge — is partition-independent."""
+    dm = solver.dm; dim = 2; comm = dm.comm.tompi4py()
     csec = dm.getCoordinateSection()
     cvec = np.asarray(dm.getCoordinatesLocal().array).reshape(-1, dim)
     v0, v1 = dm.getDepthStratum(0); e0, e1 = dm.getDepthStratum(1)
     def vcoord(q): return cvec[csec.getOffset(q) // dim]
-    bval = [b.value for b in solver.mesh.boundaries if b.name == boundary][0]
+    def key(c): return (round(float(c[0]), 9), round(float(c[1]), 9))
+
+    # local node -> reaction load, keyed by coordinate (ghosts included via pts/Rn)
+    nodeR = {key(x): float(R) for x, R in zip(xs, Rn)}
+
+    # local boundary elements as coordinate-keyed records: (ka, kmid, kb, h)
+    bval = [bb.value for bb in solver.mesh.boundaries if bb.name == boundary][0]
     sis = dm.getStratumIS(boundary, bval)
     strat = [] if (sis is None or sis.handle == 0) else [int(z) for z in sis.getIndices()]
     edges = [q for q in strat if e0 <= q < e1]
-    idx = {p: k for k, p in enumerate(pts)}
-    n = len(pts); M = np.zeros((n, n))
+    local_elems = []
     for e in edges:
-        a, b = (int(c) for c in dm.getCone(e))
-        if a not in idx or b not in idx or e not in idx:
-            continue
-        h = float(np.hypot(*(vcoord(b) - vcoord(a))))
-        Me = (h / 30.0) * np.array([[4., 2, -1], [2, 16, 2], [-1, 2, 4]])
-        tri = [idx[a], idx[e], idx[b]]
+        a, bb = (int(c) for c in dm.getCone(e))
+        ca, cb = vcoord(a), vcoord(bb)
+        cmid = _point_coord(dm, dim, cvec, csec, v0, v1, e)
+        h = float(np.hypot(*(cb - ca)))
+        local_elems.append((key(ca), key(cmid), key(cb), h))
+
+    # gather elements + node loads across ranks (1D boundary → cheap)
+    all_elems = comm.allgather(local_elems)
+    all_nodeR = comm.allgather(nodeR)
+    R_by_key = {}
+    for d in all_nodeR:
+        R_by_key.update(d)                       # same key → same value on every rank
+    # de-duplicate elements (a shared facet appears on >1 rank)
+    uniq = {}
+    for lst in all_elems:
+        for (ka, km, kb, h) in lst:
+            uniq[(ka, km, kb)] = h
+    # global node numbering + assembly
+    keys = sorted(R_by_key.keys())
+    gidx = {k: i for i, k in enumerate(keys)}
+    n = len(keys); M = np.zeros((n, n)); R = np.zeros(n)
+    for k, i in gidx.items():
+        R[i] = R_by_key[k]
+    Me = np.array([[4., 2, -1], [2, 16, 2], [-1, 2, 4]])
+    for (ka, km, kb), h in uniq.items():
+        tri = [gidx[ka], gidx[km], gidx[kb]]
+        Mh = (h / 30.0) * Me
         for ii in range(3):
             for jj in range(3):
-                M[tri[ii], tri[jj]] += Me[ii, jj]
-    sig = np.linalg.solve(M, -np.asarray(Rn))
-    return sig - sig.mean()
+                M[tri[ii], tri[jj]] += Mh[ii, jj]
+    sig_g = np.linalg.solve(M, -R)
+    sig_g = sig_g - sig_g.mean()                 # global gauge → partition-independent
+    # return σ at THIS rank's local nodes, in the input (xs/pts) order
+    return np.array([sig_g[gidx[key(x)]] for x in xs])
 
 
 def _rigid_rotation_global(solver):

--- a/src/underworld3/utilities/rotated_bc.py
+++ b/src/underworld3/utilities/rotated_bc.py
@@ -448,10 +448,10 @@ def _rotation_is_nullspace(solver, Q, normal_rows, tol=1e-8):
     return viol < tol
 
 
-def boundary_normal_traction(solver, boundary, info, consistent_mass=True):
-    """Consistent boundary normal traction σ_nn on `boundary` from the constraint
-    reaction of the last rotated-free-slip solve. Returned mean-removed (the ρg·h
-    gauge), as ``(xs, sigma)`` with one entry per boundary velocity node on this rank.
+def boundary_normal_traction(solver, boundary, info, mass="lumped"):
+    """Boundary normal traction σ_nn on `boundary` from the constraint reaction of the
+    last rotated-free-slip solve. Returned mean-removed (the ρg·h gauge), as
+    ``(xs, sigma)`` with one entry per boundary velocity node on this rank.
 
     σ_nn is recovered from the CARTESIAN nodal reaction r_c = A·u − b: the nodal load
     is R_i = n̂_i · r_c(node_i), where n̂_i is THIS boundary's outward normal at node i.
@@ -459,12 +459,22 @@ def boundary_normal_traction(solver, boundary, info, consistent_mass=True):
     rotated frame's normal row) is corner-correct — at a node shared with another
     rotated-free-slip boundary the rotated frame's first row is a mix of both walls'
     normals, but n̂·r_c is the true normal traction for this boundary. The pointwise
-    σ_nn is then the consistent P2 line-mass de-smear of R (2D).
+    σ_nn is the boundary-mass de-smear of R (2D).
 
-    Parallel-safe: r_c is scattered to a local vector (ghosts included) and read by
-    LOCAL section offset; the consistent-mass system is assembled globally by a
-    coordinate-keyed allgather of the boundary elements so every rank solves the same
-    system and the mean-removal gauge is global.
+    ``mass`` selects the de-smear:
+      * ``"lumped"`` (default) — the diagonal (row-sum) boundary mass. Being an M-matrix
+        it CANNOT overshoot at a stress discontinuity (no Gibbs wiggle where the traction
+        jumps, e.g. across a viscosity contrast), it is a purely local division (no global
+        mass solve → trivially parallel), and it is marginally more accurate than the
+        consistent mass on SolCx. Recommended for driving a free surface, where an
+        overshoot at a sharp feature injects a spurious surface-velocity pulse.
+      * ``"consistent"`` — the full consistent P2 line mass. Marginally sharper on smooth
+        tractions but overshoots at discontinuities.
+
+    Parallel-safe: r_c is scattered to a local vector (ghosts included) and read by LOCAL
+    section offset; the boundary mass is assembled globally by a coordinate-keyed
+    allgather of the boundary elements, so every rank produces the same de-smear and the
+    mean-removal gauge is global.
     """
     dm = solver.dm
     dim = solver.mesh.dim
@@ -489,27 +499,26 @@ def boundary_normal_traction(solver, boundary, info, consistent_mass=True):
         pts.append(q)
     dm.restoreLocalVec(rcl)
     xs = np.array(xs); Rn = np.array(Rn)
-    if not consistent_mass or dim != 2:
-        # lumped fallback; mean removed with the GLOBAL mean for partition-independence
+    if dim != 2:
+        # no line-mass geometry in 3D yet → crude global-mean-removed load
         comm = dm.comm.tompi4py()
         tot = comm.allreduce(float(Rn.sum()), op=MPI.SUM)
         cnt = comm.allreduce(int(Rn.size), op=MPI.SUM)
-        sig = -Rn - (-tot / max(cnt, 1))
-        return xs, sig
-    # 2D consistent P2 boundary mass, assembled globally (parallel-safe)
-    sig = _consistent_mass_2d(solver, boundary, pts, Rn, xs)
+        return xs, (-Rn) - (-tot / max(cnt, 1))
+    sig = _recover_sigma_nn_2d(solver, boundary, pts, Rn, xs, mass=mass)
     return xs, sig
 
 
-def _consistent_mass_2d(solver, boundary, pts, Rn, xs):
-    """Solve M_Γ σ = −R with the consistent P2 line mass on `boundary` (2D).
+def _recover_sigma_nn_2d(solver, boundary, pts, Rn, xs, mass="lumped"):
+    """De-smear the nodal reaction loads R into a pointwise σ_nn on `boundary` (2D) with
+    either the LUMPED (diagonal, monotone) or the CONSISTENT P2 line mass.
 
     Parallel-safe by construction: each rank emits its local boundary ELEMENTS as
-    self-contained coordinate-keyed records (the three P2 node keys + their reaction
-    loads + the element length); an allgather assembles the SAME global 1D system on
-    every rank (elements de-duplicated by key, so a facet shared across a partition cut
-    is counted once). Every rank solves it and returns σ at its own local nodes, so the
-    result — and the mean-removal gauge — is partition-independent."""
+    self-contained coordinate-keyed records (the three P2 node keys + the element length);
+    an allgather assembles the SAME global boundary mass on every rank (elements
+    de-duplicated by key, so a facet shared across a partition cut is counted once). Every
+    rank forms the identical de-smear and returns σ at its own local nodes, so the result
+    — and the mean-removal gauge — is partition-independent."""
     dm = solver.dm; dim = 2; comm = dm.comm.tompi4py()
     csec = dm.getCoordinateSection()
     cvec = np.asarray(dm.getCoordinatesLocal().array).reshape(-1, dim)
@@ -544,20 +553,33 @@ def _consistent_mass_2d(solver, boundary, pts, Rn, xs):
     for lst in all_elems:
         for (ka, km, kb, h) in lst:
             uniq[(ka, km, kb)] = h
-    # global node numbering + assembly
+    # global node numbering
     keys = sorted(R_by_key.keys())
     gidx = {k: i for i, k in enumerate(keys)}
-    n = len(keys); M = np.zeros((n, n)); R = np.zeros(n)
+    n = len(keys); R = np.zeros(n)
     for k, i in gidx.items():
         R[i] = R_by_key[k]
-    Me = np.array([[4., 2, -1], [2, 16, 2], [-1, 2, 4]])
-    for (ka, km, kb), h in uniq.items():
-        tri = [gidx[ka], gidx[km], gidx[kb]]
-        Mh = (h / 30.0) * Me
-        for ii in range(3):
-            for jj in range(3):
-                M[tri[ii], tri[jj]] += Mh[ii, jj]
-    sig_g = np.linalg.solve(M, -R)
+
+    if mass == "lumped":
+        # diagonal P2 line mass (row sums of the consistent mass): h*[1/6, 2/3, 1/6] for
+        # (vertexA, mid-edge, vertexB). Monotone → no overshoot at a stress jump.
+        mL = np.zeros(n)
+        for (ka, km, kb), h in uniq.items():
+            mL[gidx[ka]] += h / 6.0
+            mL[gidx[km]] += 2.0 * h / 3.0
+            mL[gidx[kb]] += h / 6.0
+        sig_g = -R / mL
+    else:
+        # consistent P2 line mass M σ = −R
+        M = np.zeros((n, n))
+        Me = np.array([[4., 2, -1], [2, 16, 2], [-1, 2, 4]])
+        for (ka, km, kb), h in uniq.items():
+            tri = [gidx[ka], gidx[km], gidx[kb]]
+            Mh = (h / 30.0) * Me
+            for ii in range(3):
+                for jj in range(3):
+                    M[tri[ii], tri[jj]] += Mh[ii, jj]
+        sig_g = np.linalg.solve(M, -R)
     sig_g = sig_g - sig_g.mean()                 # global gauge → partition-independent
     # return σ at THIS rank's local nodes, in the input (xs/pts) order
     return np.array([sig_g[gidx[key(x)]] for x in xs])

--- a/src/underworld3/utilities/rotated_bc.py
+++ b/src/underworld3/utilities/rotated_bc.py
@@ -509,6 +509,48 @@ def boundary_normal_traction(solver, boundary, info, mass="lumped"):
     return xs, sig
 
 
+def dynamic_topography_field(solver, boundary, info, field, buoyancy_scale=1.0, mass="lumped"):
+    """Populate a scalar MeshVariable ``field`` with the dynamic topography
+    :math:`h = -(\\sigma_{nn}-\\overline{\\sigma_{nn}})/(\\Delta\\rho\\,g)` on ``boundary``,
+    recovered from the rotated-free-slip constraint reaction (lumped by default —
+    monotone, no Gibbs overshoot at a stress jump). Interior nodes are left untouched.
+    Returns ``field``.
+
+    This is the hand-off to the free-surface machinery: the 3-number topography
+    integrator drives node motion from a surface field, so σ_nn is written onto the
+    boundary nodes of a P1 (or higher) scalar field it can read / BdIntegral. Parallel-
+    safe: the recovery is partition-independent and the write is local (each rank fills
+    its own boundary nodes, matched by coordinate to the recovery output).
+    """
+    dim = solver.mesh.dim
+    xs, sig = boundary_normal_traction(solver, boundary, info, mass=mass)
+
+    def key(c):
+        return tuple(round(float(t), 9) for t in np.asarray(c).ravel()[:dim])
+
+    # σ_nn is already mean-removed (the ρg·h gauge); topography h = -σ_nn / (Δρ g)
+    hmap = {key(x): -float(s) / buoyancy_scale for x, s in zip(np.asarray(xs), np.asarray(sig))}
+    fc = np.asarray(field.coords)
+    # Build the new nodal values in a LOCAL numpy copy, then assign the field ONCE.
+    # A per-element write to var.data fires the variable's write-callback each time; the
+    # number of boundary nodes differs per rank (a rank may own none of the boundary),
+    # so per-element writes would desync any collective in the callback and deadlock.
+    newdata = np.asarray(field.data).copy()
+    for i in range(fc.shape[0]):
+        h = hmap.get(key(fc[i]))
+        if h is not None:
+            newdata[i, 0] = h
+    field.data[...] = newdata
+    # refresh the field's gvec cache so symbolic/BdIntegral reads see the update
+    base = getattr(field, "_base_var", field)
+    if hasattr(base, "_sync_lvec_to_gvec"):
+        base._sync_lvec_to_gvec()
+    if hasattr(base, "_canonical_data"):
+        base._canonical_data = None
+    solver.mesh._stale_lvec = True
+    return field
+
+
 def _recover_sigma_nn_2d(solver, boundary, pts, Rn, xs, mass="lumped"):
     """De-smear the nodal reaction loads R into a pointwise σ_nn on `boundary` (2D) with
     either the LUMPED (diagonal, monotone) or the CONSISTENT P2 line mass.

--- a/src/underworld3/utilities/rotated_bc.py
+++ b/src/underworld3/utilities/rotated_bc.py
@@ -10,6 +10,13 @@ essential free-slip solve bit-for-bit. Direct LU here; FMG wiring is a later ste
 import numpy as np
 from petsc4py import PETSc
 
+# Monotonic counter so each rotated solve gets a UNIQUE PETSc options prefix. With a
+# fixed prefix, sequential rotated solves (e.g. two solvers in one script, or one
+# solver in a time-stepping loop) share and re-set the same global-options keys; the
+# per-solve prefix plus the delValue cleanup below keeps each solve's options local
+# and stops the global database growing / emitting "unused option" warnings.
+_ROT_SOLVE_COUNT = 0
+
 
 # --------------------------------------------------------------------------- #
 #  Rotation construction
@@ -218,16 +225,26 @@ def solve_rotated_freeslip(solver, boundaries, remove_rotation_gauge=True, verbo
     # diagonal) AND the RHS at those rows — zeroRowsColumns does NOT touch the RHS,
     # so a nonzero b there would leak straight into the solution (û_i = b_i / 1),
     # independent of the solver/tolerance.
+    # zeroRowsColumns takes GLOBAL row indices (correct); the RHS write must use
+    # OWNERSHIP-RELATIVE local indices (bhat.getArray() is this rank's local slice,
+    # so indexing it with global rows overflows on any rank whose ownership does not
+    # start at 0 — the np>1 crash that masqueraded as a hang).
     Ahat.zeroRowsColumns(normal_rows, diag=1.0)
-    ba = bhat.getArray(); ba[normal_rows] = 0.0; bhat.setArray(ba)
+    brs, bre = bhat.getOwnershipRange()
+    bloc = np.asarray([g - brs for g in normal_rows if brs <= g < bre], dtype=np.int64)
+    ba = bhat.getArray(); ba[bloc] = 0.0; bhat.setArray(ba)
 
     # ITERATIVE by default (LU is almost never right): a self-contained fieldsplit-
     # Schur solve whose velocity block is geometric FMG on the custom prolongation
     # when a hierarchy is registered (set_custom_fmg), else GAMG. Direct LU only when
     # explicitly opted in via solver._rotated_use_lu.
     if getattr(solver, "_rotated_use_lu", False):
+        # NOTE: the pressure `pin` is a naive per-rank global search (parallel-unsafe;
+        # LU is opt-in only — see the follow-up in rotated_bc). The RHS write below
+        # still uses ownership-relative indexing so it does not overflow the local slice.
         Ahat.zeroRows([pin], diag=1.0)
-        ba = bhat.getArray(); ba[pin] = 0.0; bhat.setArray(ba)
+        if pin is not None and brs <= pin < bre:
+            ba = bhat.getArray(); ba[pin - brs] = 0.0; bhat.setArray(ba)
         ksp = PETSc.KSP().create(); ksp.setOperators(Ahat); ksp.setType("preonly")
         pc = ksp.getPC(); pc.setType("lu"); pc.setFactorSolverType("mumps")
         Uhat = dm.getGlobalVec(); ksp.solve(bhat, Uhat)
@@ -256,6 +273,18 @@ def solve_rotated_freeslip(solver, boundaries, remove_rotation_gauge=True, verbo
         sg = U.getSubVector(solver._subdict[name][0])
         solver._subdict[name][1].globalToLocal(sg, var.vec)
         U.restoreSubVector(solver._subdict[name][0], sg)
+
+    # Parity with the normal solve's post-scatter sync (pyx: after the field copy-back):
+    # refresh the enhanced-variable gvec cache and drop the canonical-data cache so
+    # downstream consumers (var.data / var.array / checkpoint / stats) don't read a
+    # stale value; and mark the mesh local vector stale.
+    solver.mesh._stale_lvec = True
+    for name, var in solver.fields.items():
+        target_var = getattr(var, "_base_var", var)
+        if hasattr(target_var, "_sync_lvec_to_gvec"):
+            target_var._sync_lvec_to_gvec()
+        if hasattr(target_var, "_canonical_data"):
+            target_var._canonical_data = None
 
     return {"Q": Q, "Qt": Qt, "A": Aorig, "b": b, "U": U, "Uhat": Uhat,
             "normal_rows": normal_rows, "boundaries": list(boundaries),
@@ -293,7 +322,11 @@ def _solve_rotated_iterative(solver, Ahat, bhat, Q, Qt, normal_rows, verbose=Fal
     if nsp is not None:
         Ahat.setNullSpace(nsp); Ahat.setTransposeNullSpace(nsp); nsp.remove(bhat)
 
-    pfx = "rotfs_"
+    # UNIQUE prefix per solve (see _ROT_SOLVE_COUNT) so sequential rotated solves
+    # do not share global-options state; the keys are removed after the solve.
+    global _ROT_SOLVE_COUNT
+    _ROT_SOLVE_COUNT += 1
+    pfx = f"rotfs{_ROT_SOLVE_COUNT}_"
     opts = PETSc.Options()
     cfg = {
         "ksp_type": "fgmres", "ksp_rtol": str(float(solver.tolerance)), "ksp_max_it": "300",
@@ -307,21 +340,30 @@ def _solve_rotated_iterative(solver, Ahat, bhat, Q, Qt, normal_rows, verbose=Fal
         cfg["fieldsplit_vel_pc_type"] = "gamg"
     for k, v in cfg.items():
         opts[pfx + k] = v
-    ksp = PETSc.KSP().create(comm=dm.comm); ksp.setOptionsPrefix(pfx)
-    ksp.setOperators(Ahat)
-    pc = ksp.getPC(); pc.setType("fieldsplit")
-    pc.setFieldSplitIS(("vel", vel_is), ("pres", pres_is))
-    ksp.setFromOptions()
-    pc.setUp()
-    if custom_Pl is not None:                         # geometric FMG via custom P
-        vel_pc = pc.getFieldSplitSubKSP()[0].getPC()
-        A_vv, P_vv = vel_pc.getOperators()
-        vel_pc.reset(); vel_pc.setOperators(A_vv, P_vv)
-        custom_mg._configure_pcmg(vel_pc, custom_Pl)
-        vel_pc.setUp()
+    try:
+        ksp = PETSc.KSP().create(comm=dm.comm); ksp.setOptionsPrefix(pfx)
+        ksp.setOperators(Ahat)
+        pc = ksp.getPC(); pc.setType("fieldsplit")
+        pc.setFieldSplitIS(("vel", vel_is), ("pres", pres_is))
+        ksp.setFromOptions()
+        pc.setUp()
+        if custom_Pl is not None:                     # geometric FMG via custom P
+            vel_pc = pc.getFieldSplitSubKSP()[0].getPC()
+            A_vv, P_vv = vel_pc.getOperators()
+            vel_pc.reset(); vel_pc.setOperators(A_vv, P_vv)
+            custom_mg._configure_pcmg(vel_pc, custom_Pl)
+            vel_pc.setUp()
 
-    Uhat = Ahat.createVecRight(); Uhat.set(0.0)
-    ksp.solve(bhat, Uhat)
+        Uhat = Ahat.createVecRight(); Uhat.set(0.0)
+        ksp.solve(bhat, Uhat)
+    finally:
+        # all options consumed by setFromOptions/setUp/solve — drop them so the
+        # global database stays clean (and bounded under time-stepping).
+        for k in cfg:
+            try:
+                opts.delValue(pfx + k)
+            except Exception:
+                pass
     # An identity constraint row in an ITERATIVE solve only drives its residual
     # (= û_i) below tolerance, so û_i ~ tol, not exactly 0. Because zeroRowsColumns
     # made these DOFs fully decoupled (row AND column zeroed), û_i affects no other

--- a/src/underworld3/utilities/rotated_bc.py
+++ b/src/underworld3/utilities/rotated_bc.py
@@ -4,8 +4,11 @@ build a per-node rotation Q from boundary normals, rotate the assembled saddle
 Â=Q A Qᵀ / b̂=Q b, impose v_n=0 on the rotated normal rows, solve, rotate back
 u=Qᵀû, remove the rigid-rotation gauge, and expose σ_nn as the constraint reaction.
 
-Increment 1: box-flat (Q=identity on axis-aligned walls) must reproduce the native
-essential free-slip solve bit-for-bit. Direct LU here; FMG wiring is a later step.
+The rotated saddle is solved by a self-contained fieldsplit-Schur KSP by default: the
+velocity block is geometric FMG on the custom prolongation (``set_custom_fmg``) when a
+hierarchy is registered, else GAMG; direct MUMPS LU is opt-in via ``solver._rotated_use_lu``.
+σ_nn / dynamic topography reuse the shared Consistent-Boundary-Flux de-smear in
+``underworld3.utilities.boundary_flux``.
 """
 import numpy as np
 from petsc4py import PETSc
@@ -214,6 +217,7 @@ def solve_rotated_freeslip(solver, boundaries, remove_rotation_gauge=True, verbo
     Aorig = J.copy()
     F0 = dm.getGlobalVec(); snes.computeFunction(U0, F0)
     b = F0.copy(); b.scale(-1.0)
+    dm.restoreGlobalVec(U0); dm.restoreGlobalVec(F0)   # borrowed temporaries → return to pool
 
     Q, Qt, normal_rows = build_rotation(solver, boundaries)
 
@@ -254,14 +258,14 @@ def solve_rotated_freeslip(solver, boundaries, remove_rotation_gauge=True, verbo
             ba = bhat.getArray(); ba[pin - brs] = 0.0; bhat.setArray(ba)
         ksp = PETSc.KSP().create(); ksp.setOperators(Ahat); ksp.setType("preonly")
         pc = ksp.getPC(); pc.setType("lu"); pc.setFactorSolverType("mumps")
-        Uhat = dm.getGlobalVec(); ksp.solve(bhat, Uhat)
+        Uhat = dm.createGlobalVec(); ksp.solve(bhat, Uhat)   # returned in info → own it
         ksp_reason = ksp.getConvergedReason()
     else:
         Uhat, ksp_reason = _solve_rotated_iterative(
             solver, Ahat, bhat, Q, Qt, normal_rows, verbose=verbose)
 
-    # rotate back u = Qᵀ û
-    U = dm.getGlobalVec(); Qt.mult(Uhat, U)
+    # rotate back u = Qᵀ û  (U is returned in info → create, don't borrow from the pool)
+    U = dm.createGlobalVec(); Qt.mult(Uhat, U)
 
     # Remove the rigid-rotation gauge ONLY when it is a genuine null space of the
     # constrained problem (closed circular/spherical free-slip); on straight walls
@@ -273,6 +277,7 @@ def solve_rotated_freeslip(solver, boundaries, remove_rotation_gauge=True, verbo
         tg = _rigid_rotation_global(solver)
         coef = U.dot(tg) / (tg.dot(tg) + 1e-30)
         U.axpy(-coef, tg)
+        dm.restoreGlobalVec(tg)                 # transient → return to pool
         removed = True
 
     # scatter U → velocity/pressure fields
@@ -403,14 +408,15 @@ def _rotated_nullspace(solver, Q, normal_rows):
     vecs = []
     # constant pressure (Q = identity on pressure → unchanged)
     if getattr(solver, "_petsc_use_pressure_nullspace", False):
-        pv = dm.getGlobalVec(); pv.set(0.0)
+        pv = dm.createGlobalVec(); pv.set(0.0)     # persists inside the returned NullSpace
         pis = solver._subdict["pressure"][0]
         sp = pv.getSubVector(pis); sp.set(1.0); pv.restoreSubVector(pis, sp)
         pv.normalize(); vecs.append(pv)
     # rigid rotation (rotated), only if it satisfies the constraints
     if solver.mesh.dim == 2 and _rotation_is_nullspace(solver, Q, normal_rows):
         tg = _rigid_rotation_global(solver)
-        tr = tg.duplicate(); Q.mult(tg, tr)
+        tr = tg.duplicate(); Q.mult(tg, tr)        # tr persists in the NullSpace
+        dm.restoreGlobalVec(tg)                    # tg transient → return to pool
         vecs.append(tr)
     if not vecs:
         return None
@@ -441,8 +447,10 @@ def _rotation_is_nullspace(solver, Q, normal_rows, tol=1e-8):
     collective norms below and deadlock."""
     if solver.mesh.dim != 2:
         return False
+    dm = solver.dm
     tg = _rigid_rotation_global(solver)
     tr = tg.duplicate(); Q.mult(tg, tr)
+    dm.restoreGlobalVec(tg)                       # tg transient → return to pool
     full = tr.norm()                              # parallel norm
     # norm of tr restricted to the constrained rows: zero everything else, then .norm()
     rs, re = tr.getOwnershipRange()
@@ -451,6 +459,7 @@ def _rotation_is_nullspace(solver, Q, normal_rows, tol=1e-8):
     tra = trc.getArray(); tga = tr.getArray()
     tra[loc] = tga[loc]; trc.setArray(tra)
     viol = trc.norm() / (full + 1e-30)            # parallel (collective on all ranks)
+    tr.destroy(); trc.destroy()                   # transient duplicates
     return viol < tol
 
 

--- a/src/underworld3/utilities/rotated_bc.py
+++ b/src/underworld3/utilities/rotated_bc.py
@@ -1,0 +1,333 @@
+"""Development version of underworld3.utilities.rotated_bc — reusable rotated
+strong free-slip for the Stokes saddle. Productizes the validated prototypes:
+build a per-node rotation Q from boundary normals, rotate the assembled saddle
+Â=Q A Qᵀ / b̂=Q b, impose v_n=0 on the rotated normal rows, solve, rotate back
+u=Qᵀû, remove the rigid-rotation gauge, and expose σ_nn as the constraint reaction.
+
+Increment 1: box-flat (Q=identity on axis-aligned walls) must reproduce the native
+essential free-slip solve bit-for-bit. Direct LU here; FMG wiring is a later step.
+"""
+import numpy as np
+import scipy.sparse as sp
+from petsc4py import PETSc
+
+
+# --------------------------------------------------------------------------- #
+#  Rotation construction
+# --------------------------------------------------------------------------- #
+def _velocity_field_id(solver):
+    return 0  # velocity is field 0 in the Stokes saddle
+
+
+def _point_coord(dm, dim, cvec, csec, v0, v1, q):
+    """Coordinate of a DMPlex point (vertex → its coord; higher point → mean of
+    its closure vertices)."""
+    if v0 <= q < v1:
+        return cvec[csec.getOffset(q) // dim]
+    clo = dm.getTransitiveClosure(q)[0]
+    verts = [int(c) for c in clo if v0 <= c < v1]
+    return np.mean([cvec[csec.getOffset(v) // dim] for v in verts], axis=0)
+
+
+def _boundary_velocity_nodes(solver, boundary, normal=None):
+    """DMPlex points carrying velocity DOFs on `boundary`, each with an outward
+    unit normal. Dimension-general (2D edges, 3D faces).
+
+    `normal` selects the normal source (per boundary):
+      * None      — geometric facet normal from PETSc ``computeCellGeometryFVM``
+                    (area-weighted, accumulated to the facet closure points).
+      * sympy 1×dim Matrix — an analytic normal (function of mesh.X); evaluated
+                    at each node's coordinate. Best for exact curved/planar faces
+                    (radial ``X/|X|`` on a spherical cap; a constant on a planar
+                    side of a regional spherical box).
+      * (dim,) array — a constant normal vector.
+    Returns ``[(point, n̂), ...]``.
+    """
+    dm = solver.dm
+    dim = solver.mesh.dim
+    csec = dm.getCoordinateSection()
+    cvec = np.asarray(dm.getCoordinatesLocal().array).reshape(-1, dim)
+    v0, v1 = dm.getDepthStratum(0)
+    lsec = dm.getLocalSection()
+    VEL = _velocity_field_id(solver)
+    interior_ref = cvec.mean(axis=0)
+    bval = [b.value for b in solver.mesh.boundaries if b.name == boundary][0]
+    facets = [int(z) for z in dm.getStratumIS(boundary, bval).getIndices()]
+    fS, fE = dm.getHeightStratum(1)              # facets (edges in 2D, faces in 3D)
+
+    def coord(q):
+        return _point_coord(dm, dim, cvec, csec, v0, v1, q)
+
+    # analytic / constant normal specs → per-node evaluation
+    sym_normal = None
+    const_normal = None
+    if normal is not None:
+        try:
+            import sympy
+            if isinstance(normal, sympy.Matrix):
+                sym_normal = normal
+        except Exception:
+            pass
+        if sym_normal is None:
+            const_normal = np.asarray(normal, dtype=float).ravel()
+
+    nacc = {}
+    pts = set()
+    for f in facets:
+        if not (fS <= f < fE):
+            continue
+        # facet outward normal
+        if normal is None:
+            _, cent, nrm = dm.computeCellGeometryFVM(f)
+            ne = np.asarray(nrm, dtype=float)
+            ne = ne / (np.linalg.norm(ne) + 1e-30)
+            if np.dot(ne, np.asarray(cent) - interior_ref) < 0:
+                ne = -ne
+        # all velocity points on this facet (closure): verts + edges(3D) + the facet
+        clo = dm.getTransitiveClosure(f)[0]
+        for q in (int(c) for c in clo):
+            if lsec.getFieldDof(q, VEL) <= 0:
+                continue
+            if normal is not None:
+                cq = coord(q)
+                if sym_normal is not None:
+                    ne = np.array([float(sym_normal[0, k].subs(
+                        dict(zip(solver.mesh.X, cq)))) for k in range(dim)])
+                else:
+                    ne = const_normal.copy()
+                ne = ne / (np.linalg.norm(ne) + 1e-30)
+            nacc[q] = nacc.get(q, np.zeros(dim)) + ne
+            pts.add(q)
+    out = []
+    for q in pts:
+        nrm = nacc[q] / (np.linalg.norm(nacc[q]) + 1e-30)
+        out.append((q, nrm))
+    return out
+
+
+def build_rotation(solver, boundaries):
+    """Global sparse rotation Q on the composite saddle vector: identity except a
+    per-node (normal,tangential) block at each velocity node of `boundaries`.
+    Returns (Q, Qt, normal_rows) where normal_rows are the global rows carrying
+    the rotated NORMAL velocity component (v_n = n̂·v), to be strongly constrained.
+    """
+    dm = solver.dm
+    N = dm.getGlobalVec().getSize()
+    gsec = dm.getGlobalSection()
+    lsec = dm.getLocalSection()
+    l2g = dm.getLGMap()
+    VEL = _velocity_field_id(solver)
+
+    # gather all normals per velocity node across the boundaries. Each entry of
+    # `boundaries` is a name (geometric normal) or a (name, normal) pair.
+    node_normals = {}
+    for spec in boundaries:
+        name, normal = spec if isinstance(spec, tuple) else (spec, None)
+        for q, nrm in _boundary_velocity_nodes(solver, name, normal=normal):
+            node_normals.setdefault(q, []).append(nrm)
+
+    dim = solver.mesh.dim
+    Qd = sp.lil_matrix((N, N))
+    Qd.setdiag(1.0)
+    normal_rows = []
+    for q, nrms in node_normals.items():
+        lo = lsec.getFieldOffset(q, VEL)
+        grows = [int(l2g.apply([lo + c])[0]) for c in range(dim)]
+        if any(g < 0 for g in grows):
+            continue
+        # DIMENSION-GENERAL constraint frame. The accumulated normals span a
+        # subspace S (rank r) that the velocity must be orthogonal to:
+        #   r=1  → a face  : constrain v_n, (dim-1) tangential free
+        #   r=2  → an edge : constrain 2 normal dirs, (dim-2) free (3D edge tangent)
+        #   r=dim→ a corner: v = 0 (fully pinned)
+        # Build an orthonormal frame E (dim×dim) whose first r rows span S and whose
+        # last (dim-r) rows are the free tangential complement (SVD right vectors are
+        # a complete orthonormal basis). Q's node block rows = E (rotated component
+        # i = E[i]·v); constrain the first r rotated rows.
+        M = np.array(nrms, dtype=float)
+        # SVD → Vt rows are an orthonormal basis; the first r span the normals.
+        _, sv, Vt = np.linalg.svd(M)
+        r = int((sv > 1e-8 * (sv[0] if sv.size else 1.0)).sum())
+        E = Vt                                   # (dim, dim) orthonormal frame
+        for i in range(dim):
+            for j in range(dim):
+                Qd[grows[i], grows[j]] = E[i, j]
+        normal_rows.extend(grows[:r])            # constrain the r normal-space rows
+    Qc = Qd.tocsr()
+    Q = PETSc.Mat().createAIJ(size=(N, N), csr=(Qc.indptr, Qc.indices, Qc.data))
+    Q.assemble()
+    Qt = Q.transpose(PETSc.Mat())
+    return Q, Qt, sorted(set(normal_rows))
+
+
+# --------------------------------------------------------------------------- #
+#  The rotated solve
+# --------------------------------------------------------------------------- #
+def solve_rotated_freeslip(solver, boundaries, remove_rotation_gauge=True, verbose=False):
+    """Assemble + solve the rotated strong-free-slip Stokes saddle. Fills the
+    solver's velocity/pressure fields with the (rotated-back, gauge-removed)
+    solution. Returns a dict with the rotation Q and reaction data for σ_nn.
+
+    Called from ``SNES_Stokes_SaddlePt.solve`` after ``_build`` (so the SNES/DM
+    exist); when used standalone it builds the solver itself."""
+    if getattr(solver, "snes", None) is None:
+        solver._setup_pointwise_functions()
+        solver._setup_discretisation()
+        solver._setup_solver()
+    dm = solver.dm
+    snes = solver.snes
+
+    Q, Qt, normal_rows = build_rotation(solver, boundaries)
+
+    # A = exact Jacobian at 0 (linear), b = -F(0)
+    U0 = dm.getGlobalVec(); U0.set(0.0)
+    J = snes.getJacobian()[0]; snes.computeJacobian(U0, J)
+    Aorig = J.copy()
+    F0 = dm.getGlobalVec(); snes.computeFunction(U0, F0)
+    b = F0.copy(); b.scale(-1.0)
+
+    # rotate: Â = Q A Qᵀ, b̂ = Q b
+    Ahat = Aorig.ptap(Qt)
+    bhat = b.duplicate(); Q.mult(b, bhat)
+
+    # pin one pressure DOF (datum) — row only, keeps B^T coupling
+    gsec = dm.getGlobalSection()
+    PRE = 1; pin = None; pS, pE = gsec.getChart()
+    for q in range(pS, pE):
+        if gsec.getFieldDof(q, PRE) > 0 and gsec.getFieldOffset(q, PRE) >= 0:
+            pin = gsec.getFieldOffset(q, PRE); break
+
+    # constrain rotated normal rows (v_n=0) + pin
+    Ahat.zeroRowsColumns(normal_rows, diag=1.0)
+    Ahat.zeroRows([pin], diag=1.0)
+    ba = bhat.getArray(); ba[normal_rows] = 0.0; ba[pin] = 0.0; bhat.setArray(ba)
+
+    # direct LU (FMG wiring later)
+    ksp = PETSc.KSP().create(); ksp.setOperators(Ahat); ksp.setType("preonly")
+    pc = ksp.getPC(); pc.setType("lu"); pc.setFactorSolverType("mumps")
+    Uhat = dm.getGlobalVec(); ksp.solve(bhat, Uhat)
+
+    # rotate back u = Qᵀ û → fields
+    U = dm.getGlobalVec(); Qt.mult(Uhat, U)
+    for name, var in solver.fields.items():
+        sg = U.getSubVector(solver._subdict[name][0])
+        solver._subdict[name][1].globalToLocal(sg, var.vec)
+        U.restoreSubVector(solver._subdict[name][0], sg)
+
+    # Remove the rigid-rotation gauge ONLY when it is a genuine null space of the
+    # constrained problem — i.e. when a rigid rotation satisfies every rotated
+    # v_n=0 constraint (true on closed circular/spherical free-slip boundaries;
+    # FALSE on straight walls, where rotation violates v_n=0 and the constraint
+    # itself pins it — projecting there would corrupt the solution).
+    removed = False
+    if remove_rotation_gauge and _rotation_is_nullspace(solver, Q, normal_rows):
+        _remove_rotation_gauge(solver)
+        removed = True
+
+    return {"Q": Q, "Qt": Qt, "A": Aorig, "b": b, "U": U, "Uhat": Uhat,
+            "normal_rows": normal_rows, "boundaries": list(boundaries),
+            "rotation_gauge_removed": removed, "ksp_reason": ksp.getConvergedReason()}
+
+
+def _rotation_is_nullspace(solver, Q, normal_rows, tol=1e-8):
+    """True iff the rigid-body rotation t=(-y,x) satisfies all rotated v_n=0
+    constraints — i.e. Q·t is ~0 on every constrained normal row."""
+    if solver.mesh.dim != 2 or not normal_rows:
+        return False
+    v = solver.Unknowns.u
+    c = v.coords
+    tloc = np.column_stack([-c[:, 1], c[:, 0]])
+    # scatter t into a composite global vector, rotate, check the normal rows
+    dm = solver.dm
+    tg = dm.getGlobalVec(); tg.set(0.0)
+    vname = "velocity"
+    sg = tg.getSubVector(solver._subdict[vname][0])
+    # write t into the velocity meshvar, push to the sub global vec
+    saved = v.data.copy()
+    v.data[...] = tloc
+    solver._subdict[vname][1].localToGlobal(v.vec, sg)
+    tg.restoreSubVector(solver._subdict[vname][0], sg)
+    v.data[...] = saved
+    tr = tg.duplicate(); Q.mult(tg, tr)
+    tra = tr.getArray()
+    viol = np.linalg.norm(tra[normal_rows]) / (np.linalg.norm(tra) + 1e-30)
+    return viol < tol
+
+
+def boundary_normal_traction(solver, boundary, info, consistent_mass=True):
+    """Consistent boundary normal traction σ_nn on `boundary` from the constraint
+    reaction of the last rotated-free-slip solve.
+
+    The reaction is r = Q(A·u − b): in the rotated frame its value at each node's
+    NORMAL row is the integrated nodal traction ∫_Γ(σ·n̂)φ_i. Map those rows to the
+    boundary P2 nodes and (optionally) solve the consistent P2 boundary mass to get
+    a pointwise σ_nn. Returned mean-removed (the ρg·h gauge).
+    """
+    dm = solver.dm
+    dim = solver.mesh.dim
+    Q = info["Q"]; A = info["A"]; b = info["b"]; U = info["U"]
+    # Cartesian residual r_c = A u − b, rotated: r = Q r_c
+    rc = A.createVecLeft(); A.mult(U, rc); rc.axpy(-1.0, b)
+    r = rc.duplicate(); Q.mult(rc, r)
+    ra = r.getArray()
+
+    lsec = dm.getLocalSection(); l2g = dm.getLGMap(); VEL = _velocity_field_id(solver)
+    csec = dm.getCoordinateSection()
+    cvec = np.asarray(dm.getCoordinatesLocal().array).reshape(-1, dim)
+    v0, v1 = dm.getDepthStratum(0)
+    normal = dict((nm, nrm) for nm, nrm in
+                  [(s if isinstance(s, tuple) else (s, None)) for s in info["boundaries"]]).get(boundary)
+    nodes = _boundary_velocity_nodes(solver, boundary, normal=normal)
+    # each face node: normal row = the frame row spanning its (single) normal = grows[0]
+    xs = []; Rn = []; pts = []
+    for q, nrm in nodes:
+        lo = lsec.getFieldOffset(q, VEL)
+        row = int(l2g.apply([lo])[0])            # frame row 0 = normal (single-boundary face)
+        if row < 0:
+            continue
+        xs.append(_point_coord(dm, dim, cvec, csec, v0, v1, q))
+        Rn.append(ra[row]); pts.append(q)
+    xs = np.array(xs); Rn = np.array(Rn)
+    if not consistent_mass or dim != 2:
+        sig = -Rn
+        return xs, sig - sig.mean()
+    # 2D consistent P2 boundary mass from DMPlex top-edge connectivity
+    sig = _consistent_mass_2d(solver, boundary, normal, pts, Rn)
+    return xs, sig
+
+
+def _consistent_mass_2d(solver, boundary, normal, pts, Rn):
+    """Solve M_Γ σ = −R with the consistent P2 line mass on `boundary` (2D)."""
+    dm = solver.dm; dim = 2
+    csec = dm.getCoordinateSection()
+    cvec = np.asarray(dm.getCoordinatesLocal().array).reshape(-1, dim)
+    v0, v1 = dm.getDepthStratum(0); e0, e1 = dm.getDepthStratum(1)
+    def vcoord(q): return cvec[csec.getOffset(q) // dim]
+    bval = [b.value for b in solver.mesh.boundaries if b.name == boundary][0]
+    edges = [q for q in (int(z) for z in dm.getStratumIS(boundary, bval).getIndices())
+             if e0 <= q < e1]
+    idx = {p: k for k, p in enumerate(pts)}
+    n = len(pts); M = np.zeros((n, n))
+    for e in edges:
+        a, b = (int(c) for c in dm.getCone(e))
+        if a not in idx or b not in idx or e not in idx:
+            continue
+        h = float(np.hypot(*(vcoord(b) - vcoord(a))))
+        Me = (h / 30.0) * np.array([[4., 2, -1], [2, 16, 2], [-1, 2, 4]])
+        tri = [idx[a], idx[e], idx[b]]
+        for ii in range(3):
+            for jj in range(3):
+                M[tri[ii], tri[jj]] += Me[ii, jj]
+    sig = np.linalg.solve(M, -np.asarray(Rn))
+    return sig - sig.mean()
+
+
+def _remove_rotation_gauge(solver):
+    """Project the rigid-body rotation t=(-y,x) out of the converged velocity
+    (Cartesian). Purely tangential → cannot introduce wall throughflow."""
+    v = solver.Unknowns.u
+    c = v.coords
+    t = np.column_stack([-c[:, 1], c[:, 0]])
+    coef = np.sum(v.data * t) / np.sum(t * t)
+    v.data[...] = v.data - coef * t
+    return coef

--- a/src/underworld3/utilities/rotated_bc.py
+++ b/src/underworld3/utilities/rotated_bc.py
@@ -8,7 +8,6 @@ Increment 1: box-flat (Q=identity on axis-aligned walls) must reproduce the nati
 essential free-slip solve bit-for-bit. Direct LU here; FMG wiring is a later step.
 """
 import numpy as np
-import scipy.sparse as sp
 from petsc4py import PETSc
 
 
@@ -52,23 +51,32 @@ def _boundary_velocity_nodes(solver, boundary, normal=None):
     VEL = _velocity_field_id(solver)
     interior_ref = cvec.mean(axis=0)
     bval = [b.value for b in solver.mesh.boundaries if b.name == boundary][0]
-    facets = [int(z) for z in dm.getStratumIS(boundary, bval).getIndices()]
+    # In parallel a rank may own NO part of this boundary → getStratumIS returns a
+    # null IS; calling getIndices() on it segfaults. Guard and return no local nodes.
+    sis = dm.getStratumIS(boundary, bval)
+    if sis is None or sis.handle == 0:
+        return []
+    facets = [int(z) for z in sis.getIndices()]
     fS, fE = dm.getHeightStratum(1)              # facets (edges in 2D, faces in 3D)
 
     def coord(q):
         return _point_coord(dm, dim, cvec, csec, v0, v1, q)
 
-    # analytic / constant normal specs → per-node evaluation
-    sym_normal = None
+    # analytic / constant normal specs. An analytic (sympy) normal is LAMBDIFIED
+    # once into a fast numpy callable — per-node sympy .subs() is orders of magnitude
+    # slower and, in parallel, serialises on the rank that owns the boundary (the
+    # others idle), which looked like a hang.
+    sym_fn = None
     const_normal = None
     if normal is not None:
         try:
             import sympy
             if isinstance(normal, sympy.Matrix):
-                sym_normal = normal
+                sym_fn = sympy.lambdify(list(solver.mesh.X),
+                                        [normal[0, k] for k in range(dim)], "numpy")
         except Exception:
-            pass
-        if sym_normal is None:
+            sym_fn = None
+        if sym_fn is None:
             const_normal = np.asarray(normal, dtype=float).ravel()
 
     nacc = {}
@@ -89,10 +97,9 @@ def _boundary_velocity_nodes(solver, boundary, normal=None):
             if lsec.getFieldDof(q, VEL) <= 0:
                 continue
             if normal is not None:
-                cq = coord(q)
-                if sym_normal is not None:
-                    ne = np.array([float(sym_normal[0, k].subs(
-                        dict(zip(solver.mesh.X, cq)))) for k in range(dim)])
+                if sym_fn is not None:
+                    cq = coord(q)
+                    ne = np.asarray(sym_fn(*cq), dtype=float).ravel()
                 else:
                     ne = const_normal.copy()
                 ne = ne / (np.linalg.norm(ne) + 1e-30)
@@ -112,11 +119,10 @@ def build_rotation(solver, boundaries):
     the rotated NORMAL velocity component (v_n = n̂·v), to be strongly constrained.
     """
     dm = solver.dm
-    N = dm.getGlobalVec().getSize()
-    gsec = dm.getGlobalSection()
     lsec = dm.getLocalSection()
     l2g = dm.getLGMap()
     VEL = _velocity_field_id(solver)
+    dim = solver.mesh.dim
 
     # gather all normals per velocity node across the boundaries. Each entry of
     # `boundaries` is a name (geometric normal) or a (name, normal) pair.
@@ -126,35 +132,44 @@ def build_rotation(solver, boundaries):
         for q, nrm in _boundary_velocity_nodes(solver, name, normal=normal):
             node_normals.setdefault(q, []).append(nrm)
 
-    dim = solver.mesh.dim
-    Qd = sp.lil_matrix((N, N))
-    Qd.setdiag(1.0)
+    # Distributed Q with the assembled operator's ROW layout. Q is identity except a
+    # per-node dim×dim orthonormal block; because a node's dim velocity components
+    # live on a SINGLE DMPlex point owned by ONE rank, each block is entirely within
+    # that rank's diagonal portion — no off-rank columns. Each rank sets ONLY its
+    # owned rows (ghost copies of a shared boundary node are skipped: their global
+    # rows fall outside [rstart, rend)).
+    A = solver.snes.getJacobian()[0]
+    rstart, rend = A.getOwnershipRange()
+    nloc = rend - rstart
+    N = A.getSize()[0]
+    Q = PETSc.Mat().create(comm=dm.comm)
+    Q.setSizes(((nloc, N), (nloc, N)))
+    Q.setType("aij")
+    Q.setPreallocationNNZ((dim, 0))
+    Q.setOption(PETSc.Mat.Option.NEW_NONZERO_ALLOCATION_ERR, False)
+    for i in range(rstart, rend):
+        Q.setValue(i, i, 1.0)                    # identity default (owned rows)
+
     normal_rows = []
     for q, nrms in node_normals.items():
         lo = lsec.getFieldOffset(q, VEL)
         grows = [int(l2g.apply([lo + c])[0]) for c in range(dim)]
         if any(g < 0 for g in grows):
             continue
-        # DIMENSION-GENERAL constraint frame. The accumulated normals span a
-        # subspace S (rank r) that the velocity must be orthogonal to:
-        #   r=1  → a face  : constrain v_n, (dim-1) tangential free
-        #   r=2  → an edge : constrain 2 normal dirs, (dim-2) free (3D edge tangent)
-        #   r=dim→ a corner: v = 0 (fully pinned)
-        # Build an orthonormal frame E (dim×dim) whose first r rows span S and whose
-        # last (dim-r) rows are the free tangential complement (SVD right vectors are
-        # a complete orthonormal basis). Q's node block rows = E (rotated component
-        # i = E[i]·v); constrain the first r rotated rows.
+        if not (rstart <= grows[0] < rend):      # not owned by this rank → skip
+            continue
+        # DIMENSION-GENERAL constraint frame: the accumulated normals span a rank-r
+        # subspace the velocity must be orthogonal to (r=1 face → constrain v_n;
+        # r=2 edge → constrain 2, free the edge tangent; r=dim corner → v=0). The SVD
+        # right vectors are a complete orthonormal frame E; Q's node block rows = E
+        # (rotated component i = E[i]·v); constrain the first r rotated rows.
         M = np.array(nrms, dtype=float)
-        # SVD → Vt rows are an orthonormal basis; the first r span the normals.
         _, sv, Vt = np.linalg.svd(M)
         r = int((sv > 1e-8 * (sv[0] if sv.size else 1.0)).sum())
-        E = Vt                                   # (dim, dim) orthonormal frame
         for i in range(dim):
             for j in range(dim):
-                Qd[grows[i], grows[j]] = E[i, j]
+                Q.setValue(grows[i], grows[j], float(Vt[i, j]))
         normal_rows.extend(grows[:r])            # constrain the r normal-space rows
-    Qc = Qd.tocsr()
-    Q = PETSc.Mat().createAIJ(size=(N, N), csr=(Qc.indptr, Qc.indices, Qc.data))
     Q.assemble()
     Qt = Q.transpose(PETSc.Mat())
     return Q, Qt, sorted(set(normal_rows))
@@ -177,14 +192,16 @@ def solve_rotated_freeslip(solver, boundaries, remove_rotation_gauge=True, verbo
     dm = solver.dm
     snes = solver.snes
 
-    Q, Qt, normal_rows = build_rotation(solver, boundaries)
-
-    # A = exact Jacobian at 0 (linear), b = -F(0)
+    # Assemble the operator FIRST so its parallel row layout is final before we build
+    # Q against it (A = exact Jacobian at 0 — linear; b = -F(0)).
+    snes.setUp()
     U0 = dm.getGlobalVec(); U0.set(0.0)
     J = snes.getJacobian()[0]; snes.computeJacobian(U0, J)
     Aorig = J.copy()
     F0 = dm.getGlobalVec(); snes.computeFunction(U0, F0)
     b = F0.copy(); b.scale(-1.0)
+
+    Q, Qt, normal_rows = build_rotation(solver, boundaries)
 
     # rotate: Â = Q A Qᵀ, b̂ = Q b
     Ahat = Aorig.ptap(Qt)
@@ -219,22 +236,26 @@ def solve_rotated_freeslip(solver, boundaries, remove_rotation_gauge=True, verbo
         Uhat, ksp_reason = _solve_rotated_iterative(
             solver, Ahat, bhat, Q, Qt, normal_rows, verbose=verbose)
 
-    # rotate back u = Qᵀ û → fields
+    # rotate back u = Qᵀ û
     U = dm.getGlobalVec(); Qt.mult(Uhat, U)
+
+    # Remove the rigid-rotation gauge ONLY when it is a genuine null space of the
+    # constrained problem (closed circular/spherical free-slip); on straight walls
+    # the constraint pins the rotation, and projecting would corrupt the solution.
+    # Done on the GLOBAL vector U with PETSc dots (parallel-correct ownership — a
+    # local nodal sum would double-count shared nodes at rank boundaries).
+    removed = False
+    if remove_rotation_gauge and _rotation_is_nullspace(solver, Q, normal_rows):
+        tg = _rigid_rotation_global(solver)
+        coef = U.dot(tg) / (tg.dot(tg) + 1e-30)
+        U.axpy(-coef, tg)
+        removed = True
+
+    # scatter U → velocity/pressure fields
     for name, var in solver.fields.items():
         sg = U.getSubVector(solver._subdict[name][0])
         solver._subdict[name][1].globalToLocal(sg, var.vec)
         U.restoreSubVector(solver._subdict[name][0], sg)
-
-    # Remove the rigid-rotation gauge ONLY when it is a genuine null space of the
-    # constrained problem — i.e. when a rigid rotation satisfies every rotated
-    # v_n=0 constraint (true on closed circular/spherical free-slip boundaries;
-    # FALSE on straight walls, where rotation violates v_n=0 and the constraint
-    # itself pins it — projecting there would corrupt the solution).
-    removed = False
-    if remove_rotation_gauge and _rotation_is_nullspace(solver, Q, normal_rows):
-        _remove_rotation_gauge(solver)
-        removed = True
 
     return {"Q": Q, "Qt": Qt, "A": Aorig, "b": b, "U": U, "Uhat": Uhat,
             "normal_rows": normal_rows, "boundaries": list(boundaries),
@@ -306,8 +327,9 @@ def _solve_rotated_iterative(solver, Ahat, bhat, Q, Qt, normal_rows, verbose=Fal
     # made these DOFs fully decoupled (row AND column zeroed), û_i affects no other
     # equation → setting them to exactly 0 here makes the strong v_n=0 BC exact
     # independent of the iterative tolerance, without perturbing the rest.
-    ua = Uhat.getArray(); ua[np.asarray(normal_rows, dtype=np.int64)] = 0.0
-    Uhat.setArray(ua)
+    rs, re = Uhat.getOwnershipRange()
+    loc = np.asarray([g - rs for g in normal_rows if rs <= g < re], dtype=np.int64)
+    ua = Uhat.getArray(); ua[loc] = 0.0; Uhat.setArray(ua)
     if verbose:
         from underworld3 import mpi
         kind = "custom-FMG" if custom_Pl is not None else "GAMG"
@@ -330,7 +352,6 @@ def _rotated_nullspace(solver, Q, normal_rows):
     """
     dm = solver.dm
     vecs = []
-    nrows = np.asarray(normal_rows, dtype=np.int32)
     # constant pressure (Q = identity on pressure → unchanged)
     if getattr(solver, "_petsc_use_pressure_nullspace", False):
         pv = dm.getGlobalVec(); pv.set(0.0)
@@ -339,15 +360,7 @@ def _rotated_nullspace(solver, Q, normal_rows):
         pv.normalize(); vecs.append(pv)
     # rigid rotation (rotated), only if it satisfies the constraints
     if solver.mesh.dim == 2 and _rotation_is_nullspace(solver, Q, normal_rows):
-        v = solver.Unknowns.u
-        c = v.coords
-        saved = v.data.copy()
-        v.data[...] = np.column_stack([-c[:, 1], c[:, 0]])
-        tg = dm.getGlobalVec(); tg.set(0.0)
-        vis = solver._subdict["velocity"][0]
-        sg = tg.getSubVector(vis); solver._subdict["velocity"][1].localToGlobal(v.vec, sg)
-        tg.restoreSubVector(vis, sg)
-        v.data[...] = saved
+        tg = _rigid_rotation_global(solver)
         tr = tg.duplicate(); Q.mult(tg, tr)
         vecs.append(tr)
     if not vecs:
@@ -355,8 +368,10 @@ def _rotated_nullspace(solver, Q, normal_rows):
     # Make every null-space vector EXACTLY compatible with the strong v_n=0
     # constraint (zero at the constrained rows), then orthonormalise. This is what
     # keeps the wall-normal velocity exact under an iterative solve.
+    rs, re = vecs[0].getOwnershipRange()
+    loc = np.asarray([g - rs for g in normal_rows if rs <= g < re], dtype=np.int64)
     for w in vecs:
-        wa = w.getArray(); wa[nrows] = 0.0; w.setArray(wa)
+        wa = w.getArray(); wa[loc] = 0.0; w.setArray(wa)
     ortho = []
     for w in vecs:
         for u in ortho:
@@ -369,26 +384,24 @@ def _rotated_nullspace(solver, Q, normal_rows):
 
 def _rotation_is_nullspace(solver, Q, normal_rows, tol=1e-8):
     """True iff the rigid-body rotation t=(-y,x) satisfies all rotated v_n=0
-    constraints — i.e. Q·t is ~0 on every constrained normal row."""
-    if solver.mesh.dim != 2 or not normal_rows:
+    constraints — i.e. Q·t is ~0 on every constrained normal row.
+
+    COLLECTIVE: every rank runs the same global-vector ops. Do NOT early-return on
+    a per-rank ``not normal_rows`` — in parallel a rank may own no boundary node
+    (empty normal_rows) while others do, and an early return there would desync the
+    collective norms below and deadlock."""
+    if solver.mesh.dim != 2:
         return False
-    v = solver.Unknowns.u
-    c = v.coords
-    tloc = np.column_stack([-c[:, 1], c[:, 0]])
-    # scatter t into a composite global vector, rotate, check the normal rows
-    dm = solver.dm
-    tg = dm.getGlobalVec(); tg.set(0.0)
-    vname = "velocity"
-    sg = tg.getSubVector(solver._subdict[vname][0])
-    # write t into the velocity meshvar, push to the sub global vec
-    saved = v.data.copy()
-    v.data[...] = tloc
-    solver._subdict[vname][1].localToGlobal(v.vec, sg)
-    tg.restoreSubVector(solver._subdict[vname][0], sg)
-    v.data[...] = saved
+    tg = _rigid_rotation_global(solver)
     tr = tg.duplicate(); Q.mult(tg, tr)
-    tra = tr.getArray()
-    viol = np.linalg.norm(tra[normal_rows]) / (np.linalg.norm(tra) + 1e-30)
+    full = tr.norm()                              # parallel norm
+    # norm of tr restricted to the constrained rows: zero everything else, then .norm()
+    rs, re = tr.getOwnershipRange()
+    loc = np.asarray([g - rs for g in normal_rows if rs <= g < re], dtype=np.int64)
+    trc = tr.duplicate(); trc.set(0.0)
+    tra = trc.getArray(); tga = tr.getArray()
+    tra[loc] = tga[loc]; trc.setArray(tra)
+    viol = trc.norm() / (full + 1e-30)            # parallel (collective on all ranks)
     return viol < tol
 
 
@@ -442,8 +455,9 @@ def _consistent_mass_2d(solver, boundary, normal, pts, Rn):
     v0, v1 = dm.getDepthStratum(0); e0, e1 = dm.getDepthStratum(1)
     def vcoord(q): return cvec[csec.getOffset(q) // dim]
     bval = [b.value for b in solver.mesh.boundaries if b.name == boundary][0]
-    edges = [q for q in (int(z) for z in dm.getStratumIS(boundary, bval).getIndices())
-             if e0 <= q < e1]
+    sis = dm.getStratumIS(boundary, bval)
+    strat = [] if (sis is None or sis.handle == 0) else [int(z) for z in sis.getIndices()]
+    edges = [q for q in strat if e0 <= q < e1]
     idx = {p: k for k, p in enumerate(pts)}
     n = len(pts); M = np.zeros((n, n))
     for e in edges:
@@ -460,12 +474,19 @@ def _consistent_mass_2d(solver, boundary, normal, pts, Rn):
     return sig - sig.mean()
 
 
-def _remove_rotation_gauge(solver):
-    """Project the rigid-body rotation t=(-y,x) out of the converged velocity
-    (Cartesian). Purely tangential → cannot introduce wall throughflow."""
+def _rigid_rotation_global(solver):
+    """The Cartesian rigid-body rotation t=(-y,x) as a composite GLOBAL vector
+    (velocity DOFs only, zero pressure). Parallel-safe: built via localToGlobal on
+    the velocity sub-DM, so shared nodes are handled by PETSc, not double-counted."""
+    dm = solver.dm
     v = solver.Unknowns.u
     c = v.coords
-    t = np.column_stack([-c[:, 1], c[:, 0]])
-    coef = np.sum(v.data * t) / np.sum(t * t)
-    v.data[...] = v.data - coef * t
-    return coef
+    saved = v.data.copy()
+    v.data[...] = np.column_stack([-c[:, 1], c[:, 0]])
+    tg = dm.getGlobalVec(); tg.set(0.0)
+    vis = solver._subdict["velocity"][0]
+    sg = tg.getSubVector(vis)
+    solver._subdict["velocity"][1].localToGlobal(v.vec, sg)
+    tg.restoreSubVector(vis, sg)
+    v.data[...] = saved
+    return tg

--- a/src/underworld3/utilities/rotated_bc.py
+++ b/src/underworld3/utilities/rotated_bc.py
@@ -197,15 +197,27 @@ def solve_rotated_freeslip(solver, boundaries, remove_rotation_gauge=True, verbo
         if gsec.getFieldDof(q, PRE) > 0 and gsec.getFieldOffset(q, PRE) >= 0:
             pin = gsec.getFieldOffset(q, PRE); break
 
-    # constrain rotated normal rows (v_n=0) + pin
+    # constrain rotated normal rows (v_n=0): zero the matrix rows/cols (identity
+    # diagonal) AND the RHS at those rows — zeroRowsColumns does NOT touch the RHS,
+    # so a nonzero b there would leak straight into the solution (û_i = b_i / 1),
+    # independent of the solver/tolerance.
     Ahat.zeroRowsColumns(normal_rows, diag=1.0)
-    Ahat.zeroRows([pin], diag=1.0)
-    ba = bhat.getArray(); ba[normal_rows] = 0.0; ba[pin] = 0.0; bhat.setArray(ba)
+    ba = bhat.getArray(); ba[normal_rows] = 0.0; bhat.setArray(ba)
 
-    # direct LU (FMG wiring later)
-    ksp = PETSc.KSP().create(); ksp.setOperators(Ahat); ksp.setType("preonly")
-    pc = ksp.getPC(); pc.setType("lu"); pc.setFactorSolverType("mumps")
-    Uhat = dm.getGlobalVec(); ksp.solve(bhat, Uhat)
+    # ITERATIVE by default (LU is almost never right): a self-contained fieldsplit-
+    # Schur solve whose velocity block is geometric FMG on the custom prolongation
+    # when a hierarchy is registered (set_custom_fmg), else GAMG. Direct LU only when
+    # explicitly opted in via solver._rotated_use_lu.
+    if getattr(solver, "_rotated_use_lu", False):
+        Ahat.zeroRows([pin], diag=1.0)
+        ba = bhat.getArray(); ba[pin] = 0.0; bhat.setArray(ba)
+        ksp = PETSc.KSP().create(); ksp.setOperators(Ahat); ksp.setType("preonly")
+        pc = ksp.getPC(); pc.setType("lu"); pc.setFactorSolverType("mumps")
+        Uhat = dm.getGlobalVec(); ksp.solve(bhat, Uhat)
+        ksp_reason = ksp.getConvergedReason()
+    else:
+        Uhat, ksp_reason = _solve_rotated_iterative(
+            solver, Ahat, bhat, Q, Qt, normal_rows, verbose=verbose)
 
     # rotate back u = Qᵀ û → fields
     U = dm.getGlobalVec(); Qt.mult(Uhat, U)
@@ -226,7 +238,133 @@ def solve_rotated_freeslip(solver, boundaries, remove_rotation_gauge=True, verbo
 
     return {"Q": Q, "Qt": Qt, "A": Aorig, "b": b, "U": U, "Uhat": Uhat,
             "normal_rows": normal_rows, "boundaries": list(boundaries),
-            "rotation_gauge_removed": removed, "ksp_reason": ksp.getConvergedReason()}
+            "rotation_gauge_removed": removed, "ksp_reason": ksp_reason}
+
+
+def _solve_rotated_iterative(solver, Ahat, bhat, Q, Qt, normal_rows, verbose=False):
+    """Solve the rotated saddle with a SELF-CONTAINED fieldsplit-Schur KSP on the
+    rotated operator. The velocity block is geometric FMG on the CUSTOM prolongation
+    (PR#290, rotated) when a hierarchy is registered (``set_custom_fmg``), else GAMG.
+
+    A plain rotated Mat has no DM field info, so UW3's DM-coupled fieldsplit cannot
+    split it — we build the split from EXPLICIT velocity/pressure index sets. For the
+    custom-FMG case the velocity sub-PC gets our prolongation via ``setMGInterpolation``
+    (needs no DM); the rotated block A_vv = Q_v A_vv Q_vᵀ is formed from Âhat
+    automatically and only the FINE prolongation is rotated (Galerkin coarse ops
+    auto-correct). NO direct solve of the fine system."""
+    from underworld3.utilities import custom_mg
+    dm = solver.dm
+    vel_is = solver._subdict["velocity"][0]
+    pres_is = solver._subdict["pressure"][0]
+
+    custom_Pl = None
+    if getattr(solver, "_custom_mg", None) is not None:
+        vis = np.asarray(vel_is.getIndices())
+        g2blk = {int(g): k for k, g in enumerate(vis)}
+        Qv = Q.createSubMatrix(vel_is, vel_is)
+        nrows_blk = sorted({g2blk[g] for g in normal_rows if g in g2blk})
+        Ps = solver._custom_mg["hierarchy"].build(solver)
+        Pfine = Qv.matMult(Ps[-1]); Pfine.zeroRows(nrows_blk, diag=0.0)
+        custom_Pl = list(Ps[:-1]) + [Pfine]
+
+    # rotated coupled null space (pressure-const ⊕ Q·rotation) on the operator
+    nsp = _rotated_nullspace(solver, Q, normal_rows)
+    if nsp is not None:
+        Ahat.setNullSpace(nsp); Ahat.setTransposeNullSpace(nsp); nsp.remove(bhat)
+
+    pfx = "rotfs_"
+    opts = PETSc.Options()
+    cfg = {
+        "ksp_type": "fgmres", "ksp_rtol": str(float(solver.tolerance)), "ksp_max_it": "300",
+        "pc_type": "fieldsplit", "pc_fieldsplit_type": "schur",
+        "pc_fieldsplit_schur_fact_type": "full", "pc_fieldsplit_schur_precondition": "selfp",
+        "fieldsplit_vel_ksp_type": "preonly",
+        "fieldsplit_pres_ksp_type": "fgmres", "fieldsplit_pres_ksp_rtol": "1e-6",
+        "fieldsplit_pres_ksp_max_it": "200", "fieldsplit_pres_pc_type": "jacobi",
+    }
+    if custom_Pl is None:                             # GAMG velocity block
+        cfg["fieldsplit_vel_pc_type"] = "gamg"
+    for k, v in cfg.items():
+        opts[pfx + k] = v
+    ksp = PETSc.KSP().create(comm=dm.comm); ksp.setOptionsPrefix(pfx)
+    ksp.setOperators(Ahat)
+    pc = ksp.getPC(); pc.setType("fieldsplit")
+    pc.setFieldSplitIS(("vel", vel_is), ("pres", pres_is))
+    ksp.setFromOptions()
+    pc.setUp()
+    if custom_Pl is not None:                         # geometric FMG via custom P
+        vel_pc = pc.getFieldSplitSubKSP()[0].getPC()
+        A_vv, P_vv = vel_pc.getOperators()
+        vel_pc.reset(); vel_pc.setOperators(A_vv, P_vv)
+        custom_mg._configure_pcmg(vel_pc, custom_Pl)
+        vel_pc.setUp()
+
+    Uhat = Ahat.createVecRight(); Uhat.set(0.0)
+    ksp.solve(bhat, Uhat)
+    # An identity constraint row in an ITERATIVE solve only drives its residual
+    # (= û_i) below tolerance, so û_i ~ tol, not exactly 0. Because zeroRowsColumns
+    # made these DOFs fully decoupled (row AND column zeroed), û_i affects no other
+    # equation → setting them to exactly 0 here makes the strong v_n=0 BC exact
+    # independent of the iterative tolerance, without perturbing the rest.
+    ua = Uhat.getArray(); ua[np.asarray(normal_rows, dtype=np.int64)] = 0.0
+    Uhat.setArray(ua)
+    if verbose:
+        from underworld3 import mpi
+        kind = "custom-FMG" if custom_Pl is not None else "GAMG"
+        mpi.pprint(f"[rotated_bc] velocity block = {kind}; outer KSP "
+                   f"{ksp.getConvergedReason()} in {ksp.getIterationNumber()} its")
+    return Uhat, ksp.getConvergedReason()
+
+
+def _rotated_nullspace(solver, Q, normal_rows):
+    """Coupled Stokes null space in the rotated frame: constant pressure, plus the
+    rigid rotation Q·(-y,x) when it is a genuine null space of the constraints.
+    Returns a PETSc.NullSpace on the composite vector, or None.
+
+    Each vector is ZEROED at the constrained normal rows so it is exactly compatible
+    with the strong v_n=0 constraint. Without this, a rotation-mode vector that is
+    only ~O(h²)-small at the constrained rows (curved boundary: the normal in Q is
+    sampled at the chord midpoint, the rotation at the true P2 node) would, when
+    PETSc projects the solution onto the null space, inject a spurious wall-normal
+    component — a strong BC must be exact, independent of the iterative solve.
+    """
+    dm = solver.dm
+    vecs = []
+    nrows = np.asarray(normal_rows, dtype=np.int32)
+    # constant pressure (Q = identity on pressure → unchanged)
+    if getattr(solver, "_petsc_use_pressure_nullspace", False):
+        pv = dm.getGlobalVec(); pv.set(0.0)
+        pis = solver._subdict["pressure"][0]
+        sp = pv.getSubVector(pis); sp.set(1.0); pv.restoreSubVector(pis, sp)
+        pv.normalize(); vecs.append(pv)
+    # rigid rotation (rotated), only if it satisfies the constraints
+    if solver.mesh.dim == 2 and _rotation_is_nullspace(solver, Q, normal_rows):
+        v = solver.Unknowns.u
+        c = v.coords
+        saved = v.data.copy()
+        v.data[...] = np.column_stack([-c[:, 1], c[:, 0]])
+        tg = dm.getGlobalVec(); tg.set(0.0)
+        vis = solver._subdict["velocity"][0]
+        sg = tg.getSubVector(vis); solver._subdict["velocity"][1].localToGlobal(v.vec, sg)
+        tg.restoreSubVector(vis, sg)
+        v.data[...] = saved
+        tr = tg.duplicate(); Q.mult(tg, tr)
+        vecs.append(tr)
+    if not vecs:
+        return None
+    # Make every null-space vector EXACTLY compatible with the strong v_n=0
+    # constraint (zero at the constrained rows), then orthonormalise. This is what
+    # keeps the wall-normal velocity exact under an iterative solve.
+    for w in vecs:
+        wa = w.getArray(); wa[nrows] = 0.0; w.setArray(wa)
+    ortho = []
+    for w in vecs:
+        for u in ortho:
+            w.axpy(-w.dot(u), u)
+        nrm = w.norm()
+        if nrm > 1e-14:
+            w.scale(1.0 / nrm); ortho.append(w)
+    return PETSc.NullSpace().create(constant=False, vectors=ortho, comm=dm.comm)
 
 
 def _rotation_is_nullspace(solver, Q, normal_rows, tol=1e-8):

--- a/tests/parallel/test_1064_rotated_freeslip_parallel.py
+++ b/tests/parallel/test_1064_rotated_freeslip_parallel.py
@@ -51,6 +51,8 @@ GOLDEN_ANNULUS_FMG = (1.906961759626e-02, 5.428193e-06, 1.177002e-06)
 # box sigma_nn (boundary_normal_traction on Top, default lumped mass) vs analytic SolCx
 # sigma_yy, whole boundary: (relL2, |corr|). Recompute with `python <thisfile> sigma`.
 GOLDEN_BOX_SIGMA = (3.985444e-02, 0.999208)
+# dynamic_topography field: BdIntegral L2 of h over Top. Recompute `python <thisfile> topo`.
+GOLDEN_TOPO_BDL2 = 2.560593173e-01
 
 
 def _wrap(dm, m0):
@@ -205,6 +207,32 @@ def _box_sigma_diagnostics():
     return comm.bcast(result, root=0)
 
 
+def _box_topography_bdl2():
+    """dynamic_topography onto a P1 surface field; return the (collective) BdIntegral L2
+    of h over Top — a partition-independent scalar functional of the topography field."""
+    res = 48
+    mesh = uw.meshing.StructuredQuadBox(
+        elementRes=(res, res), minCoords=(0, 0), maxCoords=(1, 1), qdegree=3)
+    sol = A.SolCx(mesh, eta_A=1.0, eta_B=1.0e3, x_c=0.5, n=1)
+    v = uw.discretisation.MeshVariable("vTf", mesh, mesh.dim, degree=2, continuous=True)
+    p = uw.discretisation.MeshVariable("pTf", mesh, 1, degree=1, continuous=False)
+    hf = uw.discretisation.MeshVariable("hTf", mesh, 1, degree=1, continuous=True)
+    s = uw.systems.Stokes(mesh, velocityField=v, pressureField=p)
+    s.constitutive_model = uw.constitutive_models.ViscousFlowModel
+    s.constitutive_model.Parameters.shear_viscosity_0 = sol.fn_viscosity
+    s.bodyforce = sol.fn_bodyforce
+    s.penalty = 0.0
+    s.tolerance = 1e-9
+    for wall in ("Top", "Bottom", "Left", "Right"):
+        s.add_rotated_freeslip_bc(wall)
+    s.petsc_use_pressure_nullspace = True
+    s.petsc_options["snes_type"] = "ksponly"
+    s.solve()
+    s.dynamic_topography("Top", hf, buoyancy_scale=1.0)
+    return float(np.sqrt(uw.maths.BdIntegral(
+        mesh=mesh, fn=hf.sym[0] ** 2, boundary="Top").evaluate()))
+
+
 def test_rotated_freeslip_box_partition_independent():
     """Box: the parallel rotated free-slip solve reproduces the serial velocity L2 and
     keeps the analytic velocity error small."""
@@ -265,12 +293,27 @@ def test_rotated_freeslip_box_sigma_nn_partition_independent():
     assert relL2 < 0.08, f"sigma_nn relL2 vs analytic {relL2:.3f} too large"
 
 
+def test_rotated_freeslip_dynamic_topography_partition_independent():
+    """The dynamic_topography surface field is partition-independent: the collective
+    BdIntegral L2 of h over Top matches the serial reference at np=2/4. Guards the
+    field write (a per-node write would deadlock when a rank owns none of the boundary)
+    and the parallel reaction recovery underneath."""
+    bdl2 = _box_topography_bdl2()
+    assert np.isclose(bdl2, GOLDEN_TOPO_BDL2, rtol=1e-6, atol=0), (
+        f"topography BdIntegral L2 differs serial vs np={uw.mpi.size}: "
+        f"{GOLDEN_TOPO_BDL2} vs {bdl2}")
+
+
 if __name__ == "__main__":
     # Recompute the serial GOLDEN references:
-    #   `python <thisfile> {box,annulus,annulus_fmg,sigma}`.
+    #   `python <thisfile> {box,annulus,annulus_fmg,sigma,topo}`.
     import sys
     _kind = sys.argv[1] if len(sys.argv) > 1 else "box"
-    if _kind == "sigma":
+    if _kind == "topo":
+        _b = _box_topography_bdl2()
+        if uw.mpi.rank == 0:
+            print(f"DIAG_TOPO bdl2={_b:.9e}")
+    elif _kind == "sigma":
         _r = _box_sigma_diagnostics()
         if uw.mpi.rank == 0:
             print(f"DIAG_SIGMA relL2={_r[0]:.6e} corr={_r[1]:.6f} nodes={_r[2]}")

--- a/tests/parallel/test_1064_rotated_freeslip_parallel.py
+++ b/tests/parallel/test_1064_rotated_freeslip_parallel.py
@@ -48,9 +48,9 @@ GOLDEN_ANNULUS = (1.897011154231e-02, 4.563841e-05, 9.341699e-06)
 # annulus driven by CUSTOM GEOMETRIC FMG on the velocity block (nested hierarchy):
 # (velocity L2, radial-leakage L2 on Lower arc, radial-leakage L2 on Upper arc)
 GOLDEN_ANNULUS_FMG = (1.906961759626e-02, 5.428193e-06, 1.177002e-06)
-# box sigma_nn (boundary_normal_traction on Top) vs analytic SolCx sigma_yy, whole
-# boundary: (relL2, |corr|). Recompute with `python <thisfile> sigma`.
-GOLDEN_BOX_SIGMA = (4.194316e-02, 0.999122)
+# box sigma_nn (boundary_normal_traction on Top, default lumped mass) vs analytic SolCx
+# sigma_yy, whole boundary: (relL2, |corr|). Recompute with `python <thisfile> sigma`.
+GOLDEN_BOX_SIGMA = (3.985444e-02, 0.999208)
 
 
 def _wrap(dm, m0):

--- a/tests/parallel/test_1064_rotated_freeslip_parallel.py
+++ b/tests/parallel/test_1064_rotated_freeslip_parallel.py
@@ -1,0 +1,146 @@
+"""Parallel regression test for rotated strong free-slip (``add_rotated_freeslip_bc``).
+
+The rotated free-slip solve (per-node DOF rotation → strong ``v_n=0`` on the rotated
+normal rows → rotate back → gauge removal) was previously validated serially only
+(``tests/test_1018_rotated_freeslip.py``). At np>1 it crashed: the RHS constrained-row
+zeroing indexed the *local* slice with *global* row indices, which overflows on any rank
+whose ownership does not start at 0 — an asymmetric crash that masqueraded as a hang.
+With that fixed, the whole global system (and hence the velocity solve and the wall-normal
+leakage) is partition-independent.
+
+This test verifies that the parallel solve reproduces the serial reference to a tight
+tolerance for two geometries:
+
+  * **box** — 4-wall rotated free-slip on axis-aligned walls (GAMG velocity block); the
+    velocity L2 ``∫ v·v`` must match serial (bit-identical up to the parallel reduction
+    order), and the analytic SolCx velocity error must stay small.
+  * **annulus** — per-node *radial* free-slip on both arcs with the analytic normal (the
+    rotation-nullspace + gauge-removal path); the velocity L2 and the radial leakage
+    ``∫ (v·r̂)²`` on each arc must match serial.
+
+All diagnostics use the parallel-safe ``uw.maths.Integral`` / ``BdIntegral`` reductions
+(no rank-local ``v.data``, which is per-partition, and no ``uw.function.evaluate`` on
+arbitrary points, which deadlocks np>1).
+
+Run with:
+    mpirun -n 2 python -m pytest --with-mpi \\
+      tests/parallel/test_1064_rotated_freeslip_parallel.py
+    mpirun -n 4 python -m pytest --with-mpi \\
+      tests/parallel/test_1064_rotated_freeslip_parallel.py
+"""
+
+import numpy as np
+import sympy
+import pytest
+
+import underworld3 as uw
+from underworld3.function import analytic as A
+
+pytestmark = [pytest.mark.mpi(min_size=2), pytest.mark.timeout(180)]
+
+# SERIAL (np=1) reference diagnostics — the partition-independent ground truth.
+# Recompute with `python <thisfile> {box,annulus}`.
+# box:     (velocity L2, analytic velocity error)
+# annulus: (velocity L2, radial-leakage L2 on Lower arc, radial-leakage L2 on Upper arc)
+GOLDEN_BOX = (1.275109036912e-03, 1.529545e-05)
+GOLDEN_ANNULUS = (1.897011154231e-02, 4.563841e-05, 9.341699e-06)
+
+
+def _box_diagnostics():
+    """Box SolCx with rotated free-slip on all four axis-aligned walls (GAMG velocity
+    block). Returns (velocity L2, analytic velocity error)."""
+    mesh = uw.meshing.StructuredQuadBox(
+        elementRes=(24, 24), minCoords=(0, 0), maxCoords=(1, 1), qdegree=3)
+    sol = A.SolCx(mesh, eta_A=1.0, eta_B=1.0e3, x_c=0.5, n=1)
+    v = uw.discretisation.MeshVariable("vB", mesh, mesh.dim, degree=2, continuous=True)
+    p = uw.discretisation.MeshVariable("pB", mesh, 1, degree=1, continuous=False)
+    s = uw.systems.Stokes(mesh, velocityField=v, pressureField=p)
+    s.constitutive_model = uw.constitutive_models.ViscousFlowModel
+    s.constitutive_model.Parameters.shear_viscosity_0 = sol.fn_viscosity
+    s.bodyforce = sol.fn_bodyforce
+    s.penalty = 0.0
+    s.tolerance = 1e-9
+    for wall in ("Top", "Bottom", "Left", "Right"):
+        s.add_rotated_freeslip_bc(wall)
+    s.petsc_use_pressure_nullspace = True
+    s.petsc_options["snes_type"] = "ksponly"
+    s.solve()
+
+    L2 = float(np.sqrt(uw.maths.Integral(mesh, v.sym.dot(v.sym)).evaluate()))
+    verr = float(sol.velocity_error(v))
+    return L2, verr
+
+
+def _annulus_diagnostics():
+    """Annulus with per-node radial free-slip on both arcs (analytic normal). Returns
+    (velocity L2, radial-leakage L2 on Lower arc, radial-leakage L2 on Upper arc)."""
+    RI, RO = 0.5, 1.0
+    mesh = uw.meshing.Annulus(radiusInner=RI, radiusOuter=RO, cellSize=0.1, qdegree=3)
+    x, y = mesh.X
+    r = sympy.sqrt(x**2 + y**2)
+    th = sympy.atan2(y, x)
+    v = uw.discretisation.MeshVariable("Va", mesh, mesh.dim, degree=2, continuous=True)
+    p = uw.discretisation.MeshVariable("Pa", mesh, 1, degree=1, continuous=True)
+    s = uw.systems.Stokes(mesh, velocityField=v, pressureField=p)
+    s.constitutive_model = uw.constitutive_models.ViscousFlowModel
+    s.constitutive_model.Parameters.shear_viscosity_0 = 1.0
+    s.bodyforce = sympy.Matrix([[x / r * sympy.cos(4 * th) * (r - RI) * (RO - r) * 40.0,
+                                 y / r * sympy.cos(4 * th) * (r - RI) * (RO - r) * 40.0]])
+    nhat = sympy.Matrix([[x / r, y / r]])
+    s.add_rotated_freeslip_bc("Lower", normal=nhat)
+    s.add_rotated_freeslip_bc("Upper", normal=nhat)
+    s.tolerance = 1e-9
+    s.petsc_use_pressure_nullspace = True
+    s.petsc_options["snes_type"] = "ksponly"
+    s.solve()
+
+    L2 = float(np.sqrt(uw.maths.Integral(mesh, v.sym.dot(v.sym)).evaluate()))
+    vr = v.sym[0] * x / r + v.sym[1] * y / r      # radial velocity v·r̂
+    leak_lo = float(np.sqrt(uw.maths.BdIntegral(
+        mesh=mesh, fn=vr**2, boundary="Lower").evaluate()))
+    leak_up = float(np.sqrt(uw.maths.BdIntegral(
+        mesh=mesh, fn=vr**2, boundary="Upper").evaluate()))
+    return L2, leak_lo, leak_up
+
+
+def test_rotated_freeslip_box_partition_independent():
+    """Box: the parallel rotated free-slip solve reproduces the serial velocity L2 and
+    keeps the analytic velocity error small."""
+    L2, verr = _box_diagnostics()
+    L2_ref, verr_ref = GOLDEN_BOX
+    assert np.isclose(L2, L2_ref, rtol=1e-8, atol=0), (
+        f"box velocity L2 differs serial vs np={uw.mpi.size}: {L2_ref} vs {L2}")
+    # analytic accuracy is preserved (partition may change the exact digit but not
+    # the order of magnitude of the SolCx error)
+    assert verr < 1e-3, f"box velocity error {verr:.2e} too large at np={uw.mpi.size}"
+
+
+def test_rotated_freeslip_annulus_partition_independent():
+    """Annulus: the parallel radial free-slip solve reproduces the serial velocity L2
+    and the (partition-independent) radial leakage on both arcs."""
+    L2, leak_lo, leak_up = _annulus_diagnostics()
+    L2_ref, leak_lo_ref, leak_up_ref = GOLDEN_ANNULUS
+    # velocity L2 is iterative-solver-tolerance reproducible (~1e-8 rel), not the
+    # box's 1e-10 — the annulus carries a rotation null space + gauge removal.
+    assert np.isclose(L2, L2_ref, rtol=1e-6, atol=0), (
+        f"annulus velocity L2 differs serial vs np={uw.mpi.size}: {L2_ref} vs {L2}")
+    assert np.isclose(leak_lo, leak_lo_ref, rtol=1e-4, atol=0), (
+        f"annulus Lower leakage differs serial vs np={uw.mpi.size}: "
+        f"{leak_lo_ref} vs {leak_lo}")
+    assert np.isclose(leak_up, leak_up_ref, rtol=1e-4, atol=0), (
+        f"annulus Upper leakage differs serial vs np={uw.mpi.size}: "
+        f"{leak_up_ref} vs {leak_up}")
+
+
+if __name__ == "__main__":
+    # Recompute the serial GOLDEN references: `python <thisfile> {box,annulus}`.
+    import sys
+    _kind = sys.argv[1] if len(sys.argv) > 1 else "box"
+    if _kind == "annulus":
+        _L2, _lo, _up = _annulus_diagnostics()
+        if uw.mpi.rank == 0:
+            print(f"DIAG_ANNULUS {_L2:.12e} {_lo:.6e} {_up:.6e}")
+    else:
+        _L2, _verr = _box_diagnostics()
+        if uw.mpi.rank == 0:
+            print(f"DIAG_BOX {_L2:.12e} {_verr:.6e}")

--- a/tests/parallel/test_1064_rotated_freeslip_parallel.py
+++ b/tests/parallel/test_1064_rotated_freeslip_parallel.py
@@ -35,6 +35,7 @@ import pytest
 
 import underworld3 as uw
 from underworld3.function import analytic as A
+from underworld3.utilities import custom_mg
 
 pytestmark = [pytest.mark.mpi(min_size=2), pytest.mark.timeout(180)]
 
@@ -44,6 +45,18 @@ pytestmark = [pytest.mark.mpi(min_size=2), pytest.mark.timeout(180)]
 # annulus: (velocity L2, radial-leakage L2 on Lower arc, radial-leakage L2 on Upper arc)
 GOLDEN_BOX = (1.275109036912e-03, 1.529545e-05)
 GOLDEN_ANNULUS = (1.897011154231e-02, 4.563841e-05, 9.341699e-06)
+# annulus driven by CUSTOM GEOMETRIC FMG on the velocity block (nested hierarchy):
+# (velocity L2, radial-leakage L2 on Lower arc, radial-leakage L2 on Upper arc)
+GOLDEN_ANNULUS_FMG = (1.906961759626e-02, 5.428193e-06, 1.177002e-06)
+
+
+def _wrap(dm, m0):
+    """Wrap a refined DMPlex as a UW3 mesh carrying the base mesh's boundaries and
+    coordinate system (for building a nested annulus MG hierarchy)."""
+    return uw.discretisation.Mesh(
+        dm.clone(), simplex=True,
+        coordinate_system_type=m0.CoordinateSystem.coordinate_type,
+        qdegree=3, boundaries=m0.boundaries)
 
 
 def _box_diagnostics():
@@ -103,6 +116,47 @@ def _annulus_diagnostics():
     return L2, leak_lo, leak_up
 
 
+def _annulus_fmg_diagnostics():
+    """Annulus radial free-slip whose velocity block is CUSTOM GEOMETRIC FMG on a
+    nested hierarchy (coarse annulus -> refine -> refine), via set_custom_fmg — no
+    GAMG, no direct solve. Returns (velocity L2, leakage L2 on Lower, on Upper)."""
+    RI, RO = 0.5, 1.0
+    m0 = uw.meshing.Annulus(radiusInner=RI, radiusOuter=RO, cellSize=0.2, qdegree=3)
+    dm1 = m0.dm.refine()
+    dm2 = dm1.refine()
+    coarse = [m0, _wrap(dm1, m0)]
+    fine = _wrap(dm2, m0)
+
+    x, y = fine.X
+    r = sympy.sqrt(x**2 + y**2)
+    th = sympy.atan2(y, x)
+    v = uw.discretisation.MeshVariable("Vf", fine, fine.dim, degree=2, continuous=True)
+    p = uw.discretisation.MeshVariable("Pf", fine, 1, degree=1, continuous=True)
+    s = uw.systems.Stokes(fine, velocityField=v, pressureField=p)
+    s.constitutive_model = uw.constitutive_models.ViscousFlowModel
+    s.constitutive_model.Parameters.shear_viscosity_0 = 1.0
+    s.bodyforce = sympy.Matrix([[x / r * sympy.cos(4 * th) * (r - RI) * (RO - r) * 40.0,
+                                 y / r * sympy.cos(4 * th) * (r - RI) * (RO - r) * 40.0]])
+    nhat = sympy.Matrix([[x / r, y / r]])
+    s.add_rotated_freeslip_bc("Lower", normal=nhat)
+    s.add_rotated_freeslip_bc("Upper", normal=nhat)
+    s.tolerance = 1e-9
+    s.saddle_preconditioner = 1.0
+    s.petsc_use_pressure_nullspace = True
+    s.petsc_options["snes_type"] = "ksponly"
+    custom_mg.set_custom_fmg(s, coarse, builder="barycentric", field_id=0)
+    s.solve()
+
+    assert s._rotated_freeslip_info["ksp_reason"] > 0, "custom-FMG rotated solve did not converge"
+    L2 = float(np.sqrt(uw.maths.Integral(fine, v.sym.dot(v.sym)).evaluate()))
+    vr = v.sym[0] * x / r + v.sym[1] * y / r
+    leak_lo = float(np.sqrt(uw.maths.BdIntegral(
+        mesh=fine, fn=vr**2, boundary="Lower").evaluate()))
+    leak_up = float(np.sqrt(uw.maths.BdIntegral(
+        mesh=fine, fn=vr**2, boundary="Upper").evaluate()))
+    return L2, leak_lo, leak_up
+
+
 def test_rotated_freeslip_box_partition_independent():
     """Box: the parallel rotated free-slip solve reproduces the serial velocity L2 and
     keeps the analytic velocity error small."""
@@ -132,14 +186,34 @@ def test_rotated_freeslip_annulus_partition_independent():
         f"{leak_up_ref} vs {leak_up}")
 
 
+def test_rotated_freeslip_annulus_fmg_partition_independent():
+    """The full stack: rotated radial free-slip on the annulus with the velocity block
+    driven by CUSTOM GEOMETRIC FMG (set_custom_fmg) reproduces the serial velocity L2
+    and radial leakage in parallel — FMG x rotated x annulus x np>1."""
+    L2, leak_lo, leak_up = _annulus_fmg_diagnostics()
+    L2_ref, leak_lo_ref, leak_up_ref = GOLDEN_ANNULUS_FMG
+    assert np.isclose(L2, L2_ref, rtol=1e-6, atol=0), (
+        f"FMG annulus velocity L2 differs serial vs np={uw.mpi.size}: {L2_ref} vs {L2}")
+    assert np.isclose(leak_lo, leak_lo_ref, rtol=1e-4, atol=0), (
+        f"FMG annulus Lower leakage differs serial vs np={uw.mpi.size}: "
+        f"{leak_lo_ref} vs {leak_lo}")
+    assert np.isclose(leak_up, leak_up_ref, rtol=1e-4, atol=0), (
+        f"FMG annulus Upper leakage differs serial vs np={uw.mpi.size}: "
+        f"{leak_up_ref} vs {leak_up}")
+
+
 if __name__ == "__main__":
-    # Recompute the serial GOLDEN references: `python <thisfile> {box,annulus}`.
+    # Recompute the serial GOLDEN references: `python <thisfile> {box,annulus,annulus_fmg}`.
     import sys
     _kind = sys.argv[1] if len(sys.argv) > 1 else "box"
     if _kind == "annulus":
         _L2, _lo, _up = _annulus_diagnostics()
         if uw.mpi.rank == 0:
             print(f"DIAG_ANNULUS {_L2:.12e} {_lo:.6e} {_up:.6e}")
+    elif _kind == "annulus_fmg":
+        _L2, _lo, _up = _annulus_fmg_diagnostics()
+        if uw.mpi.rank == 0:
+            print(f"DIAG_ANNULUS_FMG {_L2:.12e} {_lo:.6e} {_up:.6e}")
     else:
         _L2, _verr = _box_diagnostics()
         if uw.mpi.rank == 0:

--- a/tests/parallel/test_1064_rotated_freeslip_parallel.py
+++ b/tests/parallel/test_1064_rotated_freeslip_parallel.py
@@ -48,6 +48,9 @@ GOLDEN_ANNULUS = (1.897011154231e-02, 4.563841e-05, 9.341699e-06)
 # annulus driven by CUSTOM GEOMETRIC FMG on the velocity block (nested hierarchy):
 # (velocity L2, radial-leakage L2 on Lower arc, radial-leakage L2 on Upper arc)
 GOLDEN_ANNULUS_FMG = (1.906961759626e-02, 5.428193e-06, 1.177002e-06)
+# box sigma_nn (boundary_normal_traction on Top) vs analytic SolCx sigma_yy, whole
+# boundary: (relL2, |corr|). Recompute with `python <thisfile> sigma`.
+GOLDEN_BOX_SIGMA = (4.194316e-02, 0.999122)
 
 
 def _wrap(dm, m0):
@@ -157,6 +160,51 @@ def _annulus_fmg_diagnostics():
     return L2, leak_lo, leak_up
 
 
+def _box_sigma_diagnostics():
+    """Recover sigma_nn on Top via boundary_normal_traction and compare to the exact
+    SolCx sigma_yy over the WHOLE boundary. The per-rank local (xs, sigma) are gathered
+    + de-duplicated on rank 0, the metric is computed there and broadcast, so every rank
+    returns the same (relL2, |corr|) — a direct partition-independence check."""
+    res = 48
+    mesh = uw.meshing.StructuredQuadBox(
+        elementRes=(res, res), minCoords=(0, 0), maxCoords=(1, 1), qdegree=3)
+    sol = A.SolCx(mesh, eta_A=1.0, eta_B=1.0e3, x_c=0.5, n=1)
+    v = uw.discretisation.MeshVariable("vS", mesh, mesh.dim, degree=2, continuous=True)
+    p = uw.discretisation.MeshVariable("pS", mesh, 1, degree=1, continuous=False)
+    s = uw.systems.Stokes(mesh, velocityField=v, pressureField=p)
+    s.constitutive_model = uw.constitutive_models.ViscousFlowModel
+    s.constitutive_model.Parameters.shear_viscosity_0 = sol.fn_viscosity
+    s.bodyforce = sol.fn_bodyforce
+    s.penalty = 0.0
+    s.tolerance = 1e-9
+    for wall in ("Top", "Bottom", "Left", "Right"):
+        s.add_rotated_freeslip_bc(wall)
+    s.petsc_use_pressure_nullspace = True
+    s.petsc_options["snes_type"] = "ksponly"
+    s.solve()
+
+    xs, sig = s.boundary_normal_traction("Top")
+    comm = uw.mpi.comm
+    gx = comm.gather(np.asarray(xs).reshape(-1, 2), root=0)
+    gs = comm.gather(np.asarray(sig).reshape(-1), root=0)
+    result = None
+    if uw.mpi.rank == 0:
+        allx = np.concatenate(gx) if len(gx) else np.zeros((0, 2))
+        alls = np.concatenate(gs) if len(gs) else np.zeros(0)
+        seen = {}
+        for xc, sc in zip(allx, alls):
+            seen[(round(float(xc[0]), 9), round(float(xc[1]), 9))] = (xc, sc)
+        X = np.array([u[0] for u in seen.values()])
+        S = np.array([u[1] for u in seen.values()])
+        syy = np.asarray(sol.evaluate_stress(X))[:, 1]
+        syy = syy - syy.mean()
+        corr = float(np.dot(S, syy) / (np.linalg.norm(S) * np.linalg.norm(syy)))
+        S = S if corr >= 0 else -S
+        relL2 = float(np.linalg.norm(S - syy) / np.linalg.norm(syy))
+        result = (relL2, abs(corr), len(X))
+    return comm.bcast(result, root=0)
+
+
 def test_rotated_freeslip_box_partition_independent():
     """Box: the parallel rotated free-slip solve reproduces the serial velocity L2 and
     keeps the analytic velocity error small."""
@@ -202,11 +250,31 @@ def test_rotated_freeslip_annulus_fmg_partition_independent():
         f"{leak_up_ref} vs {leak_up}")
 
 
+def test_rotated_freeslip_box_sigma_nn_partition_independent():
+    """sigma_nn (boundary_normal_traction) recovery is partition-independent: the whole-
+    boundary relL2 / |corr| vs analytic SolCx sigma_yy match the serial reference (and
+    stay accurate) in parallel — the reaction read + consistent-mass de-smear are
+    parallel-safe."""
+    relL2, corr, nnodes = _box_sigma_diagnostics()
+    relL2_ref, corr_ref = GOLDEN_BOX_SIGMA
+    assert nnodes == 97, f"expected 97 top nodes, gathered {nnodes} at np={uw.mpi.size}"
+    assert np.isclose(relL2, relL2_ref, rtol=1e-4, atol=0), (
+        f"sigma_nn relL2 differs serial vs np={uw.mpi.size}: {relL2_ref} vs {relL2}")
+    assert np.isclose(corr, corr_ref, rtol=1e-4, atol=0), (
+        f"sigma_nn corr differs serial vs np={uw.mpi.size}: {corr_ref} vs {corr}")
+    assert relL2 < 0.08, f"sigma_nn relL2 vs analytic {relL2:.3f} too large"
+
+
 if __name__ == "__main__":
-    # Recompute the serial GOLDEN references: `python <thisfile> {box,annulus,annulus_fmg}`.
+    # Recompute the serial GOLDEN references:
+    #   `python <thisfile> {box,annulus,annulus_fmg,sigma}`.
     import sys
     _kind = sys.argv[1] if len(sys.argv) > 1 else "box"
-    if _kind == "annulus":
+    if _kind == "sigma":
+        _r = _box_sigma_diagnostics()
+        if uw.mpi.rank == 0:
+            print(f"DIAG_SIGMA relL2={_r[0]:.6e} corr={_r[1]:.6f} nodes={_r[2]}")
+    elif _kind == "annulus":
         _L2, _lo, _up = _annulus_diagnostics()
         if uw.mpi.rank == 0:
             print(f"DIAG_ANNULUS {_L2:.12e} {_lo:.6e} {_up:.6e}")

--- a/tests/test_1018_rotated_freeslip.py
+++ b/tests/test_1018_rotated_freeslip.py
@@ -171,3 +171,41 @@ def test_rotated_freeslip_boundary_normal_traction_solcx():
     relL2 = np.linalg.norm(sig - syy) / np.linalg.norm(syy)
     assert abs(corr) > 0.99, f"sigma_nn shape corr {corr:.3f} too low"
     assert relL2 < 0.08, f"sigma_nn relL2 vs analytic sigma_yy {relL2:.3f} too large"
+
+
+def test_rotated_freeslip_sigma_nn_lumped_no_overshoot():
+    """The default (lumped) sigma_nn de-smear is MONOTONE at the SolCx viscosity jump:
+    its total variation matches the analytic (no Gibbs overshoot), whereas the
+    consistent-mass de-smear adds spurious variation. This is the property that matters
+    for driving a free surface (an overshoot injects a spurious surface-velocity pulse)."""
+    res = 48
+    mesh = uw.meshing.StructuredQuadBox(
+        elementRes=(res, res), minCoords=(0, 0), maxCoords=(1, 1), qdegree=3)
+    sol = A.SolCx(mesh, eta_A=1.0, eta_B=1.0e3, x_c=0.5, n=1)
+    v = uw.discretisation.MeshVariable("vL", mesh, mesh.dim, degree=2, continuous=True)
+    p = uw.discretisation.MeshVariable("pL", mesh, 1, degree=1, continuous=False)
+    s = uw.systems.Stokes(mesh, velocityField=v, pressureField=p)
+    s.constitutive_model = uw.constitutive_models.ViscousFlowModel
+    s.constitutive_model.Parameters.shear_viscosity_0 = sol.fn_viscosity
+    s.bodyforce = sol.fn_bodyforce
+    s.penalty = 0.0
+    s.tolerance = 1e-9
+    for wall in ("Top", "Bottom", "Left", "Right"):
+        s.add_rotated_freeslip_bc(wall)
+    s.petsc_use_pressure_nullspace = True
+    s.petsc_options["snes_type"] = "ksponly"
+    s.solve()
+
+    def total_variation(xs, sig):
+        o = np.argsort(np.asarray(xs)[:, 0])
+        return float(np.sum(np.abs(np.diff(np.asarray(sig)[o]))))
+
+    xs, sig_l = s.boundary_normal_traction("Top", mass="lumped")     # default
+    _, sig_c = s.boundary_normal_traction("Top", mass="consistent")
+    syy = np.asarray(sol.evaluate_stress(np.asarray(xs)))[:, 1]
+    tv_ref = total_variation(xs, syy - syy.mean())
+    tv_l = total_variation(xs, sig_l)
+    tv_c = total_variation(xs, sig_c)
+    # lumped adds essentially no spurious variation over the analytic; consistent does
+    assert tv_l < 1.05 * tv_ref, f"lumped TV {tv_l:.3f} exceeds analytic {tv_ref:.3f}"
+    assert tv_l < tv_c, f"lumped TV {tv_l:.3f} not smoother than consistent {tv_c:.3f}"

--- a/tests/test_1018_rotated_freeslip.py
+++ b/tests/test_1018_rotated_freeslip.py
@@ -209,3 +209,44 @@ def test_rotated_freeslip_sigma_nn_lumped_no_overshoot():
     # lumped adds essentially no spurious variation over the analytic; consistent does
     assert tv_l < 1.05 * tv_ref, f"lumped TV {tv_l:.3f} exceeds analytic {tv_ref:.3f}"
     assert tv_l < tv_c, f"lumped TV {tv_l:.3f} not smoother than consistent {tv_c:.3f}"
+
+
+def test_rotated_freeslip_dynamic_topography_field():
+    """dynamic_topography writes h = -(sigma_nn - mean)/(rho g) onto a scalar surface
+    MeshVariable (the free-surface hand-off): the field at the top vertices reproduces
+    the analytic SolCx topography, and the field is usable symbolically (BdIntegral)."""
+    res = 48
+    mesh = uw.meshing.StructuredQuadBox(
+        elementRes=(res, res), minCoords=(0, 0), maxCoords=(1, 1), qdegree=3)
+    sol = A.SolCx(mesh, eta_A=1.0, eta_B=1.0e3, x_c=0.5, n=1)
+    v = uw.discretisation.MeshVariable("vD", mesh, mesh.dim, degree=2, continuous=True)
+    p = uw.discretisation.MeshVariable("pD", mesh, 1, degree=1, continuous=False)
+    hf = uw.discretisation.MeshVariable("hD", mesh, 1, degree=1, continuous=True)
+    s = uw.systems.Stokes(mesh, velocityField=v, pressureField=p)
+    s.constitutive_model = uw.constitutive_models.ViscousFlowModel
+    s.constitutive_model.Parameters.shear_viscosity_0 = sol.fn_viscosity
+    s.bodyforce = sol.fn_bodyforce
+    s.penalty = 0.0
+    s.tolerance = 1e-9
+    for wall in ("Top", "Bottom", "Left", "Right"):
+        s.add_rotated_freeslip_bc(wall)
+    s.petsc_use_pressure_nullspace = True
+    s.petsc_options["snes_type"] = "ksponly"
+    s.solve()
+
+    ret = s.dynamic_topography("Top", hf, buoyancy_scale=1.0)
+    assert ret is hf
+    # field at the top vertices reproduces the analytic topography (mean-removed)
+    hc = hf.coords
+    top = np.abs(hc[:, 1] - 1.0) < 1e-6
+    tt = np.asarray(sol.topography_top(hc[top])); tt = tt - tt.mean()
+    hv = hf.data[top, 0]
+    corr = np.dot(hv, tt) / (np.linalg.norm(hv) * np.linalg.norm(tt))
+    hv = hv if corr >= 0 else -hv
+    relL2 = np.linalg.norm(hv - tt) / np.linalg.norm(tt)
+    assert abs(corr) > 0.99, f"topography field corr {corr:.3f} too low"
+    assert relL2 < 0.09, f"topography field relL2 {relL2:.3f} too large"
+    # symbolically usable (the free-surface integrator reads it via BdIntegral)
+    bdl2 = float(np.sqrt(uw.maths.BdIntegral(
+        mesh=mesh, fn=hf.sym[0] ** 2, boundary="Top").evaluate()))
+    assert bdl2 > 0.0

--- a/tests/test_1018_rotated_freeslip.py
+++ b/tests/test_1018_rotated_freeslip.py
@@ -9,8 +9,16 @@ import pytest
 import sympy
 import underworld3 as uw
 from underworld3.function import analytic as A
+from underworld3.utilities import custom_mg
 
 pytestmark = [pytest.mark.level_1, pytest.mark.tier_a]
+
+
+def _wrap(dm, m0):
+    return uw.discretisation.Mesh(
+        dm.clone(), simplex=True,
+        coordinate_system_type=m0.CoordinateSystem.coordinate_type,
+        qdegree=3, boundaries=m0.boundaries)
 
 
 def _solcx_essential(mesh, sol):
@@ -93,3 +101,39 @@ def test_rotated_freeslip_annulus_zero_leakage():
     t = np.column_stack([-vc[:, 1], vc[:, 0]])
     rotfrac = abs(np.sum(v.data * t) / np.sum(t * t)) * np.sqrt(np.sum(t * t)) / (np.linalg.norm(v.data) + 1e-30)
     assert rotfrac < 1e-8, f"rotation gauge {rotfrac:.2e} not removed"
+
+
+def test_rotated_freeslip_geometric_fmg_velocity_block():
+    """The rotated free-slip velocity block is driven by GEOMETRIC FMG on a custom
+    prolongation (set_custom_fmg) — no direct solve — and still reproduces the
+    essential free-slip solution, with the wall-normal velocity exact."""
+    m0 = uw.meshing.UnstructuredSimplexBox(
+        minCoords=(0, 0), maxCoords=(1, 1), cellSize=0.2, regular=True, qdegree=3)
+    dm0 = m0.dm
+    dm1 = dm0.refine()
+    dm2 = dm1.refine()
+    coarse = [_wrap(dm0, m0), _wrap(dm1, m0)]
+    fine = _wrap(dm2, m0)
+    sol = A.SolCx(fine, eta_A=1.0, eta_B=1.0e3, x_c=0.5, n=1)
+
+    vE = _solcx_essential(fine, sol)
+
+    v = uw.discretisation.MeshVariable("vF", fine, fine.dim, degree=2, continuous=True)
+    p = uw.discretisation.MeshVariable("pF", fine, 1, degree=1, continuous=False)
+    s = uw.systems.Stokes(fine, velocityField=v, pressureField=p)
+    s.constitutive_model = uw.constitutive_models.ViscousFlowModel
+    s.constitutive_model.Parameters.shear_viscosity_0 = sol.fn_viscosity
+    s.saddle_preconditioner = 1.0 / sol.fn_viscosity
+    s.bodyforce = sol.fn_bodyforce
+    s.tolerance = 1e-9
+    for wall in ("Top", "Bottom", "Left", "Right"):
+        s.add_rotated_freeslip_bc(wall)
+    s.petsc_use_pressure_nullspace = True
+    s.petsc_options["snes_type"] = "ksponly"
+    custom_mg.set_custom_fmg(s, coarse, builder="barycentric", field_id=0)
+    s.solve()
+
+    # geometric MG on the velocity block converged, and matches essential
+    assert s._rotated_freeslip_info["ksp_reason"] > 0
+    rel = np.linalg.norm(v.data - vE.data) / np.linalg.norm(vE.data)
+    assert rel < 5e-3, f"FMG rotated free-slip differs from essential by {rel:.2e}"

--- a/tests/test_1018_rotated_freeslip.py
+++ b/tests/test_1018_rotated_freeslip.py
@@ -1,0 +1,95 @@
+"""Rotated strong free-slip BC (add_rotated_freeslip_bc) through the real solver API.
+
+Increment 1 validation: on an axis-aligned box, rotated free-slip on all four walls
+must reproduce the native essential free-slip solve, enforce zero wall-normal flow,
+and (annulus) give per-node radial free-slip with machine-zero leakage.
+"""
+import numpy as np
+import pytest
+import sympy
+import underworld3 as uw
+from underworld3.function import analytic as A
+
+pytestmark = [pytest.mark.level_1, pytest.mark.tier_a]
+
+
+def _solcx_essential(mesh, sol):
+    v = uw.discretisation.MeshVariable("vE", mesh, mesh.dim, degree=2, continuous=True)
+    p = uw.discretisation.MeshVariable("pE", mesh, 1, degree=1, continuous=False)
+    s = uw.systems.Stokes(mesh, velocityField=v, pressureField=p)
+    s.constitutive_model = uw.constitutive_models.ViscousFlowModel
+    s.constitutive_model.Parameters.shear_viscosity_0 = sol.fn_viscosity
+    s.bodyforce = sol.fn_bodyforce
+    s.penalty = 0.0
+    s.tolerance = 1e-9
+    s.add_essential_bc((sympy.oo, 0.0), "Top")
+    s.add_essential_bc((sympy.oo, 0.0), "Bottom")
+    s.add_essential_bc((0.0, sympy.oo), "Left")
+    s.add_essential_bc((0.0, sympy.oo), "Right")
+    s.petsc_use_pressure_nullspace = True
+    s.petsc_options["snes_type"] = "ksponly"
+    s.solve()
+    return v
+
+
+def test_rotated_freeslip_box_reproduces_essential():
+    """Box: rotated free-slip on all 4 axis-aligned walls == native essential free-slip."""
+    mesh = uw.meshing.StructuredQuadBox(
+        elementRes=(24, 24), minCoords=(0, 0), maxCoords=(1, 1), qdegree=3)
+    sol = A.SolCx(mesh, eta_A=1.0, eta_B=1.0e3, x_c=0.5, n=1)
+    vE = _solcx_essential(mesh, sol)
+
+    v = uw.discretisation.MeshVariable("vR", mesh, mesh.dim, degree=2, continuous=True)
+    p = uw.discretisation.MeshVariable("pR", mesh, 1, degree=1, continuous=False)
+    s = uw.systems.Stokes(mesh, velocityField=v, pressureField=p)
+    s.constitutive_model = uw.constitutive_models.ViscousFlowModel
+    s.constitutive_model.Parameters.shear_viscosity_0 = sol.fn_viscosity
+    s.bodyforce = sol.fn_bodyforce
+    s.penalty = 0.0
+    s.tolerance = 1e-9
+    for wall in ("Top", "Bottom", "Left", "Right"):
+        s.add_rotated_freeslip_bc(wall)
+    s.petsc_use_pressure_nullspace = True
+    s.petsc_options["snes_type"] = "ksponly"
+    s.solve()
+
+    rel = np.linalg.norm(v.data - vE.data) / np.linalg.norm(vE.data)
+    assert rel < 1e-4, f"rotated free-slip differs from essential by {rel:.2e}"
+    # exact analytic accuracy
+    assert sol.velocity_error(v) < 1e-3
+
+
+def test_rotated_freeslip_annulus_zero_leakage():
+    """Annulus: per-node radial free-slip on both arcs → machine-zero v_r leakage,
+    with the analytic radial normal."""
+    RI, RO = 0.5, 1.0
+    mesh = uw.meshing.Annulus(radiusInner=RI, radiusOuter=RO, cellSize=0.1, qdegree=3)
+    x, y = mesh.X
+    r = sympy.sqrt(x**2 + y**2)
+    th = sympy.atan2(y, x)
+    v = uw.discretisation.MeshVariable("Va", mesh, mesh.dim, degree=2, continuous=True)
+    p = uw.discretisation.MeshVariable("Pa", mesh, 1, degree=1, continuous=True)
+    s = uw.systems.Stokes(mesh, velocityField=v, pressureField=p)
+    s.constitutive_model = uw.constitutive_models.ViscousFlowModel
+    s.constitutive_model.Parameters.shear_viscosity_0 = 1.0
+    s.bodyforce = sympy.Matrix([[x / r * sympy.cos(4 * th) * (r - RI) * (RO - r) * 40.0,
+                                 y / r * sympy.cos(4 * th) * (r - RI) * (RO - r) * 40.0]])
+    nhat = sympy.Matrix([[x / r, y / r]])
+    s.add_rotated_freeslip_bc("Lower", normal=nhat)
+    s.add_rotated_freeslip_bc("Upper", normal=nhat)
+    s.petsc_use_pressure_nullspace = True
+    s.petsc_options["snes_type"] = "ksponly"
+    s.solve()
+
+    vc = v.coords
+    rr = np.hypot(vc[:, 0], vc[:, 1])
+    rhat = vc / rr[:, None]
+    vr = np.einsum("ij,ij->i", v.data, rhat)
+    vmax = np.linalg.norm(v.data, axis=1).max() + 1e-30
+    for lab, mask in [("inner", np.abs(rr - RI) < 1e-4), ("outer", np.abs(rr - RO) < 1e-4)]:
+        leak = np.abs(vr[mask]).max() / vmax
+        assert leak < 1e-10, f"{lab} radial leakage {leak:.2e} not machine-zero"
+    # rigid-rotation gauge removed
+    t = np.column_stack([-vc[:, 1], vc[:, 0]])
+    rotfrac = abs(np.sum(v.data * t) / np.sum(t * t)) * np.sqrt(np.sum(t * t)) / (np.linalg.norm(v.data) + 1e-30)
+    assert rotfrac < 1e-8, f"rotation gauge {rotfrac:.2e} not removed"

--- a/tests/test_1018_rotated_freeslip.py
+++ b/tests/test_1018_rotated_freeslip.py
@@ -137,3 +137,37 @@ def test_rotated_freeslip_geometric_fmg_velocity_block():
     assert s._rotated_freeslip_info["ksp_reason"] > 0
     rel = np.linalg.norm(v.data - vE.data) / np.linalg.norm(vE.data)
     assert rel < 5e-3, f"FMG rotated free-slip differs from essential by {rel:.2e}"
+
+
+def test_rotated_freeslip_boundary_normal_traction_solcx():
+    """sigma_nn recovered by boundary_normal_traction on the top boundary reproduces
+    the exact SolCx analytic sigma_yy (mean-removed) to a few percent. Exercises the
+    Cartesian-reaction + n_hat projection (corner-correct) + consistent P2 line mass."""
+    res = 48
+    mesh = uw.meshing.StructuredQuadBox(
+        elementRes=(res, res), minCoords=(0, 0), maxCoords=(1, 1), qdegree=3)
+    sol = A.SolCx(mesh, eta_A=1.0, eta_B=1.0e3, x_c=0.5, n=1)
+    v = uw.discretisation.MeshVariable("vT", mesh, mesh.dim, degree=2, continuous=True)
+    p = uw.discretisation.MeshVariable("pT", mesh, 1, degree=1, continuous=False)
+    s = uw.systems.Stokes(mesh, velocityField=v, pressureField=p)
+    s.constitutive_model = uw.constitutive_models.ViscousFlowModel
+    s.constitutive_model.Parameters.shear_viscosity_0 = sol.fn_viscosity
+    s.bodyforce = sol.fn_bodyforce
+    s.penalty = 0.0
+    s.tolerance = 1e-9
+    for wall in ("Top", "Bottom", "Left", "Right"):
+        s.add_rotated_freeslip_bc(wall)
+    s.petsc_use_pressure_nullspace = True
+    s.petsc_options["snes_type"] = "ksponly"
+    s.solve()
+
+    xs, sig = s.boundary_normal_traction("Top")
+    top = np.asarray(xs)
+    syy = np.asarray(sol.evaluate_stress(top))[:, 1]
+    syy = syy - syy.mean()
+    sig = np.asarray(sig)
+    corr = np.dot(sig, syy) / (np.linalg.norm(sig) * np.linalg.norm(syy))
+    sig = sig if corr >= 0 else -sig                      # sigma = -R sign convention
+    relL2 = np.linalg.norm(sig - syy) / np.linalg.norm(syy)
+    assert abs(corr) > 0.99, f"sigma_nn shape corr {corr:.3f} too low"
+    assert relL2 < 0.08, f"sigma_nn relL2 vs analytic sigma_yy {relL2:.3f} too large"


### PR DESCRIPTION
## What

In-solver **rotated strong free-slip** for the Stokes saddle, its **σ_nn / CBF dynamic-topography** recovery, and a **MeshVariable hand-off to the free-surface machinery** — all validated in parallel.

`stokes.add_rotated_freeslip_bc(boundary, normal=None)` imposes `v·n̂ = 0` in a per-node (normal, tangential) frame (SVD constraint frame, dim-general). `stokes.boundary_normal_traction(boundary, mass="lumped")` returns σ_nn from the constraint reaction. `stokes.dynamic_topography(boundary, field)` writes `h = -(σ_nn - mean)/(Δρg)` onto a scalar surface field for the 3-number topography integrator.

## Stacking

⚠️ **Stacked on #290** (custom-mg-prolongation): the rotated FMG path uses `custom_mg.set_custom_fmg`. Based against `feature/custom-mg-prolongation` so the diff shows only the rotated-bc work — **retarget to `development` once #290 merges.**

## Highlights this series

- **Parallel np>1 "hang" fixed** — it was an asymmetric crash (global row index into a local RHS slice), not a hang. Same class fixed in the σ_nn read and the field write.
- **σ_nn recovery**: Cartesian reaction projected onto the boundary normal (`n̂·r_c`) — corner-correct; whole-boundary relL2 vs analytic SolCx σ_yy **0.43 → 0.042** (res48), converging to 0.030 (res96), corr 0.999.
- **Mass lumping** removes the Gibbs overshoot at a stress jump (monotone M-matrix de-smear) — the safe default for driving a free surface; also marginally more accurate and parallel-trivial (local division).
- **Parallel-safe** throughout: reaction via `globalToLocal`, boundary mass via coordinate-keyed allgather → byte-identical np=1/2/4.
- **Full stack verified**: custom geometric FMG × rotated × annulus × parallel converges (reason 2) and is partition-independent.

## Tests

- `tests/test_1018_rotated_freeslip.py` (serial, 6): box↔essential, annulus zero-leakage, FMG velocity block, σ_nn accuracy, lumped no-overshoot (total-variation), dynamic_topography field.
- `tests/parallel/test_1064_rotated_freeslip_parallel.py` (5): box + annulus + FMG-annulus + σ_nn + topography-field partition-independence. Passes at `-n 2` and `-n 4`.

## Not in this PR (queued)

Default the boundary normal to `mesh.boundary_normal`; 3D spherical validation; wiring into the fs4 free-surface driver.

Underworld development team with AI support from Claude Code