### PR TITLE
fix(units): UWQuantity handles offset temperature units (degC/degF)

### DIFF
--- a/src/underworld3/function/quantities.py
+++ b/src/underworld3/function/quantities.py
@@ -53,7 +53,8 @@ class UWQuantity:
     def __init__(
         self,
         value: Union[float, int, np.ndarray],
-        units: Optional[str] = None
+        units: Optional[str] = None,
+        _normalise_offset: bool = True,
     ):
         """
         Initialize a UWQuantity.
@@ -64,6 +65,14 @@ class UWQuantity:
             The dimensional value
         units : str or Pint Unit, optional
             Units specification
+        _normalise_offset : bool, default True
+            Internal. When True (the user-input boundary), an offset
+            temperature unit (``degC`` / ``degF``) is converted to absolute
+            kelvin on construction so that the stored quantity is always
+            multiplicative — no internal code (arithmetic, non-dimensional-
+            isation) ever meets a non-multiplicative unit. Set False only on
+            the output boundary (:meth:`to`) so a ``.to("degC")`` display
+            result is allowed to keep its offset unit.
         """
         from ..scaling import units as ureg
 
@@ -86,8 +95,22 @@ class UWQuantity:
                 # String - parse it
                 self._pint_unit = ureg.parse_expression(units).units
 
-            # Create Pint Quantity for arithmetic
-            self._pint_qty = self._value * self._pint_unit
+            # Create Pint Quantity for arithmetic. Use the registry Quantity
+            # constructor (value, unit) rather than ``value * unit``: the
+            # latter raises OffsetUnitCalculusError for offset temperature
+            # units (degC/degF), since ``scalar * degC`` is ambiguous in Pint.
+            self._pint_qty = ureg.Quantity(self._value, self._pint_unit)
+
+            # Input boundary: normalise an offset temperature unit (degC/degF)
+            # to absolute kelvin, so the stored quantity is multiplicative and
+            # no internal code meets a non-multiplicative unit. The user still
+            # reads it back in degC via .to("degC"). Multiplicative temperature
+            # units (kelvin, delta_degC) and all non-temperature units are left
+            # untouched.
+            if _normalise_offset and self._is_offset_temperature(self._pint_qty):
+                self._pint_qty = self._pint_qty.to(ureg.kelvin)
+                self._value = self._pint_qty.magnitude
+                self._pint_unit = self._pint_qty.units
         else:
             self._pint_unit = None
             self._pint_qty = None
@@ -95,6 +118,26 @@ class UWQuantity:
         # Cache for non-dimensional value (computed lazily)
         self._nd_value_cache = None
         self._nd_value_valid = False
+
+    @staticmethod
+    def _is_offset_temperature(pint_qty) -> bool:
+        """True if ``pint_qty`` carries a non-multiplicative (offset)
+        temperature unit such as ``degC`` / ``degF``.
+
+        These are the units for which scalar multiplication (``value * unit``,
+        ``qty * 2``) is ambiguous in Pint and raises ``OffsetUnitCalculusError``
+        — so they must not persist on a stored quantity. Detected via Pint's own
+        ``_is_multiplicative`` flag, which is False for offset units and True for
+        absolute kelvin/rankine *and* for a temperature difference
+        (``delta_degC``, correctly left alone). The ``[temperature]`` guard keeps
+        the kelvin conversion at the call site well-defined.
+        """
+        try:
+            if not pint_qty.check("[temperature]"):
+                return False
+            return not pint_qty._is_multiplicative
+        except Exception:
+            return False
 
     @classmethod
     def _from_pint(cls, pint_qty, model_registry=None):
@@ -247,7 +290,13 @@ class UWQuantity:
             raise ValueError("Cannot convert dimensionless quantity")
 
         converted = self._pint_qty.to(target_units)
-        return UWQuantity(converted.magnitude, converted.units)
+        # Output boundary: a .to("degC")/.to("degF") display result is allowed
+        # to keep its offset unit — do NOT re-normalise it back to kelvin
+        # (normalisation is an input-only concern). For all other targets this
+        # is a no-op (the unit is already multiplicative).
+        return UWQuantity(
+            converted.magnitude, converted.units, _normalise_offset=False
+        )
 
     def to_base_units(self) -> 'UWQuantity':
         """Convert to SI base units."""

--- a/tests/test_0757_uwquantity_offset_units.py
+++ b/tests/test_0757_uwquantity_offset_units.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Regression: UWQuantity handles offset temperature units (degC/degF).
+
+Pint forbids scalar arithmetic on offset (non-multiplicative) units — both
+``value * u.degC`` and ``qty * 2`` raise ``OffsetUnitCalculusError``. Previously
+``UWQuantity.__init__`` built its Pint quantity as ``value * unit``, so
+``uw.quantity(20, "degC")`` crashed at construction, and any offset temperature
+that slipped through non-dimensionalised silently to the wrong value.
+
+The fix normalises an offset temperature to absolute **kelvin at the input
+boundary**, so the stored quantity is always multiplicative and no internal code
+(arithmetic, non-dimensionalisation) ever meets an offset unit. The user reads it
+back in degC via ``.to("degC")`` — the only place an offset unit reappears is the
+output boundary. A temperature *difference* (``delta_degC``) is multiplicative and
+must be left untouched.
+"""
+import sympy
+import pytest
+
+import underworld3 as uw
+
+pytestmark = [pytest.mark.level_1, pytest.mark.tier_a]
+
+
+def test_construct_degC_does_not_crash():
+    """uw.quantity(., 'degC') constructs (previously OffsetUnitCalculusError)."""
+    q = uw.quantity(20.0, "degC")
+    assert q is not None
+
+
+def test_offset_normalised_to_kelvin_internally():
+    """An offset temperature is stored as absolute kelvin (multiplicative)."""
+    q = uw.quantity(20.0, "degC")
+    assert str(q.units) == "kelvin"
+    assert q.value == pytest.approx(293.15)
+
+    qf = uw.quantity(32.0, "degF")
+    assert str(qf.units) == "kelvin"
+    assert qf.value == pytest.approx(273.15)
+
+
+def test_display_round_trips_to_degC():
+    """.to('degC') reproduces the input value (output boundary keeps offset)."""
+    q = uw.quantity(20.0, "degC")
+    back = q.to("degC")
+    assert str(back.units) == "degree_Celsius"
+    assert back.value == pytest.approx(20.0)
+
+
+def test_kelvin_displays_to_degC():
+    """A kelvin quantity converts to degC for display."""
+    assert uw.quantity(300.0, "K").to("degC").value == pytest.approx(26.85)
+
+
+def test_scalar_multiply_offset_input_does_not_raise():
+    """Scalar arithmetic works because the stored unit is kelvin, not degC."""
+    q = uw.quantity(20.0, "degC")  # -> 293.15 K
+    doubled = q * 2
+    assert doubled.value == pytest.approx(586.3)
+    assert str(doubled.units) == "kelvin"
+
+
+def test_delta_degC_is_not_normalised():
+    """A temperature DIFFERENCE is multiplicative and must be preserved."""
+    q = uw.quantity(5.0, "delta_degC")
+    assert "delta" in str(q.units)
+    assert q.value == pytest.approx(5.0)
+
+
+def test_non_dimensionalise_offset_matches_kelvin_equivalent():
+    """nd(500 degC) equals nd(773.15 K) under an active model (no silent error)."""
+    uw.reset_default_model()
+    model = uw.get_default_model()
+    model.set_reference_quantities(
+        domain_depth=uw.quantity(1000, "km"),
+        plate_velocity=uw.quantity(5, "cm/year"),
+        mantle_viscosity=uw.quantity(1e21, "Pa*s"),
+        temperature_difference=uw.quantity(1000, "K"),
+    )
+    nd_degC = float(uw.quantity(500.0, "degC").data)   # 500 degC = 773.15 K
+    nd_K = float(uw.quantity(773.15, "K").data)
+    assert nd_degC == pytest.approx(nd_K)
+    assert nd_degC == pytest.approx(0.77315)
+
+
+def test_non_offset_units_unaffected():
+    """A plain (non-temperature) unit is stored and non-dimensionalised as before."""
+    q = uw.quantity(1000.0, "km")
+    assert str(q.units) == "kilometer"
+    assert q.value == pytest.approx(1000.0)


### PR DESCRIPTION
## Summary

`UWQuantity.__init__` built its Pint quantity as `value * unit`, which raises `OffsetUnitCalculusError` for offset (non-multiplicative) units. So `uw.quantity(20, "degC")` **crashed at construction**, and any offset temperature that reached non-dimensionalisation failed **silently** (a bare `except` fell back to the dimensional value — the #279 silent-boundary class).

## Design: offset units live only at the user boundary

- **Input** (`__init__`): construct via the registry `Quantity(value, unit)` constructor, then normalise an offset temperature (degC/degF) to absolute **kelvin**. The stored quantity is always multiplicative, so no internal code (arithmetic, nd, JIT) ever meets a non-multiplicative unit. Offset detection uses Pint's own `_is_multiplicative` flag, which correctly leaves a temperature *difference* (`delta_degC`) untouched.
- **Output** (`.to("degC")`): a display result keeps its offset unit via a non-normalising construction path.

## Verified

| behaviour | before | after |
|---|---|---|
| `uw.quantity(20,'degC')` | ❌ OffsetUnitCalculusError | ✅ stored 293.15 K |
| `.to('degC')` round-trip | — | ✅ 20 °C |
| `q * 2` on a degC input | ❌ raises | ✅ 586.3 K |
| `nd(500 degC)` | ❌ silent-wrong | ✅ 0.77315 (== nd(773.15 K)) |
| `delta_degC` (difference) | — | ✅ preserved, not normalised |

New `tests/test_0757_uwquantity_offset_units.py` (8 cases). Existing units tests (`test_0756`, `test_1011`) unaffected — 14/14 green locally.

Companion to the #263 thermal-convection units tutorial (which previously side-stepped this by staying in Kelvin). Relates to #279 (ND↔units boundary enforcement).

Underworld development team with AI support from Claude Code