### PR TITLE
Rotated strong free-slip inside the nonlinear Stokes solve

### DIFF
--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -5208,8 +5208,11 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
         # partition-independent enough for the norm comparison.
         rs, re = U1.getOwnershipRange()
         idx = np.arange(rs, re, dtype=float)
-        U1.setArray(0.1 * np.sin(0.7 * idx + 0.3))
-        U2.setArray(0.1 * np.sin(1.3 * idx + 1.1))
+        # write IN PLACE into each vec's PETSc-owned array (getArray returns a writable
+        # view). setArray with a fresh numpy temporary on a POOLED getGlobalVec is risky:
+        # its storage lifetime/pool reuse is not guaranteed for the later computeJacobian.
+        a1 = U1.getArray(); a1[:] = 0.1 * np.sin(0.7 * idx + 0.3)
+        a2 = U2.getArray(); a2[:] = 0.1 * np.sin(1.3 * idx + 1.1)
         J1 = J.copy(); J2 = J.copy()
         try:
             snes.computeJacobian(U1, J1)

--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -7908,25 +7908,26 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
             self.dm.setAuxiliaryVec(self.mesh.lvec, None)
             self._update_constants()
 
-            # Two paths:
-            #  * LINEAR model, zero initial guess, no Picard warmup → the validated
-            #    one-shot solve (assemble J(0),F(0); rotate; single self-contained
-            #    fieldsplit KSP). Fast, and the linear solution is exact so warm-start
-            #    / Picard would add nothing — hence the extra guards on this branch.
-            #  * otherwise (nonlinear rheology, or an explicitly-requested warm-start
-            #    / Picard) → the manual outer Newton/Picard loop that rotates F(u),
-            #    J(u) and the v_n=0 constraint every iteration. A nonlinear model is
-            #    detected by probing the assembled Jacobian for solution-dependence
-            #    (a symbolic test cannot see the JIT-substituted strain-rate term).
+            # Two paths, keyed on whether the model is nonlinear (detected by probing
+            # the assembled Jacobian for solution-dependence — a symbolic test cannot
+            # see the JIT-substituted strain-rate term):
+            #  * LINEAR model → the validated one-shot solve (assemble J(0),F(0);
+            #    rotate; single self-contained fieldsplit KSP). Fast, and the linear
+            #    solution is exact, so warm-start / Picard warmup add nothing and are
+            #    correctly ignored here.
+            #  * NONLINEAR model → the manual outer Newton/Picard loop that rotates
+            #    F(u), J(u) and the v_n=0 constraint every iteration. It honours
+            #    zero_init_guess (warm start), the Picard warmup count, and the
+            #    consistent_jacobian tangent (Picard / Newton / continuation).
             from underworld3.utilities.rotated_bc import (
                 solve_rotated_freeslip, solve_rotated_freeslip_nonlinear)
-            if zero_init_guess and picard == 0 and not self._residual_is_nonlinear():
+            if not self._residual_is_nonlinear():
                 self._rotated_freeslip_info = solve_rotated_freeslip(
                     self, self._rotated_freeslip_bcs, verbose=verbose)
             else:
                 self._rotated_freeslip_info = solve_rotated_freeslip_nonlinear(
                     self, self._rotated_freeslip_bcs, verbose=verbose,
-                    zero_init_guess=zero_init_guess)
+                    zero_init_guess=zero_init_guess, picard=picard)
             return
 
         if time is not None:

--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -7892,18 +7892,6 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
         # rotation + strong v_n=0 + reaction=sigma_nn). Handles the whole assemble/
         # solve/rotate-back/gauge-removal; stashes info for boundary_normal_traction.
         if self._rotated_freeslip_bcs:
-            # This is a LINEAR solve path: it assembles the Jacobian and residual once at
-            # U=0 and solves the rotated saddle directly, so it does NOT run the SNES
-            # nonlinear iteration. Nonlinear rheology / Picard / warm-start are therefore
-            # unsupported through this path — guard the explicit cases (and, below, a
-            # nonlinear constitutive model) rather than silently returning a
-            # single-linearisation answer.
-            if picard != 0 or not zero_init_guess:
-                raise NotImplementedError(
-                    "rotated free-slip BCs support only a single linear solve "
-                    "(zero_init_guess=True, picard=0). Nonlinear rheology or warm-start "
-                    "would require integrating the rotated constraint into the SNES "
-                    "iteration; not yet implemented.")
             # Run the same pre-solve preamble as the standard path so the pointwise
             # functions see the DM time, the auxiliary vector, and updated constants
             # (needed for problems whose coefficients live in auxiliary fields). This
@@ -7920,23 +7908,25 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
             self.dm.setAuxiliaryVec(self.mesh.lvec, None)
             self._update_constants()
 
-            # A nonlinear constitutive model would be silently linearised at u=0 by
-            # this one-shot path (the guard above only catches the EXPLICIT nonlinear
-            # signals). Probe the assembled Jacobian for solution-dependence and fail
-            # fast rather than return a single-linearisation answer.
-            if self._residual_is_nonlinear():
-                raise NotImplementedError(
-                    "rotated free-slip BCs currently support only LINEAR Stokes "
-                    "(constant or temperature-dependent viscosity). The registered "
-                    "constitutive model is nonlinear in the unknowns (the effective "
-                    "viscosity depends on velocity, its gradient, or pressure), which "
-                    "through the rotated free-slip path would silently return a single "
-                    "Newton linearisation from u=0. Integrating the rotated constraint "
-                    "into the SNES nonlinear iteration is not yet implemented.")
-
-            from underworld3.utilities.rotated_bc import solve_rotated_freeslip
-            self._rotated_freeslip_info = solve_rotated_freeslip(
-                self, self._rotated_freeslip_bcs, verbose=verbose)
+            # Two paths:
+            #  * LINEAR model, zero initial guess, no Picard warmup → the validated
+            #    one-shot solve (assemble J(0),F(0); rotate; single self-contained
+            #    fieldsplit KSP). Fast, and the linear solution is exact so warm-start
+            #    / Picard would add nothing — hence the extra guards on this branch.
+            #  * otherwise (nonlinear rheology, or an explicitly-requested warm-start
+            #    / Picard) → the manual outer Newton/Picard loop that rotates F(u),
+            #    J(u) and the v_n=0 constraint every iteration. A nonlinear model is
+            #    detected by probing the assembled Jacobian for solution-dependence
+            #    (a symbolic test cannot see the JIT-substituted strain-rate term).
+            from underworld3.utilities.rotated_bc import (
+                solve_rotated_freeslip, solve_rotated_freeslip_nonlinear)
+            if zero_init_guess and picard == 0 and not self._residual_is_nonlinear():
+                self._rotated_freeslip_info = solve_rotated_freeslip(
+                    self, self._rotated_freeslip_bcs, verbose=verbose)
+            else:
+                self._rotated_freeslip_info = solve_rotated_freeslip_nonlinear(
+                    self, self._rotated_freeslip_bcs, verbose=verbose,
+                    zero_init_guess=zero_init_guess)
             return
 
         if time is not None:

--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -5176,6 +5176,51 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
         self.is_setup = False
         return
 
+    def _residual_is_nonlinear(self, tol=1e-8):
+        r"""True if the Stokes residual is nonlinear in the unknowns :math:`(v, p)`
+        — i.e. the assembled Jacobian depends on the solution, so Newton / Picard
+        iteration is required.
+
+        Detected by a NUMERICAL probe: assemble the Jacobian at two distinct
+        velocity states and compare. A symbolic test on ``F1.sym`` cannot see the
+        nonlinearity — the effective viscosity's strain-rate (velocity-gradient)
+        dependence is carried as a JIT-substituted *placeholder* symbol
+        (``\dot\varepsilon_{II}``) in the flux, decoupled from the gradient
+        ``L`` in the symbolic form, so it only becomes visible once the operator
+        is assembled at a concrete iterate. Constant- or temperature-dependent
+        viscosity ⇒ ``J`` independent of ``v`` ⇒ the two assemblies are
+        bit-identical ⇒ linear.
+
+        Used to fail-fast on the rotated-free-slip path, which is a single linear
+        solve (assemble ``J(0)``, ``F(0)`` once) and would otherwise SILENTLY
+        return one Newton linearisation from ``u=0`` for a nonlinear model. The
+        caller must have run the pre-solve preamble (auxiliary vector + constants)
+        so the assembly sees the correct coefficients.
+        """
+        snes = self.snes
+        dm = self.dm
+        snes.setUp()
+        J = snes.getJacobian()[0]
+        U1 = dm.getGlobalVec(); U2 = dm.getGlobalVec()
+        # two distinct smooth, bounded states with non-zero velocity gradients
+        # (a linear operator gives the SAME J for both; only a solution-dependent
+        # viscosity makes them differ). Ownership-relative index keeps it
+        # partition-independent enough for the norm comparison.
+        rs, re = U1.getOwnershipRange()
+        idx = np.arange(rs, re, dtype=float)
+        U1.setArray(0.1 * np.sin(0.7 * idx + 0.3))
+        U2.setArray(0.1 * np.sin(1.3 * idx + 1.1))
+        J1 = J.copy(); J2 = J.copy()
+        try:
+            snes.computeJacobian(U1, J1)
+            snes.computeJacobian(U2, J2)
+            J2.axpy(-1.0, J1)                       # J2 <- J(U2) - J(U1)
+            rel = J2.norm() / (J1.norm() + 1e-300)
+        finally:
+            dm.restoreGlobalVec(U1); dm.restoreGlobalVec(U2)
+            J1.destroy(); J2.destroy()
+        return rel > tol
+
     def boundary_normal_traction(self, boundary, mass="lumped"):
         r"""Return the boundary normal traction :math:`\sigma_{nn}` on a
         rotated-free-slip ``boundary`` as the constraint reaction from the last
@@ -7850,8 +7895,9 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
             # This is a LINEAR solve path: it assembles the Jacobian and residual once at
             # U=0 and solves the rotated saddle directly, so it does NOT run the SNES
             # nonlinear iteration. Nonlinear rheology / Picard / warm-start are therefore
-            # unsupported through this path — guard the explicit cases rather than
-            # silently returning a single-linearisation answer.
+            # unsupported through this path — guard the explicit cases (and, below, a
+            # nonlinear constitutive model) rather than silently returning a
+            # single-linearisation answer.
             if picard != 0 or not zero_init_guess:
                 raise NotImplementedError(
                     "rotated free-slip BCs support only a single linear solve "
@@ -7860,7 +7906,9 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
                     "iteration; not yet implemented.")
             # Run the same pre-solve preamble as the standard path so the pointwise
             # functions see the DM time, the auxiliary vector, and updated constants
-            # (needed for problems whose coefficients live in auxiliary fields).
+            # (needed for problems whose coefficients live in auxiliary fields). This
+            # must precede the nonlinearity probe below so the trial assemblies see
+            # the correct coefficients.
             if time is not None:
                 if hasattr(time, 'magnitude') or hasattr(time, '_pint_qty'):
                     t_nd = float(uw.non_dimensionalise(time))
@@ -7871,6 +7919,20 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
             self.mesh.update_lvec()
             self.dm.setAuxiliaryVec(self.mesh.lvec, None)
             self._update_constants()
+
+            # A nonlinear constitutive model would be silently linearised at u=0 by
+            # this one-shot path (the guard above only catches the EXPLICIT nonlinear
+            # signals). Probe the assembled Jacobian for solution-dependence and fail
+            # fast rather than return a single-linearisation answer.
+            if self._residual_is_nonlinear():
+                raise NotImplementedError(
+                    "rotated free-slip BCs currently support only LINEAR Stokes "
+                    "(constant or temperature-dependent viscosity). The registered "
+                    "constitutive model is nonlinear in the unknowns (the effective "
+                    "viscosity depends on velocity, its gradient, or pressure), which "
+                    "through the rotated free-slip path would silently return a single "
+                    "Newton linearisation from u=0. Integrating the rotated constraint "
+                    "into the SNES nonlinear iteration is not yet implemented.")
 
             from underworld3.utilities.rotated_bc import solve_rotated_freeslip
             self._rotated_freeslip_info = solve_rotated_freeslip(

--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -1405,6 +1405,7 @@ class SNES_Stokes(SNES_Stokes_SaddlePt):
                 zero_init_guess,
                 _force_setup=_force_setup,
                 verbose=verbose,
+                picard=picard,
                 divergence_retries=divergence_retries,
             )
 

--- a/src/underworld3/utilities/rotated_bc.py
+++ b/src/underworld3/utilities/rotated_bc.py
@@ -336,7 +336,7 @@ def _gather_fields_to_global(solver):
 
 
 def solve_rotated_freeslip_nonlinear(solver, boundaries, remove_rotation_gauge=True,
-                                     verbose=False, zero_init_guess=True,
+                                     verbose=False, zero_init_guess=True, picard=0,
                                      rtol=None, atol=1.0e-11, stol=1.0e-8, max_it=50):
     """Nonlinear rotated strong-free-slip solve: a manual outer Newton/Picard loop
     that rotates the residual F(u), the Jacobian J(u) and the v_n=0 constraint EVERY
@@ -364,7 +364,24 @@ def solve_rotated_freeslip_nonlinear(solver, boundaries, remove_rotation_gauge=T
     The tangent used by ``computeJacobian`` is the solver's own (``consistent_jacobian``
     → Picard / Newton / continuation), so the rotated loop inherits the same tangent
     the standard path would use. The converged Cartesian residual is stashed as the
-    constraint reaction for σ_nn recovery (``boundary_normal_traction``)."""
+    constraint reaction for σ_nn recovery (``boundary_normal_traction``).
+
+    Tangent / warmup handling (mirrors the standard ``solve`` path so nothing is
+    silently ignored):
+
+    * ``consistent_jacobian == "continuation"`` — a two-phase Picard→Newton solve via
+      the ``constants[]``-routed blend α: phase 1 holds α=0 (frozen/Picard tangent) to
+      the loose ``solver.newton_switch_rtol`` (and at least ``picard`` iterations if
+      given) to enter Newton's basin; phase 2 sets α=1 (consistent Newton tangent) and
+      drives to the requested tolerance. α is restored to 0 afterwards.
+    * ``consistent_jacobian is True`` (pure Newton) with ``picard > 0`` — a Picard
+      warmup needs the frozen tangent, which the pure-Newton compile does not carry, so
+      this **raises** ``NotImplementedError`` pointing to ``"continuation"`` rather than
+      silently ignoring the request.
+    * ``consistent_jacobian is False`` (default, frozen/Picard) — the whole solve is
+      already the frozen tangent, so ``picard`` is inherently satisfied (matches the
+      standard path, whose post-warmup Newton phase also uses the frozen tangent here).
+    """
     if getattr(solver, "snes", None) is None:
         solver._setup_pointwise_functions(); solver._setup_discretisation(); solver._setup_solver()
     dm = solver.dm
@@ -372,6 +389,23 @@ def solve_rotated_freeslip_nonlinear(solver, boundaries, remove_rotation_gauge=T
     snes.setUp()
     if rtol is None:
         rtol = float(solver.tolerance)
+
+    # Resolve the tangent / warmup policy (see the docstring). ``continuation`` runs a
+    # staged α=0 → α=1 solve; pure Newton + picard>0 is unsupported (no frozen tangent
+    # to warm up with) and errors loudly; frozen (default) already satisfies a warmup.
+    mode = getattr(solver, "consistent_jacobian", False)
+    continuation = (mode == "continuation")
+    if picard and not continuation and mode is True:
+        raise NotImplementedError(
+            f"rotated free-slip: a Picard->Newton warmup (picard={picard}) with the "
+            "consistent Newton tangent (consistent_jacobian=True) requires "
+            "consistent_jacobian='continuation' — with pure Newton the frozen (Picard) "
+            "tangent needed for the warmup is not compiled in. Use "
+            "consistent_jacobian='continuation' (staged Picard then Newton), or drop "
+            "picard to run pure Newton.")
+    switch_rtol = max(float(getattr(solver, "newton_switch_rtol", 1.0e-2)), rtol)
+    if continuation:
+        solver._set_newton_alpha(0.0)            # start in the Picard phase
 
     # Q, the custom-FMG prolongation and the coupled null space depend only on the
     # geometry / normals (NOT the solution), so build them ONCE and reuse each step.
@@ -399,6 +433,7 @@ def solve_rotated_freeslip_nonlinear(solver, boundaries, remove_rotation_gauge=T
         return Fh
 
     r0 = None; last_reason = 0; iters = 0
+    phase = "picard" if continuation else "newton"
     for iters in range(max_it):
         Fhat = rotated_residual(u, keep_cartesian=True)
         rnorm = Fhat.norm()
@@ -406,11 +441,21 @@ def solve_rotated_freeslip_nonlinear(solver, boundaries, remove_rotation_gauge=T
             r0 = rnorm
         if verbose:
             from underworld3 import mpi
-            mpi.pprint(f"[rotated_bc] nonlinear iter {iters:2d}  |F̂|={rnorm:.6e}  rel={rnorm/(r0+1e-300):.3e}")
+            mpi.pprint(f"[rotated_bc] nonlinear iter {iters:2d}  |F̂|={rnorm:.6e}  "
+                       f"rel={rnorm/(r0+1e-300):.3e}  [{phase}]")
         # residual convergence (relative to the initial residual, plus an absolute
         # floor so an already-converged warm start does not chase machine noise).
         if rnorm <= rtol * r0 + atol:
             Fhat.destroy(); break
+        # Continuation: switch the frozen (Picard, α=0) tangent to the consistent
+        # (Newton, α=1) tangent once the residual has dropped into Newton's basin (the
+        # loose newton_switch_rtol) and at least `picard` Picard iterations have run.
+        if continuation and phase == "picard" and rnorm <= switch_rtol * r0 and iters >= picard:
+            solver._set_newton_alpha(1.0); phase = "newton"
+            if verbose:
+                from underworld3 import mpi
+                mpi.pprint(f"[rotated_bc] continuation: Picard→Newton at iter {iters} "
+                           f"(rel |F̂| {rnorm/(r0+1e-300):.2e})")
         snes.computeJacobian(u, J)
         Ahat = J.ptap(Qt); Ahat.zeroRowsColumns(normal_rows, diag=1.0)
         bhat = Fhat.copy(); bhat.scale(-1.0)
@@ -442,12 +487,17 @@ def solve_rotated_freeslip_nonlinear(solver, boundaries, remove_rotation_gauge=T
         if not improved:
             break
 
+    # Restore a clean frozen (Picard) tangent for any subsequent solve (next time
+    # step), matching the standard _continuation_solve which leaves alpha at 0.
+    if continuation:
+        solver._set_newton_alpha(0.0)
+
     removed = _finalize_rotated_solution(solver, u, Q, normal_rows, remove_rotation_gauge)
 
     return {"Q": Q, "Qt": Qt, "reaction": reaction, "U": u,
             "normal_rows": normal_rows, "boundaries": list(boundaries),
             "rotation_gauge_removed": removed, "ksp_reason": last_reason,
-            "nonlinear_iterations": iters}
+            "nonlinear_iterations": iters, "continuation_switched": phase == "newton"}
 
 
 def _build_rotated_custom_Pl(solver, Q, normal_rows):

--- a/src/underworld3/utilities/rotated_bc.py
+++ b/src/underworld3/utilities/rotated_bc.py
@@ -433,7 +433,7 @@ def solve_rotated_freeslip_nonlinear(solver, boundaries, remove_rotation_gauge=T
         Fh = Fc.duplicate(); Q.mult(Fc, Fh); _zero_rows_local(Fh, normal_rows)
         return Fh
 
-    r0 = None; last_reason = 0; iters = 0
+    r0 = None; last_reason = 0; iters = 0; converged = False
     phase = "picard" if continuation else "newton"
     for iters in range(max_it):
         Fhat = rotated_residual(u, keep_cartesian=True)
@@ -447,7 +447,7 @@ def solve_rotated_freeslip_nonlinear(solver, boundaries, remove_rotation_gauge=T
         # residual convergence (relative to the initial residual, plus an absolute
         # floor so an already-converged warm start does not chase machine noise).
         if rnorm <= rtol * r0 + atol:
-            Fhat.destroy(); break
+            converged = True; Fhat.destroy(); break
         # Continuation: switch the frozen (Picard, α=0) tangent to the consistent
         # (Newton, α=1) tangent once the residual has dropped into Newton's basin (the
         # loose newton_switch_rtol) and at least `picard` Picard iterations have run.
@@ -469,6 +469,7 @@ def solve_rotated_freeslip_nonlinear(solver, boundaries, remove_rotation_gauge=T
         # (otherwise the relative test above, with a tiny r0, chatters near machine
         # level). ‖u‖=0 on a cold start ⇒ this never fires prematurely (d is large).
         if d.norm() <= stol * (u.norm() + 1e-30):
+            converged = True
             Ahat.destroy(); dhat.destroy(); d.destroy(); bhat.destroy(); Fhat.destroy()
             break
         # backtracking line search on ‖F̂‖ (full Newton/Picard step first). Cheap
@@ -493,13 +494,24 @@ def solve_rotated_freeslip_nonlinear(solver, boundaries, remove_rotation_gauge=T
     if continuation:
         solver._set_newton_alpha(0.0)
 
+    # The loop can exhaust max_it or stall in the line search (`not improved`) without
+    # meeting the residual / step-norm criteria. Warn — as the standard SNES path does
+    # on divergence — so an unconverged iterate left in the fields is not silent.
+    if not converged:
+        from underworld3 import mpi
+        rel = (rnorm / (r0 + 1e-300)) if r0 is not None else float("nan")
+        mpi.pprint(f"[rotated_bc] WARNING: nonlinear rotated free-slip did NOT converge "
+                   f"in {iters + 1} iterations (rel |F̂| = {rel:.2e}); the fields hold "
+                   f"the last (unconverged) iterate.")
+
     Fc.destroy()                             # residual output buffer (reaction is kept for info)
     removed = _finalize_rotated_solution(solver, u, Q, normal_rows, remove_rotation_gauge)
 
     return {"Q": Q, "Qt": Qt, "reaction": reaction, "U": u,
             "normal_rows": normal_rows, "boundaries": list(boundaries),
             "rotation_gauge_removed": removed, "ksp_reason": last_reason,
-            "nonlinear_iterations": iters, "continuation_switched": phase == "newton"}
+            "nonlinear_iterations": iters, "converged": converged,
+            "continuation_switched": continuation and phase == "newton"}
 
 
 def _build_rotated_custom_Pl(solver, Q, normal_rows):

--- a/src/underworld3/utilities/rotated_bc.py
+++ b/src/underworld3/utilities/rotated_bc.py
@@ -420,6 +420,7 @@ def solve_rotated_freeslip_nonlinear(solver, boundaries, remove_rotation_gauge=T
     else:
         u = _gather_fields_to_global(solver)
     uh = u.duplicate(); Q.mult(u, uh); _zero_rows_local(uh, normal_rows); Qt.mult(uh, u)
+    uh.destroy()                             # transient projection buffer
 
     J = snes.getJacobian()[0]
     Fc = dm.createGlobalVec()
@@ -492,6 +493,7 @@ def solve_rotated_freeslip_nonlinear(solver, boundaries, remove_rotation_gauge=T
     if continuation:
         solver._set_newton_alpha(0.0)
 
+    Fc.destroy()                             # residual output buffer (reaction is kept for info)
     removed = _finalize_rotated_solution(solver, u, Q, normal_rows, remove_rotation_gauge)
 
     return {"Q": Q, "Qt": Qt, "reaction": reaction, "U": u,
@@ -518,7 +520,7 @@ def _build_rotated_custom_Pl(solver, Q, normal_rows):
 
 
 def _solve_rotated_iterative(solver, Ahat, bhat, Q, Qt, normal_rows, verbose=False,
-                             custom_Pl=None, nsp=None, Uhat0=None):
+                             custom_Pl=None, nsp=None):
     """Solve the rotated saddle with a SELF-CONTAINED fieldsplit-Schur KSP on the
     rotated operator. The velocity block is geometric FMG on the CUSTOM prolongation
     (PR#290, rotated) when a hierarchy is registered (``set_custom_fmg``), else GAMG.
@@ -531,8 +533,7 @@ def _solve_rotated_iterative(solver, Ahat, bhat, Q, Qt, normal_rows, verbose=Fal
     auto-correct). NO direct solve of the fine system.
 
     ``custom_Pl`` / ``nsp`` may be PREBUILT (nonlinear driver: build once, reuse each
-    Newton step); when None they are built here (linear one-shot). ``Uhat0`` seeds the
-    KSP initial guess (unused in the linear path; the nonlinear increment starts at 0)."""
+    Newton step); when None they are built here (linear one-shot)."""
     from underworld3.utilities import custom_mg
     dm = solver.dm
     vel_is = solver._subdict["velocity"][0]
@@ -710,10 +711,10 @@ def boundary_normal_traction(solver, boundary, info, mass="lumped"):
     # driver stashes it directly (the final ``computeFunction`` residual); the linear
     # one-shot reconstructs it as A·u−b (with A=J(0), b=−F(0), F affine ⇒ A·u−b=F(u)).
     if info.get("reaction") is not None:
-        rc = info["reaction"]
+        rc = info["reaction"]; own_rc = False    # owned by info — do NOT destroy
     else:
         A = info["A"]; b = info["b"]; U = info["U"]
-        rc = A.createVecLeft(); A.mult(U, rc); rc.axpy(-1.0, b)
+        rc = A.createVecLeft(); A.mult(U, rc); rc.axpy(-1.0, b); own_rc = True
     rcl = dm.getLocalVec(); dm.globalToLocal(rc, rcl); rca = np.asarray(rcl.getArray())
 
     lsec = dm.getLocalSection(); VEL = _velocity_field_id(solver)
@@ -730,6 +731,8 @@ def boundary_normal_traction(solver, boundary, info, mass="lumped"):
         xs.append(_point_coord(dm, dim, cvec, csec, v0, v1, q))
         Rn.append(float(np.dot(nrm, rcv)))        # R_i = n̂·r_c  (corner-correct)
     dm.restoreLocalVec(rcl)
+    if own_rc:
+        rc.destroy()                          # reconstructed A·u−b (linear path) — free it
     xs = np.array(xs); Rn = np.array(Rn)
     # σ_nn = −(nodal reaction), de-smeared by the SHARED boundary-mass primitive and
     # mean-removed (the ρg·h gauge). partial_reaction=False: the reaction here comes from

--- a/src/underworld3/utilities/rotated_bc.py
+++ b/src/underworld3/utilities/rotated_bc.py
@@ -267,6 +267,20 @@ def solve_rotated_freeslip(solver, boundaries, remove_rotation_gauge=True, verbo
     # rotate back u = Qᵀ û  (U is returned in info → create, don't borrow from the pool)
     U = dm.createGlobalVec(); Qt.mult(Uhat, U)
 
+    removed = _finalize_rotated_solution(solver, U, Q, normal_rows, remove_rotation_gauge)
+
+    return {"Q": Q, "Qt": Qt, "A": Aorig, "b": b, "U": U, "Uhat": Uhat,
+            "normal_rows": normal_rows, "boundaries": list(boundaries),
+            "rotation_gauge_removed": removed, "ksp_reason": ksp_reason}
+
+
+def _finalize_rotated_solution(solver, U, Q, normal_rows, remove_rotation_gauge):
+    """Remove the rigid-rotation gauge (if it is a genuine null space of the
+    constrained problem), scatter the composite global vector ``U`` into the
+    velocity/pressure fields, and refresh the enhanced-variable caches. Shared by
+    the linear one-shot and the nonlinear driver. Returns whether the gauge was
+    removed."""
+    dm = solver.dm
     # Remove the rigid-rotation gauge ONLY when it is a genuine null space of the
     # constrained problem (closed circular/spherical free-slip); on straight walls
     # the constraint pins the rotation, and projecting would corrupt the solution.
@@ -297,13 +311,164 @@ def solve_rotated_freeslip(solver, boundaries, remove_rotation_gauge=True, verbo
             target_var._sync_lvec_to_gvec()
         if hasattr(target_var, "_canonical_data"):
             target_var._canonical_data = None
+    return removed
 
-    return {"Q": Q, "Qt": Qt, "A": Aorig, "b": b, "U": U, "Uhat": Uhat,
+
+def _zero_rows_local(vec, normal_rows):
+    """Zero ``vec`` at the global rows ``normal_rows`` using ownership-relative
+    local indices (indexing the local slice with global rows overflows on any rank
+    whose ownership does not start at 0 — the np>1 crash class)."""
+    rs, re = vec.getOwnershipRange()
+    loc = np.asarray([g - rs for g in normal_rows if rs <= g < re], dtype=np.int64)
+    a = vec.getArray(); a[loc] = 0.0; vec.setArray(a)
+
+
+def _gather_fields_to_global(solver):
+    """Composite global vector built from the solver's current velocity/pressure
+    field values (the warm-start initial guess for the nonlinear driver)."""
+    dm = solver.dm
+    U = dm.createGlobalVec(); U.set(0.0)
+    for name, var in solver.fields.items():
+        sg = U.getSubVector(solver._subdict[name][0])
+        solver._subdict[name][1].localToGlobal(var.vec, sg)
+        U.restoreSubVector(solver._subdict[name][0], sg)
+    return U
+
+
+def solve_rotated_freeslip_nonlinear(solver, boundaries, remove_rotation_gauge=True,
+                                     verbose=False, zero_init_guess=True,
+                                     rtol=None, atol=1.0e-11, stol=1.0e-8, max_it=50):
+    """Nonlinear rotated strong-free-slip solve: a manual outer Newton/Picard loop
+    that rotates the residual F(u), the Jacobian J(u) and the v_n=0 constraint EVERY
+    iteration, reusing the validated self-contained rotated fieldsplit-Schur solve
+    (``_solve_rotated_iterative``, incl. custom geometric FMG / GAMG velocity block
+    and the rotated coupled null space) for each Newton increment.
+
+    Why a manual loop rather than ``snes.solve()``: the rotated operator ``Q A Qᵀ``
+    (a ``ptap`` result) carries no DM field information, so PETSc's DM-coupled
+    fieldsplit + geometric-MG cannot precondition it (SUBPC_ERROR); the increment
+    must be solved by the IS-based self-contained fieldsplit. Driving that from a
+    manual Newton loop keeps the whole validated linear machinery and imposes the
+    strong constraint exactly at every iterate.
+
+    Each iteration (unknown carried in the CARTESIAN frame ``u``; the increment is
+    solved in the rotated frame ``û = Q u``):
+      * ``F = computeFunction(u)``  → Cartesian residual (native essential BCs on
+        other boundaries already applied by the DM);
+      * ``F̂ = Q F``, zero ``F̂`` at the constrained normal rows (the constraint
+        residual is 0 there); converge on ‖F̂‖;
+      * ``Ĵ = Q J(u) Qᵀ`` with ``zeroRowsColumns(normal_rows)``;
+      * solve ``Ĵ δ̂ = −F̂``, ``δ = Qᵀ δ̂``, with a ‖F̂‖ backtracking line search;
+      * ``u += α δ`` and re-impose ``v_n = 0`` exactly.
+
+    The tangent used by ``computeJacobian`` is the solver's own (``consistent_jacobian``
+    → Picard / Newton / continuation), so the rotated loop inherits the same tangent
+    the standard path would use. The converged Cartesian residual is stashed as the
+    constraint reaction for σ_nn recovery (``boundary_normal_traction``)."""
+    if getattr(solver, "snes", None) is None:
+        solver._setup_pointwise_functions(); solver._setup_discretisation(); solver._setup_solver()
+    dm = solver.dm
+    snes = solver.snes
+    snes.setUp()
+    if rtol is None:
+        rtol = float(solver.tolerance)
+
+    # Q, the custom-FMG prolongation and the coupled null space depend only on the
+    # geometry / normals (NOT the solution), so build them ONCE and reuse each step.
+    Q, Qt, normal_rows = build_rotation(solver, boundaries)
+    custom_Pl = _build_rotated_custom_Pl(solver, Q, normal_rows)
+    nsp = _rotated_nullspace(solver, Q, normal_rows)
+
+    # initial guess (cartesian, composite): warm-start from the fields or zero, then
+    # impose v_n=0 exactly on it so the iteration starts feasible.
+    if zero_init_guess:
+        u = dm.createGlobalVec(); u.set(0.0)
+    else:
+        u = _gather_fields_to_global(solver)
+    uh = u.duplicate(); Q.mult(u, uh); _zero_rows_local(uh, normal_rows); Qt.mult(uh, u)
+
+    J = snes.getJacobian()[0]
+    Fc = dm.createGlobalVec()
+    reaction = dm.createGlobalVec()          # the final (un-zeroed) Cartesian residual
+
+    def rotated_residual(uvec, keep_cartesian=False):
+        snes.computeFunction(uvec, Fc)
+        if keep_cartesian:
+            Fc.copy(reaction)                # stash the Cartesian reaction for σ_nn
+        Fh = Fc.duplicate(); Q.mult(Fc, Fh); _zero_rows_local(Fh, normal_rows)
+        return Fh
+
+    r0 = None; last_reason = 0; iters = 0
+    for iters in range(max_it):
+        Fhat = rotated_residual(u, keep_cartesian=True)
+        rnorm = Fhat.norm()
+        if r0 is None:
+            r0 = rnorm
+        if verbose:
+            from underworld3 import mpi
+            mpi.pprint(f"[rotated_bc] nonlinear iter {iters:2d}  |F̂|={rnorm:.6e}  rel={rnorm/(r0+1e-300):.3e}")
+        # residual convergence (relative to the initial residual, plus an absolute
+        # floor so an already-converged warm start does not chase machine noise).
+        if rnorm <= rtol * r0 + atol:
+            Fhat.destroy(); break
+        snes.computeJacobian(u, J)
+        Ahat = J.ptap(Qt); Ahat.zeroRowsColumns(normal_rows, diag=1.0)
+        bhat = Fhat.copy(); bhat.scale(-1.0)
+        dhat, last_reason = _solve_rotated_iterative(
+            solver, Ahat, bhat, Q, Qt, normal_rows,
+            custom_Pl=custom_Pl, nsp=nsp, verbose=False)
+        d = dm.createGlobalVec(); Qt.mult(dhat, d)
+        # step-norm convergence (SNES_CONVERGED_SNORM): a tiny Newton step means we
+        # are at the solution — the exit for a warm start that is already converged
+        # (otherwise the relative test above, with a tiny r0, chatters near machine
+        # level). ‖u‖=0 on a cold start ⇒ this never fires prematurely (d is large).
+        if d.norm() <= stol * (u.norm() + 1e-30):
+            Ahat.destroy(); dhat.destroy(); d.destroy(); bhat.destroy(); Fhat.destroy()
+            break
+        # backtracking line search on ‖F̂‖ (full Newton/Picard step first). Cheap
+        # insurance far from the solution; α=1 is accepted immediately near it. If no
+        # step reduces the residual, the iteration has stalled (typically already at
+        # the solution) → stop rather than accept a non-decreasing step.
+        alpha = 1.0; improved = False
+        for _ls in range(8):
+            utry = u.copy(); utry.axpy(alpha, d)
+            uth = utry.duplicate(); Q.mult(utry, uth); _zero_rows_local(uth, normal_rows); Qt.mult(uth, utry)
+            uth.destroy()
+            Ftry = rotated_residual(utry)
+            if Ftry.norm() < rnorm:
+                u.destroy(); u = utry; improved = True; Ftry.destroy(); break
+            utry.destroy(); Ftry.destroy(); alpha *= 0.5
+        Ahat.destroy(); dhat.destroy(); d.destroy(); bhat.destroy(); Fhat.destroy()
+        if not improved:
+            break
+
+    removed = _finalize_rotated_solution(solver, u, Q, normal_rows, remove_rotation_gauge)
+
+    return {"Q": Q, "Qt": Qt, "reaction": reaction, "U": u,
             "normal_rows": normal_rows, "boundaries": list(boundaries),
-            "rotation_gauge_removed": removed, "ksp_reason": ksp_reason}
+            "rotation_gauge_removed": removed, "ksp_reason": last_reason,
+            "nonlinear_iterations": iters}
 
 
-def _solve_rotated_iterative(solver, Ahat, bhat, Q, Qt, normal_rows, verbose=False):
+def _build_rotated_custom_Pl(solver, Q, normal_rows):
+    """The rotated custom-FMG prolongation list [*coarse, Q_v·P_fine] for the
+    velocity block, or None if no hierarchy is registered. Depends only on Q and
+    the mesh (NOT the solution), so the nonlinear driver builds it ONCE and reuses
+    it across Newton iterations (the prolongation build is the expensive part)."""
+    if getattr(solver, "_custom_mg", None) is None:
+        return None
+    vel_is = solver._subdict["velocity"][0]
+    vis = np.asarray(vel_is.getIndices())
+    g2blk = {int(g): k for k, g in enumerate(vis)}
+    Qv = Q.createSubMatrix(vel_is, vel_is)
+    nrows_blk = sorted({g2blk[g] for g in normal_rows if g in g2blk})
+    Ps = solver._custom_mg["hierarchy"].build(solver)
+    Pfine = Qv.matMult(Ps[-1]); Pfine.zeroRows(nrows_blk, diag=0.0)
+    return list(Ps[:-1]) + [Pfine]
+
+
+def _solve_rotated_iterative(solver, Ahat, bhat, Q, Qt, normal_rows, verbose=False,
+                             custom_Pl=None, nsp=None, Uhat0=None):
     """Solve the rotated saddle with a SELF-CONTAINED fieldsplit-Schur KSP on the
     rotated operator. The velocity block is geometric FMG on the CUSTOM prolongation
     (PR#290, rotated) when a hierarchy is registered (``set_custom_fmg``), else GAMG.
@@ -313,24 +478,22 @@ def _solve_rotated_iterative(solver, Ahat, bhat, Q, Qt, normal_rows, verbose=Fal
     custom-FMG case the velocity sub-PC gets our prolongation via ``setMGInterpolation``
     (needs no DM); the rotated block A_vv = Q_v A_vv Q_vᵀ is formed from Âhat
     automatically and only the FINE prolongation is rotated (Galerkin coarse ops
-    auto-correct). NO direct solve of the fine system."""
+    auto-correct). NO direct solve of the fine system.
+
+    ``custom_Pl`` / ``nsp`` may be PREBUILT (nonlinear driver: build once, reuse each
+    Newton step); when None they are built here (linear one-shot). ``Uhat0`` seeds the
+    KSP initial guess (unused in the linear path; the nonlinear increment starts at 0)."""
     from underworld3.utilities import custom_mg
     dm = solver.dm
     vel_is = solver._subdict["velocity"][0]
     pres_is = solver._subdict["pressure"][0]
 
-    custom_Pl = None
-    if getattr(solver, "_custom_mg", None) is not None:
-        vis = np.asarray(vel_is.getIndices())
-        g2blk = {int(g): k for k, g in enumerate(vis)}
-        Qv = Q.createSubMatrix(vel_is, vel_is)
-        nrows_blk = sorted({g2blk[g] for g in normal_rows if g in g2blk})
-        Ps = solver._custom_mg["hierarchy"].build(solver)
-        Pfine = Qv.matMult(Ps[-1]); Pfine.zeroRows(nrows_blk, diag=0.0)
-        custom_Pl = list(Ps[:-1]) + [Pfine]
+    if custom_Pl is None:
+        custom_Pl = _build_rotated_custom_Pl(solver, Q, normal_rows)
 
     # rotated coupled null space (pressure-const ⊕ Q·rotation) on the operator
-    nsp = _rotated_nullspace(solver, Q, normal_rows)
+    if nsp is None:
+        nsp = _rotated_nullspace(solver, Q, normal_rows)
     if nsp is not None:
         Ahat.setNullSpace(nsp); Ahat.setTransposeNullSpace(nsp); nsp.remove(bhat)
 
@@ -493,9 +656,14 @@ def boundary_normal_traction(solver, boundary, info, mass="lumped"):
     """
     dm = solver.dm
     dim = solver.mesh.dim
-    A = info["A"]; b = info["b"]; U = info["U"]
-    # Cartesian nodal reaction r_c = A u − b (global), scattered to local incl. ghosts
-    rc = A.createVecLeft(); A.mult(U, rc); rc.axpy(-1.0, b)
+    # Cartesian nodal reaction r_c = F(u) at the converged state. The nonlinear
+    # driver stashes it directly (the final ``computeFunction`` residual); the linear
+    # one-shot reconstructs it as A·u−b (with A=J(0), b=−F(0), F affine ⇒ A·u−b=F(u)).
+    if info.get("reaction") is not None:
+        rc = info["reaction"]
+    else:
+        A = info["A"]; b = info["b"]; U = info["U"]
+        rc = A.createVecLeft(); A.mult(U, rc); rc.axpy(-1.0, b)
     rcl = dm.getLocalVec(); dm.globalToLocal(rc, rcl); rca = np.asarray(rcl.getArray())
 
     lsec = dm.getLocalSection(); VEL = _velocity_field_id(solver)

--- a/tests/parallel/test_1064_rotated_freeslip_parallel.py
+++ b/tests/parallel/test_1064_rotated_freeslip_parallel.py
@@ -54,9 +54,9 @@ GOLDEN_ANNULUS_FMG = (1.906961759626e-02, 5.428193e-06, 1.177002e-06)
 GOLDEN_BOX_NONLINEAR = (8.069396188270e-04, 7)
 # box sigma_nn (boundary_normal_traction on Top, default lumped mass) vs analytic SolCx
 # sigma_yy, whole boundary: (relL2, |corr|). Recompute with `python <thisfile> sigma`.
-GOLDEN_BOX_SIGMA = (3.985444e-02, 0.999208)
+GOLDEN_BOX_SIGMA = (5.554578e-02, 0.998466)
 # dynamic_topography field: BdIntegral L2 of h over Top. Recompute `python <thisfile> topo`.
-GOLDEN_TOPO_BDL2 = 2.560593173e-01
+GOLDEN_TOPO_BDL2 = 2.553916470e-01
 
 
 def _wrap(dm, m0):
@@ -202,7 +202,7 @@ def _box_sigma_diagnostics():
     SolCx sigma_yy over the WHOLE boundary. The per-rank local (xs, sigma) are gathered
     + de-duplicated on rank 0, the metric is computed there and broadcast, so every rank
     returns the same (relL2, |corr|) — a direct partition-independence check."""
-    res = 48
+    res = 24
     mesh = uw.meshing.StructuredQuadBox(
         elementRes=(res, res), minCoords=(0, 0), maxCoords=(1, 1), qdegree=3)
     sol = A.SolCx(mesh, eta_A=1.0, eta_B=1.0e3, x_c=0.5, n=1)
@@ -245,7 +245,7 @@ def _box_sigma_diagnostics():
 def _box_topography_bdl2():
     """dynamic_topography onto a P1 surface field; return the (collective) BdIntegral L2
     of h over Top — a partition-independent scalar functional of the topography field."""
-    res = 48
+    res = 24
     mesh = uw.meshing.StructuredQuadBox(
         elementRes=(res, res), minCoords=(0, 0), maxCoords=(1, 1), qdegree=3)
     sol = A.SolCx(mesh, eta_A=1.0, eta_B=1.0e3, x_c=0.5, n=1)
@@ -333,12 +333,12 @@ def test_rotated_freeslip_box_sigma_nn_partition_independent():
     parallel-safe."""
     relL2, corr, nnodes = _box_sigma_diagnostics()
     relL2_ref, corr_ref = GOLDEN_BOX_SIGMA
-    assert nnodes == 97, f"expected 97 top nodes, gathered {nnodes} at np={uw.mpi.size}"
+    assert nnodes == 49, f"expected 49 top nodes, gathered {nnodes} at np={uw.mpi.size}"
     assert np.isclose(relL2, relL2_ref, rtol=1e-4, atol=0), (
         f"sigma_nn relL2 differs serial vs np={uw.mpi.size}: {relL2_ref} vs {relL2}")
     assert np.isclose(corr, corr_ref, rtol=1e-4, atol=0), (
         f"sigma_nn corr differs serial vs np={uw.mpi.size}: {corr_ref} vs {corr}")
-    assert relL2 < 0.08, f"sigma_nn relL2 vs analytic {relL2:.3f} too large"
+    assert relL2 < 0.10, f"sigma_nn relL2 vs analytic {relL2:.3f} too large"
 
 
 def test_rotated_freeslip_dynamic_topography_partition_independent():

--- a/tests/parallel/test_1064_rotated_freeslip_parallel.py
+++ b/tests/parallel/test_1064_rotated_freeslip_parallel.py
@@ -48,6 +48,9 @@ GOLDEN_ANNULUS = (1.897011154231e-02, 4.563841e-05, 9.341699e-06)
 # annulus driven by CUSTOM GEOMETRIC FMG on the velocity block (nested hierarchy):
 # (velocity L2, radial-leakage L2 on Lower arc, radial-leakage L2 on Upper arc)
 GOLDEN_ANNULUS_FMG = (1.906961759626e-02, 5.428193e-06, 1.177002e-06)
+# NONLINEAR (power-law) box with rotated free-slip through the manual Newton/Picard
+# loop: (velocity L2, nonlinear iteration count). Recompute `python <thisfile> nonlinear`.
+GOLDEN_BOX_NONLINEAR = (2.724091573142e-03, 38)
 # box sigma_nn (boundary_normal_traction on Top, default lumped mass) vs analytic SolCx
 # sigma_yy, whole boundary: (relL2, |corr|). Recompute with `python <thisfile> sigma`.
 GOLDEN_BOX_SIGMA = (3.985444e-02, 0.999208)
@@ -160,6 +163,36 @@ def _annulus_fmg_diagnostics():
     leak_up = float(np.sqrt(uw.maths.BdIntegral(
         mesh=fine, fn=vr**2, boundary="Upper").evaluate()))
     return L2, leak_lo, leak_up
+
+
+def _box_nonlinear_diagnostics():
+    """NONLINEAR box: power-law viscosity eta = eps_II^(1/n-1) with rotated free-slip
+    on all four walls, solved by the manual Newton/Picard loop (GAMG velocity block).
+    Returns (velocity L2, nonlinear iteration count) — both must be partition-
+    independent (the loop's ptap / rotate / constrain / increment-solve are all
+    collective and ownership-relative)."""
+    mesh = uw.meshing.StructuredQuadBox(
+        elementRes=(16, 16), minCoords=(0, 0), maxCoords=(1, 1), qdegree=3)
+    x, y = mesh.X
+    v = uw.discretisation.MeshVariable("vNLp", mesh, mesh.dim, degree=2, continuous=True)
+    p = uw.discretisation.MeshVariable("pNLp", mesh, 1, degree=1, continuous=False)
+    s = uw.systems.Stokes(mesh, velocityField=v, pressureField=p)
+    s.constitutive_model = uw.constitutive_models.ViscousFlowModel
+    g = sympy.Matrix([[v.sym[0].diff(x), v.sym[0].diff(y)],
+                      [v.sym[1].diff(x), v.sym[1].diff(y)]])
+    e = 0.5 * (g + g.T)
+    eII = sympy.sqrt(0.5 * (e[0, 0] ** 2 + e[1, 1] ** 2) + e[0, 1] ** 2 + 1.0e-12)
+    s.constitutive_model.Parameters.shear_viscosity_0 = eII ** (1.0 / 3.0 - 1.0)
+    s.bodyforce = sympy.Matrix([[0.0, -3.0 * sympy.cos(sympy.pi * x)]])
+    s.penalty = 0.0
+    s.tolerance = 1e-8
+    s.petsc_use_pressure_nullspace = True
+    for wall in ("Top", "Bottom", "Left", "Right"):
+        s.add_rotated_freeslip_bc(wall)
+    s.solve()
+
+    L2 = float(np.sqrt(uw.maths.Integral(mesh, v.sym.dot(v.sym)).evaluate()))
+    return L2, int(s._rotated_freeslip_info["nonlinear_iterations"])
 
 
 def _box_sigma_diagnostics():
@@ -278,6 +311,19 @@ def test_rotated_freeslip_annulus_fmg_partition_independent():
         f"{leak_up_ref} vs {leak_up}")
 
 
+def test_rotated_freeslip_box_nonlinear_partition_independent():
+    """NONLINEAR rotated free-slip is partition-independent: a power-law box solved by
+    the manual Newton/Picard loop reproduces the serial velocity L2 and iteration count
+    at np=2/4 — the rotated residual/Jacobian, the increment solve and the constraint
+    zeroing are all parallel-safe (ownership-relative indexing, collective norms)."""
+    L2, iters = _box_nonlinear_diagnostics()
+    L2_ref, iters_ref = GOLDEN_BOX_NONLINEAR
+    assert np.isclose(L2, L2_ref, rtol=1e-6, atol=0), (
+        f"nonlinear box velocity L2 differs serial vs np={uw.mpi.size}: {L2_ref} vs {L2}")
+    assert iters == iters_ref, (
+        f"nonlinear iteration count differs serial vs np={uw.mpi.size}: {iters_ref} vs {iters}")
+
+
 def test_rotated_freeslip_box_sigma_nn_partition_independent():
     """sigma_nn (boundary_normal_traction) recovery is partition-independent: the whole-
     boundary relL2 / |corr| vs analytic SolCx sigma_yy match the serial reference (and
@@ -309,7 +355,11 @@ if __name__ == "__main__":
     #   `python <thisfile> {box,annulus,annulus_fmg,sigma,topo}`.
     import sys
     _kind = sys.argv[1] if len(sys.argv) > 1 else "box"
-    if _kind == "topo":
+    if _kind == "nonlinear":
+        _L2, _its = _box_nonlinear_diagnostics()
+        if uw.mpi.rank == 0:
+            print(f"DIAG_NONLINEAR {_L2:.12e} {_its}")
+    elif _kind == "topo":
         _b = _box_topography_bdl2()
         if uw.mpi.rank == 0:
             print(f"DIAG_TOPO bdl2={_b:.9e}")

--- a/tests/parallel/test_1064_rotated_freeslip_parallel.py
+++ b/tests/parallel/test_1064_rotated_freeslip_parallel.py
@@ -48,9 +48,10 @@ GOLDEN_ANNULUS = (1.897011154231e-02, 4.563841e-05, 9.341699e-06)
 # annulus driven by CUSTOM GEOMETRIC FMG on the velocity block (nested hierarchy):
 # (velocity L2, radial-leakage L2 on Lower arc, radial-leakage L2 on Upper arc)
 GOLDEN_ANNULUS_FMG = (1.906961759626e-02, 5.428193e-06, 1.177002e-06)
-# NONLINEAR (power-law) box with rotated free-slip through the manual Newton/Picard
-# loop: (velocity L2, nonlinear iteration count). Recompute `python <thisfile> nonlinear`.
-GOLDEN_BOX_NONLINEAR = (2.724091573142e-03, 38)
+# NONLINEAR (power-law) box with rotated free-slip through the manual Newton loop
+# (consistent tangent): (velocity L2, nonlinear iteration count). Recompute
+# `python <thisfile> nonlinear`.
+GOLDEN_BOX_NONLINEAR = (8.069396188270e-04, 7)
 # box sigma_nn (boundary_normal_traction on Top, default lumped mass) vs analytic SolCx
 # sigma_yy, whole boundary: (relL2, |corr|). Recompute with `python <thisfile> sigma`.
 GOLDEN_BOX_SIGMA = (3.985444e-02, 0.999208)
@@ -167,12 +168,12 @@ def _annulus_fmg_diagnostics():
 
 def _box_nonlinear_diagnostics():
     """NONLINEAR box: power-law viscosity eta = eps_II^(1/n-1) with rotated free-slip
-    on all four walls, solved by the manual Newton/Picard loop (GAMG velocity block).
-    Returns (velocity L2, nonlinear iteration count) — both must be partition-
-    independent (the loop's ptap / rotate / constrain / increment-solve are all
-    collective and ownership-relative)."""
+    on all four walls, solved by the manual Newton loop (consistent tangent, GAMG
+    velocity block). Returns (velocity L2, nonlinear iteration count) — both must be
+    partition-independent (the loop's ptap / rotate / constrain / increment-solve are
+    all collective and ownership-relative)."""
     mesh = uw.meshing.StructuredQuadBox(
-        elementRes=(16, 16), minCoords=(0, 0), maxCoords=(1, 1), qdegree=3)
+        elementRes=(8, 8), minCoords=(0, 0), maxCoords=(1, 1), qdegree=3)
     x, y = mesh.X
     v = uw.discretisation.MeshVariable("vNLp", mesh, mesh.dim, degree=2, continuous=True)
     p = uw.discretisation.MeshVariable("pNLp", mesh, 1, degree=1, continuous=False)
@@ -183,10 +184,11 @@ def _box_nonlinear_diagnostics():
     e = 0.5 * (g + g.T)
     eII = sympy.sqrt(0.5 * (e[0, 0] ** 2 + e[1, 1] ** 2) + e[0, 1] ** 2 + 1.0e-12)
     s.constitutive_model.Parameters.shear_viscosity_0 = eII ** (1.0 / 3.0 - 1.0)
-    s.bodyforce = sympy.Matrix([[0.0, -3.0 * sympy.cos(sympy.pi * x)]])
+    s.bodyforce = sympy.Matrix([[0.0, -2.0 * sympy.cos(sympy.pi * x)]])
     s.penalty = 0.0
-    s.tolerance = 1e-8
+    s.tolerance = 1e-7
     s.petsc_use_pressure_nullspace = True
+    s.consistent_jacobian = True                 # Newton tangent (few iterations)
     for wall in ("Top", "Bottom", "Left", "Right"):
         s.add_rotated_freeslip_bc(wall)
     s.solve()

--- a/tests/test_1018_rotated_freeslip.py
+++ b/tests/test_1018_rotated_freeslip.py
@@ -211,45 +211,151 @@ def test_rotated_freeslip_sigma_nn_lumped_no_overshoot():
     assert tv_l < tv_c, f"lumped TV {tv_l:.3f} not smoother than consistent {tv_c:.3f}"
 
 
-def test_rotated_freeslip_nonlinear_guard_raises():
-    """Step-0 safety guard: the rotated free-slip path is a single LINEAR solve
-    (it assembles J,F once at u=0). A nonlinear constitutive model would be
-    silently linearised, so solve() must fail fast with a clear NotImplementedError
-    rather than return a single-linearisation answer. A linear model must NOT trip
-    the guard (covered by the other tests, checked directly here too)."""
+def _powerlaw_stokes(mesh, prefix, amp=3.0, nexp=3.0):
+    """A genuinely NONLINEAR Stokes: power-law viscosity eta = eps_II^(1/n - 1)
+    (smooth, so Newton/Picard iterates robustly), driven by a horizontally-varying
+    vertical body force so there is real shear."""
+    x, y = mesh.X
+    v = uw.discretisation.MeshVariable(prefix + "v", mesh, mesh.dim, degree=2, continuous=True)
+    p = uw.discretisation.MeshVariable(prefix + "p", mesh, 1, degree=1, continuous=False)
+    s = uw.systems.Stokes(mesh, velocityField=v, pressureField=p)
+    s.constitutive_model = uw.constitutive_models.ViscousFlowModel
+    g = sympy.Matrix([[v.sym[0].diff(x), v.sym[0].diff(y)],
+                      [v.sym[1].diff(x), v.sym[1].diff(y)]])
+    e = 0.5 * (g + g.T)
+    eII = sympy.sqrt(0.5 * (e[0, 0] ** 2 + e[1, 1] ** 2) + e[0, 1] ** 2 + 1.0e-12)
+    s.constitutive_model.Parameters.shear_viscosity_0 = eII ** (1.0 / nexp - 1.0)
+    s.bodyforce = sympy.Matrix([[0.0, -amp * sympy.cos(sympy.pi * x)]])
+    s.penalty = 0.0
+    s.tolerance = 1e-8
+    s.petsc_use_pressure_nullspace = True
+    return s, v, p
+
+
+def _powerlaw_essential(mesh, prefix):
+    s, v, p = _powerlaw_stokes(mesh, prefix)
+    s.add_essential_bc((sympy.oo, 0.0), "Top")
+    s.add_essential_bc((sympy.oo, 0.0), "Bottom")
+    s.add_essential_bc((0.0, sympy.oo), "Left")
+    s.add_essential_bc((0.0, sympy.oo), "Right")
+    s.solve()
+    return v
+
+
+def test_rotated_freeslip_nonlinear_matches_essential():
+    """A NONLINEAR (power-law) rotated free-slip solve genuinely iterates and
+    converges to the SAME answer as the native essential nonlinear free-slip solve
+    on the axis-aligned box (both impose v_n=0 — identical discrete problem), with
+    machine-zero wall-normal velocity. This exercises the rotated constraint INSIDE
+    the nonlinear iteration (rotate F(u), J(u), v_n=0 every step)."""
     mesh = uw.meshing.StructuredQuadBox(
         elementRes=(12, 12), minCoords=(0, 0), maxCoords=(1, 1), qdegree=3)
+    vE = _powerlaw_essential(mesh, "nlE")
 
-    # nonlinear (viscoplastic yield) -> guard must raise
-    vN = uw.discretisation.MeshVariable("vNg", mesh, mesh.dim, degree=2, continuous=True)
-    pN = uw.discretisation.MeshVariable("pNg", mesh, 1, degree=1, continuous=False)
-    sN = uw.systems.Stokes(mesh, velocityField=vN, pressureField=pN)
-    sN.constitutive_model = uw.constitutive_models.ViscoPlasticFlowModel
-    sN.constitutive_model.Parameters.shear_viscosity_0 = 1.0
-    sN.constitutive_model.Parameters.yield_stress = 1.0
-    sN.constitutive_model.Parameters.strainrate_inv_II_min = 1.0e-10
-    sN.bodyforce = sympy.Matrix([[0.0, -1.0]])
-    sN.tolerance = 1e-6
+    s, vR, pR = _powerlaw_stokes(mesh, "nlR")
     for wall in ("Top", "Bottom", "Left", "Right"):
-        sN.add_rotated_freeslip_bc(wall)
-    sN.petsc_use_pressure_nullspace = True
-    with pytest.raises(NotImplementedError, match="LINEAR"):
-        sN.solve()
+        s.add_rotated_freeslip_bc(wall)
+    s.solve()  # routes to the nonlinear rotated driver
 
-    # linear (constant viscosity) -> guard must NOT raise
-    vL = uw.discretisation.MeshVariable("vLg", mesh, mesh.dim, degree=2, continuous=True)
-    pL = uw.discretisation.MeshVariable("pLg", mesh, 1, degree=1, continuous=False)
-    sL = uw.systems.Stokes(mesh, velocityField=vL, pressureField=pL)
-    sL.constitutive_model = uw.constitutive_models.ViscousFlowModel
-    sL.constitutive_model.Parameters.shear_viscosity_0 = 1.0
-    sL.bodyforce = sympy.Matrix([[0.0, -1.0]])
-    sL.tolerance = 1e-9
+    info = s._rotated_freeslip_info
+    assert info["nonlinear_iterations"] > 1, "rotated solve did not genuinely iterate"
+    rel = np.linalg.norm(vR.data - vE.data) / np.linalg.norm(vE.data)
+    assert rel < 1e-3, f"nonlinear rotated free-slip differs from essential by {rel:.2e}"
+    # zero wall-normal flow on every wall
+    vc = vR.coords
+    for lab, msk, comp in [("Top", np.abs(vc[:, 1] - 1) < 1e-6, 1),
+                           ("Bottom", np.abs(vc[:, 1]) < 1e-6, 1),
+                           ("Left", np.abs(vc[:, 0]) < 1e-6, 0),
+                           ("Right", np.abs(vc[:, 0] - 1) < 1e-6, 0)]:
+        leak = np.abs(vR.data[msk, comp]).max() if msk.any() else 0.0
+        assert leak < 1e-10, f"{lab} wall-normal velocity {leak:.2e} not machine-zero"
+
+
+def test_rotated_freeslip_nonlinear_warm_start():
+    """Warm-start (zero_init_guess=False) through the nonlinear rotated path: a
+    2-step 'time loop' re-solving from the previous converged state stays correct
+    and converges (the step-norm exit avoids chasing machine noise)."""
+    mesh = uw.meshing.StructuredQuadBox(
+        elementRes=(12, 12), minCoords=(0, 0), maxCoords=(1, 1), qdegree=3)
+    vE = _powerlaw_essential(mesh, "wsE")
+
+    s, vR, pR = _powerlaw_stokes(mesh, "wsR")
     for wall in ("Top", "Bottom", "Left", "Right"):
-        sL.add_rotated_freeslip_bc(wall)
-    sL.petsc_use_pressure_nullspace = True
-    sL.petsc_options["snes_type"] = "ksponly"
-    sL.solve()  # must not raise
-    assert sL._rotated_freeslip_info is not None
+        s.add_rotated_freeslip_bc(wall)
+    s.solve()                              # cold
+    s.solve(zero_init_guess=False)         # warm (step 2)
+
+    rel = np.linalg.norm(vR.data - vE.data) / np.linalg.norm(vE.data)
+    assert rel < 1e-3, f"warm-start rotated free-slip differs from essential by {rel:.2e}"
+    # warm-start from an already-converged state converges in few iterations
+    assert s._rotated_freeslip_info["nonlinear_iterations"] <= 3
+
+
+def test_rotated_freeslip_nonlinear_geometric_fmg():
+    """The NONLINEAR rotated free-slip velocity block is driven by geometric FMG on
+    the custom prolongation (set_custom_fmg) — the rotated prolongation is built once
+    and reused across Newton iterations — and still converges to the essential
+    nonlinear free-slip solution."""
+    m0 = uw.meshing.UnstructuredSimplexBox(
+        minCoords=(0, 0), maxCoords=(1, 1), cellSize=0.25, regular=True, qdegree=3)
+    dm0 = m0.dm
+    dm1 = dm0.refine()
+    dm2 = dm1.refine()
+    coarse = [_wrap(dm0, m0), _wrap(dm1, m0)]
+    fine = _wrap(dm2, m0)
+    vE = _powerlaw_essential(fine, "nlfE")
+
+    s, vR, pR = _powerlaw_stokes(fine, "nlfR")
+    for wall in ("Top", "Bottom", "Left", "Right"):
+        s.add_rotated_freeslip_bc(wall)
+    custom_mg.set_custom_fmg(s, coarse, builder="barycentric", field_id=0)
+    s.solve()
+
+    info = s._rotated_freeslip_info
+    assert info["nonlinear_iterations"] > 1
+    assert info["ksp_reason"] > 0                # geometric MG increment converged
+    rel = np.linalg.norm(vR.data - vE.data) / np.linalg.norm(vE.data)
+    assert rel < 5e-3, f"nonlinear FMG rotated free-slip differs from essential by {rel:.2e}"
+
+
+def test_rotated_freeslip_nonlinear_annulus_zero_leakage():
+    """Genuinely-rotated frame under nonlinear iteration: a power-law annulus with
+    per-node radial free-slip on both arcs genuinely iterates, gives machine-zero
+    radial leakage, and the rigid-rotation gauge is removed."""
+    RI, RO = 0.5, 1.0
+    mesh = uw.meshing.Annulus(radiusInner=RI, radiusOuter=RO, cellSize=0.15, qdegree=3)
+    x, y = mesh.X
+    r = sympy.sqrt(x**2 + y**2)
+    th = sympy.atan2(y, x)
+    v = uw.discretisation.MeshVariable("Vnla", mesh, mesh.dim, degree=2, continuous=True)
+    p = uw.discretisation.MeshVariable("Pnla", mesh, 1, degree=1, continuous=True)
+    s = uw.systems.Stokes(mesh, velocityField=v, pressureField=p)
+    s.constitutive_model = uw.constitutive_models.ViscousFlowModel
+    g = sympy.Matrix([[v.sym[0].diff(x), v.sym[0].diff(y)],
+                      [v.sym[1].diff(x), v.sym[1].diff(y)]])
+    e = 0.5 * (g + g.T)
+    eII = sympy.sqrt(0.5 * (e[0, 0] ** 2 + e[1, 1] ** 2) + e[0, 1] ** 2 + 1.0e-12)
+    s.constitutive_model.Parameters.shear_viscosity_0 = eII ** (1.0 / 3.0 - 1.0)
+    s.bodyforce = sympy.Matrix([[x / r * sympy.cos(4 * th) * (r - RI) * (RO - r) * 40.0,
+                                 y / r * sympy.cos(4 * th) * (r - RI) * (RO - r) * 40.0]])
+    nhat = sympy.Matrix([[x / r, y / r]])
+    s.add_rotated_freeslip_bc("Lower", normal=nhat)
+    s.add_rotated_freeslip_bc("Upper", normal=nhat)
+    s.petsc_use_pressure_nullspace = True
+    s.tolerance = 1e-7
+    s.solve()
+
+    info = s._rotated_freeslip_info
+    assert info["nonlinear_iterations"] > 1, "annulus rotated solve did not genuinely iterate"
+    assert info["rotation_gauge_removed"]
+    vc = v.coords
+    rr = np.hypot(vc[:, 0], vc[:, 1])
+    rhat = vc / rr[:, None]
+    vr = np.einsum("ij,ij->i", v.data, rhat)
+    vmax = np.linalg.norm(v.data, axis=1).max() + 1e-30
+    for lab, mask in [("inner", np.abs(rr - RI) < 1e-4), ("outer", np.abs(rr - RO) < 1e-4)]:
+        leak = np.abs(vr[mask]).max() / vmax
+        assert leak < 1e-10, f"{lab} radial leakage {leak:.2e} not machine-zero"
 
 
 def test_rotated_freeslip_dynamic_topography_field():

--- a/tests/test_1018_rotated_freeslip.py
+++ b/tests/test_1018_rotated_freeslip.py
@@ -271,6 +271,42 @@ def test_rotated_freeslip_nonlinear_matches_essential():
         assert leak < 1e-10, f"{lab} wall-normal velocity {leak:.2e} not machine-zero"
 
 
+def test_rotated_freeslip_newton_tangent_matches_essential():
+    """The CONSISTENT NEWTON tangent (consistent_jacobian=True) works through the
+    rotated path: on a power-law box it converges in the SAME small number of Newton
+    iterations as the native essential Newton solve, and to the same answer at
+    (near) machine precision — i.e. the rotated constraint does not degrade the
+    Newton tangent, it is genuine Newton, not defect-correction. Contrast the frozen
+    (Picard) tangent, which converges only at a linear rate (many more iterations)."""
+    mesh = uw.meshing.StructuredQuadBox(
+        elementRes=(12, 12), minCoords=(0, 0), maxCoords=(1, 1), qdegree=3)
+
+    sE, vE, _ = _powerlaw_stokes(mesh, "ntE")
+    sE.consistent_jacobian = True
+    sE.add_essential_bc((sympy.oo, 0.0), "Top")
+    sE.add_essential_bc((sympy.oo, 0.0), "Bottom")
+    sE.add_essential_bc((0.0, sympy.oo), "Left")
+    sE.add_essential_bc((0.0, sympy.oo), "Right")
+    sE.solve()
+    essential_newton_its = sE.snes.getIterationNumber()
+
+    s, vR, pR = _powerlaw_stokes(mesh, "ntR")
+    s.consistent_jacobian = True
+    for wall in ("Top", "Bottom", "Left", "Right"):
+        s.add_rotated_freeslip_bc(wall)
+    s.solve()
+
+    its = s._rotated_freeslip_info["nonlinear_iterations"]
+    # genuine Newton: a small iteration count, comparable to the essential Newton
+    # solve (NOT the ~4-5x larger Picard/frozen-tangent count on the same problem).
+    assert its <= 2 * essential_newton_its + 2, (
+        f"rotated Newton took {its} iters vs essential Newton {essential_newton_its} "
+        f"— tangent likely not the consistent one")
+    assert its < 20, f"rotated Newton not converging at Newton rate ({its} iters)"
+    rel = np.linalg.norm(vR.data - vE.data) / np.linalg.norm(vE.data)
+    assert rel < 1e-6, f"rotated Newton differs from essential Newton by {rel:.2e}"
+
+
 def test_rotated_freeslip_nonlinear_warm_start():
     """Warm-start (zero_init_guess=False) through the nonlinear rotated path: a
     2-step 'time loop' re-solving from the previous converged state stays correct

--- a/tests/test_1018_rotated_freeslip.py
+++ b/tests/test_1018_rotated_freeslip.py
@@ -211,10 +211,11 @@ def test_rotated_freeslip_sigma_nn_lumped_no_overshoot():
     assert tv_l < tv_c, f"lumped TV {tv_l:.3f} not smoother than consistent {tv_c:.3f}"
 
 
-def _powerlaw_stokes(mesh, prefix, amp=3.0, nexp=3.0):
+def _powerlaw_stokes(mesh, prefix, amp=2.0, nexp=3.0, cj=None):
     """A genuinely NONLINEAR Stokes: power-law viscosity eta = eps_II^(1/n - 1)
     (smooth, so Newton/Picard iterates robustly), driven by a horizontally-varying
-    vertical body force so there is real shear."""
+    vertical body force so there is real shear. ``cj`` sets ``consistent_jacobian``
+    (None=default frozen/Picard, True=consistent Newton, "continuation"=staged)."""
     x, y = mesh.X
     v = uw.discretisation.MeshVariable(prefix + "v", mesh, mesh.dim, degree=2, continuous=True)
     p = uw.discretisation.MeshVariable(prefix + "p", mesh, 1, degree=1, continuous=False)
@@ -227,41 +228,49 @@ def _powerlaw_stokes(mesh, prefix, amp=3.0, nexp=3.0):
     s.constitutive_model.Parameters.shear_viscosity_0 = eII ** (1.0 / nexp - 1.0)
     s.bodyforce = sympy.Matrix([[0.0, -amp * sympy.cos(sympy.pi * x)]])
     s.penalty = 0.0
-    s.tolerance = 1e-8
+    s.tolerance = 1e-7
     s.petsc_use_pressure_nullspace = True
+    if cj is not None:
+        s.consistent_jacobian = cj
     return s, v, p
 
 
-def _powerlaw_essential(mesh, prefix):
-    s, v, p = _powerlaw_stokes(mesh, prefix)
+def _powerlaw_essential(mesh, prefix, cj=None):
+    s, v, p = _powerlaw_stokes(mesh, prefix, cj=cj)
     s.add_essential_bc((sympy.oo, 0.0), "Top")
     s.add_essential_bc((sympy.oo, 0.0), "Bottom")
     s.add_essential_bc((0.0, sympy.oo), "Left")
     s.add_essential_bc((0.0, sympy.oo), "Right")
     s.solve()
-    return v
+    return v, s.snes.getIterationNumber()
 
 
-def test_rotated_freeslip_nonlinear_matches_essential():
-    """A NONLINEAR (power-law) rotated free-slip solve genuinely iterates and
-    converges to the SAME answer as the native essential nonlinear free-slip solve
-    on the axis-aligned box (both impose v_n=0 — identical discrete problem), with
-    machine-zero wall-normal velocity. This exercises the rotated constraint INSIDE
-    the nonlinear iteration (rotate F(u), J(u), v_n=0 every step)."""
+@pytest.fixture(scope="module")
+def plaw_box_ref():
+    """A small power-law box + its native ESSENTIAL nonlinear free-slip solution,
+    solved ONCE (Newton tangent) and shared across the rotated-vs-essential box
+    tests. The converged solution is tangent-independent, so this one reference
+    serves the Picard / Newton / continuation tests. Returns (mesh, vE_data,
+    essential_newton_iters)."""
     mesh = uw.meshing.StructuredQuadBox(
-        elementRes=(12, 12), minCoords=(0, 0), maxCoords=(1, 1), qdegree=3)
-    vE = _powerlaw_essential(mesh, "nlE")
+        elementRes=(8, 8), minCoords=(0, 0), maxCoords=(1, 1), qdegree=3)
+    vE, its = _powerlaw_essential(mesh, "refE", cj=True)
+    return mesh, np.copy(vE.data), its
 
-    s, vR, pR = _powerlaw_stokes(mesh, "nlR")
+
+def test_rotated_freeslip_nonlinear_matches_essential(plaw_box_ref):
+    """Default (frozen/Picard) tangent through the rotated path: genuinely iterates
+    and converges to the native essential nonlinear free-slip answer (both impose
+    v_n=0 — identical discrete problem), with machine-zero wall-normal flow on every
+    wall. Exercises the rotated constraint INSIDE the nonlinear iteration."""
+    mesh, vE, _ = plaw_box_ref
+    s, vR, pR = _powerlaw_stokes(mesh, "nlP")           # default (Picard) tangent
     for wall in ("Top", "Bottom", "Left", "Right"):
         s.add_rotated_freeslip_bc(wall)
-    s.solve()  # routes to the nonlinear rotated driver
-
+    s.solve()
     info = s._rotated_freeslip_info
     assert info["nonlinear_iterations"] > 1, "rotated solve did not genuinely iterate"
-    rel = np.linalg.norm(vR.data - vE.data) / np.linalg.norm(vE.data)
-    assert rel < 1e-3, f"nonlinear rotated free-slip differs from essential by {rel:.2e}"
-    # zero wall-normal flow on every wall
+    assert np.linalg.norm(vR.data - vE) / np.linalg.norm(vE) < 1e-3
     vc = vR.coords
     for lab, msk, comp in [("Top", np.abs(vc[:, 1] - 1) < 1e-6, 1),
                            ("Bottom", np.abs(vc[:, 1]) < 1e-6, 1),
@@ -271,58 +280,72 @@ def test_rotated_freeslip_nonlinear_matches_essential():
         assert leak < 1e-10, f"{lab} wall-normal velocity {leak:.2e} not machine-zero"
 
 
-def test_rotated_freeslip_newton_tangent_matches_essential():
-    """The CONSISTENT NEWTON tangent (consistent_jacobian=True) works through the
-    rotated path: on a power-law box it converges in the SAME small number of Newton
-    iterations as the native essential Newton solve, and to the same answer at
-    (near) machine precision — i.e. the rotated constraint does not degrade the
-    Newton tangent, it is genuine Newton, not defect-correction. Contrast the frozen
-    (Picard) tangent, which converges only at a linear rate (many more iterations)."""
-    mesh = uw.meshing.StructuredQuadBox(
-        elementRes=(12, 12), minCoords=(0, 0), maxCoords=(1, 1), qdegree=3)
-
-    sE, vE, _ = _powerlaw_stokes(mesh, "ntE")
-    sE.consistent_jacobian = True
-    sE.add_essential_bc((sympy.oo, 0.0), "Top")
-    sE.add_essential_bc((sympy.oo, 0.0), "Bottom")
-    sE.add_essential_bc((0.0, sympy.oo), "Left")
-    sE.add_essential_bc((0.0, sympy.oo), "Right")
-    sE.solve()
-    essential_newton_its = sE.snes.getIterationNumber()
-
-    s, vR, pR = _powerlaw_stokes(mesh, "ntR")
-    s.consistent_jacobian = True
+def test_rotated_freeslip_newton_tangent(plaw_box_ref):
+    """consistent_jacobian=True is genuine Newton through the rotated path: it
+    converges in about the same small iteration count as the native essential Newton
+    solve (NOT the ~4-5x larger Picard count) and to the same answer at (near) machine
+    precision — the rotated constraint does not degrade the consistent tangent."""
+    mesh, vE, ess_its = plaw_box_ref
+    s, vR, pR = _powerlaw_stokes(mesh, "ntR", cj=True)
     for wall in ("Top", "Bottom", "Left", "Right"):
         s.add_rotated_freeslip_bc(wall)
     s.solve()
-
     its = s._rotated_freeslip_info["nonlinear_iterations"]
-    # genuine Newton: a small iteration count, comparable to the essential Newton
-    # solve (NOT the ~4-5x larger Picard/frozen-tangent count on the same problem).
-    assert its <= 2 * essential_newton_its + 2, (
-        f"rotated Newton took {its} iters vs essential Newton {essential_newton_its} "
+    assert its <= 2 * ess_its + 2, (
+        f"rotated Newton took {its} iters vs essential Newton {ess_its} "
         f"— tangent likely not the consistent one")
     assert its < 20, f"rotated Newton not converging at Newton rate ({its} iters)"
-    rel = np.linalg.norm(vR.data - vE.data) / np.linalg.norm(vE.data)
-    assert rel < 1e-6, f"rotated Newton differs from essential Newton by {rel:.2e}"
+    assert np.linalg.norm(vR.data - vE) / np.linalg.norm(vE) < 1e-6
 
 
-def test_rotated_freeslip_nonlinear_warm_start():
-    """Warm-start (zero_init_guess=False) through the nonlinear rotated path: a
-    2-step 'time loop' re-solving from the previous converged state stays correct
-    and converges (the step-norm exit avoids chasing machine noise)."""
-    mesh = uw.meshing.StructuredQuadBox(
-        elementRes=(12, 12), minCoords=(0, 0), maxCoords=(1, 1), qdegree=3)
-    vE = _powerlaw_essential(mesh, "wsE")
+def test_rotated_freeslip_continuation_tangent(plaw_box_ref):
+    """consistent_jacobian='continuation' works through the rotated path: a staged
+    Picard→Newton solve (α=0 to the loose newton_switch_rtol, then α=1) that switches
+    tangents and converges to the essential Newton answer. picard=N extends the α=0
+    phase (so the wrapper's picard forwarding and the staging are both exercised)."""
+    mesh, vE, _ = plaw_box_ref
+    s, vR, pR = _powerlaw_stokes(mesh, "ctR", cj="continuation")
+    for wall in ("Top", "Bottom", "Left", "Right"):
+        s.add_rotated_freeslip_bc(wall)
+    s.solve()
+    info = s._rotated_freeslip_info
+    assert info["continuation_switched"], "continuation never switched Picard→Newton"
+    assert 1 < info["nonlinear_iterations"] < 36, "continuation not staging as expected"
+    assert np.linalg.norm(vR.data - vE) / np.linalg.norm(vE) < 1e-6
 
-    s, vR, pR = _powerlaw_stokes(mesh, "wsR")
+    # picard=N holds the α=0 (Picard) phase for >= N iterations before switching
+    s2, _, _ = _powerlaw_stokes(mesh, "ctR2", cj="continuation")
+    for wall in ("Top", "Bottom", "Left", "Right"):
+        s2.add_rotated_freeslip_bc(wall)
+    s2.solve(picard=25)
+    assert s2._rotated_freeslip_info["nonlinear_iterations"] >= 25, (
+        "picard did not extend the continuation Picard phase")
+
+
+def test_rotated_freeslip_picard_newton_unsupported_raises(plaw_box_ref):
+    """picard>0 with the pure consistent-Newton tangent has no frozen warmup tangent
+    to form, so the rotated path raises a clear NotImplementedError pointing to
+    'continuation' rather than silently ignoring it. Also confirms the SNES_Stokes
+    wrapper forwards picard to the plain-Stokes solve at all."""
+    mesh, _, _ = plaw_box_ref
+    s, v, p = _powerlaw_stokes(mesh, "prN", cj=True)
+    for wall in ("Top", "Bottom", "Left", "Right"):
+        s.add_rotated_freeslip_bc(wall)
+    with pytest.raises(NotImplementedError, match="continuation"):
+        s.solve(picard=3)
+
+
+def test_rotated_freeslip_nonlinear_warm_start(plaw_box_ref):
+    """Warm-start (zero_init_guess=False) through the nonlinear rotated path: a 2-step
+    'time loop' re-solving from the previous converged state stays correct and
+    converges in few iterations (the step-norm exit avoids chasing machine noise)."""
+    mesh, vE, _ = plaw_box_ref
+    s, vR, pR = _powerlaw_stokes(mesh, "wsR", cj=True)     # Newton (fast)
     for wall in ("Top", "Bottom", "Left", "Right"):
         s.add_rotated_freeslip_bc(wall)
     s.solve()                              # cold
     s.solve(zero_init_guess=False)         # warm (step 2)
-
-    rel = np.linalg.norm(vR.data - vE.data) / np.linalg.norm(vE.data)
-    assert rel < 1e-3, f"warm-start rotated free-slip differs from essential by {rel:.2e}"
+    assert np.linalg.norm(vR.data - vE) / np.linalg.norm(vE) < 1e-6
     # warm-start from an already-converged state converges in few iterations
     assert s._rotated_freeslip_info["nonlinear_iterations"] <= 3
 
@@ -332,16 +355,15 @@ def test_rotated_freeslip_nonlinear_geometric_fmg():
     the custom prolongation (set_custom_fmg) — the rotated prolongation is built once
     and reused across Newton iterations — and still converges to the essential
     nonlinear free-slip solution."""
+    # a small 2-level nested hierarchy (one refinement) + the Newton tangent keep the
+    # cost down while still exercising the rotated custom-FMG prolongation reuse.
     m0 = uw.meshing.UnstructuredSimplexBox(
-        minCoords=(0, 0), maxCoords=(1, 1), cellSize=0.25, regular=True, qdegree=3)
-    dm0 = m0.dm
-    dm1 = dm0.refine()
-    dm2 = dm1.refine()
-    coarse = [_wrap(dm0, m0), _wrap(dm1, m0)]
-    fine = _wrap(dm2, m0)
-    vE = _powerlaw_essential(fine, "nlfE")
+        minCoords=(0, 0), maxCoords=(1, 1), cellSize=0.4, regular=True, qdegree=3)
+    coarse = [_wrap(m0.dm, m0)]
+    fine = _wrap(m0.dm.refine(), m0)
+    vE, _ = _powerlaw_essential(fine, "nlfE", cj=True)
 
-    s, vR, pR = _powerlaw_stokes(fine, "nlfR")
+    s, vR, pR = _powerlaw_stokes(fine, "nlfR", cj=True)
     for wall in ("Top", "Bottom", "Left", "Right"):
         s.add_rotated_freeslip_bc(wall)
     custom_mg.set_custom_fmg(s, coarse, builder="barycentric", field_id=0)
@@ -359,7 +381,7 @@ def test_rotated_freeslip_nonlinear_annulus_zero_leakage():
     per-node radial free-slip on both arcs genuinely iterates, gives machine-zero
     radial leakage, and the rigid-rotation gauge is removed."""
     RI, RO = 0.5, 1.0
-    mesh = uw.meshing.Annulus(radiusInner=RI, radiusOuter=RO, cellSize=0.15, qdegree=3)
+    mesh = uw.meshing.Annulus(radiusInner=RI, radiusOuter=RO, cellSize=0.3, qdegree=3)
     x, y = mesh.X
     r = sympy.sqrt(x**2 + y**2)
     th = sympy.atan2(y, x)
@@ -375,6 +397,7 @@ def test_rotated_freeslip_nonlinear_annulus_zero_leakage():
     s.bodyforce = sympy.Matrix([[x / r * sympy.cos(4 * th) * (r - RI) * (RO - r) * 40.0,
                                  y / r * sympy.cos(4 * th) * (r - RI) * (RO - r) * 40.0]])
     nhat = sympy.Matrix([[x / r, y / r]])
+    s.consistent_jacobian = True                 # Newton tangent (few iterations)
     s.add_rotated_freeslip_bc("Lower", normal=nhat)
     s.add_rotated_freeslip_bc("Upper", normal=nhat)
     s.petsc_use_pressure_nullspace = True

--- a/tests/test_1018_rotated_freeslip.py
+++ b/tests/test_1018_rotated_freeslip.py
@@ -43,7 +43,7 @@ def _solcx_essential(mesh, sol):
 def test_rotated_freeslip_box_reproduces_essential():
     """Box: rotated free-slip on all 4 axis-aligned walls == native essential free-slip."""
     mesh = uw.meshing.StructuredQuadBox(
-        elementRes=(24, 24), minCoords=(0, 0), maxCoords=(1, 1), qdegree=3)
+        elementRes=(16, 16), minCoords=(0, 0), maxCoords=(1, 1), qdegree=3)
     sol = A.SolCx(mesh, eta_A=1.0, eta_B=1.0e3, x_c=0.5, n=1)
     vE = _solcx_essential(mesh, sol)
 
@@ -107,13 +107,12 @@ def test_rotated_freeslip_geometric_fmg_velocity_block():
     """The rotated free-slip velocity block is driven by GEOMETRIC FMG on a custom
     prolongation (set_custom_fmg) — no direct solve — and still reproduces the
     essential free-slip solution, with the wall-normal velocity exact."""
+    # a small 2-level nested hierarchy (one refinement) keeps the cost down while
+    # still driving the velocity block by geometric FMG on the custom prolongation.
     m0 = uw.meshing.UnstructuredSimplexBox(
         minCoords=(0, 0), maxCoords=(1, 1), cellSize=0.2, regular=True, qdegree=3)
-    dm0 = m0.dm
-    dm1 = dm0.refine()
-    dm2 = dm1.refine()
-    coarse = [_wrap(dm0, m0), _wrap(dm1, m0)]
-    fine = _wrap(dm2, m0)
+    coarse = [_wrap(m0.dm, m0)]
+    fine = _wrap(m0.dm.refine(), m0)
     sol = A.SolCx(fine, eta_A=1.0, eta_B=1.0e3, x_c=0.5, n=1)
 
     vE = _solcx_essential(fine, sol)
@@ -142,8 +141,12 @@ def test_rotated_freeslip_geometric_fmg_velocity_block():
 def test_rotated_freeslip_boundary_normal_traction_solcx():
     """sigma_nn recovered by boundary_normal_traction on the top boundary reproduces
     the exact SolCx analytic sigma_yy (mean-removed) to a few percent. Exercises the
-    Cartesian-reaction + n_hat projection (corner-correct) + consistent P2 line mass."""
-    res = 48
+    Cartesian-reaction + n_hat projection (corner-correct) + consistent P2 line mass.
+
+    Run at a modest resolution: SolCx breakage is catastrophic (corr collapses toward
+    0, relL2 blows up to O(1)), not gradual, so a coarse mesh still catches it — the
+    thresholds carry margin over the res-24 values (corr 0.998, relL2 0.056)."""
+    res = 24
     mesh = uw.meshing.StructuredQuadBox(
         elementRes=(res, res), minCoords=(0, 0), maxCoords=(1, 1), qdegree=3)
     sol = A.SolCx(mesh, eta_A=1.0, eta_B=1.0e3, x_c=0.5, n=1)
@@ -169,8 +172,8 @@ def test_rotated_freeslip_boundary_normal_traction_solcx():
     corr = np.dot(sig, syy) / (np.linalg.norm(sig) * np.linalg.norm(syy))
     sig = sig if corr >= 0 else -sig                      # sigma = -R sign convention
     relL2 = np.linalg.norm(sig - syy) / np.linalg.norm(syy)
-    assert abs(corr) > 0.99, f"sigma_nn shape corr {corr:.3f} too low"
-    assert relL2 < 0.08, f"sigma_nn relL2 vs analytic sigma_yy {relL2:.3f} too large"
+    assert abs(corr) > 0.97, f"sigma_nn shape corr {corr:.3f} too low"
+    assert relL2 < 0.10, f"sigma_nn relL2 vs analytic sigma_yy {relL2:.3f} too large"
 
 
 def test_rotated_freeslip_sigma_nn_lumped_no_overshoot():
@@ -178,7 +181,7 @@ def test_rotated_freeslip_sigma_nn_lumped_no_overshoot():
     its total variation matches the analytic (no Gibbs overshoot), whereas the
     consistent-mass de-smear adds spurious variation. This is the property that matters
     for driving a free surface (an overshoot injects a spurious surface-velocity pulse)."""
-    res = 48
+    res = 24
     mesh = uw.meshing.StructuredQuadBox(
         elementRes=(res, res), minCoords=(0, 0), maxCoords=(1, 1), qdegree=3)
     sol = A.SolCx(mesh, eta_A=1.0, eta_B=1.0e3, x_c=0.5, n=1)
@@ -207,7 +210,7 @@ def test_rotated_freeslip_sigma_nn_lumped_no_overshoot():
     tv_l = total_variation(xs, sig_l)
     tv_c = total_variation(xs, sig_c)
     # lumped adds essentially no spurious variation over the analytic; consistent does
-    assert tv_l < 1.05 * tv_ref, f"lumped TV {tv_l:.3f} exceeds analytic {tv_ref:.3f}"
+    assert tv_l < 1.1 * tv_ref, f"lumped TV {tv_l:.3f} exceeds analytic {tv_ref:.3f}"
     assert tv_l < tv_c, f"lumped TV {tv_l:.3f} not smoother than consistent {tv_c:.3f}"
 
 
@@ -421,7 +424,7 @@ def test_rotated_freeslip_dynamic_topography_field():
     """dynamic_topography writes h = -(sigma_nn - mean)/(rho g) onto a scalar surface
     MeshVariable (the free-surface hand-off): the field at the top vertices reproduces
     the analytic SolCx topography, and the field is usable symbolically (BdIntegral)."""
-    res = 48
+    res = 24
     mesh = uw.meshing.StructuredQuadBox(
         elementRes=(res, res), minCoords=(0, 0), maxCoords=(1, 1), qdegree=3)
     sol = A.SolCx(mesh, eta_A=1.0, eta_B=1.0e3, x_c=0.5, n=1)
@@ -450,8 +453,8 @@ def test_rotated_freeslip_dynamic_topography_field():
     corr = np.dot(hv, tt) / (np.linalg.norm(hv) * np.linalg.norm(tt))
     hv = hv if corr >= 0 else -hv
     relL2 = np.linalg.norm(hv - tt) / np.linalg.norm(tt)
-    assert abs(corr) > 0.99, f"topography field corr {corr:.3f} too low"
-    assert relL2 < 0.09, f"topography field relL2 {relL2:.3f} too large"
+    assert abs(corr) > 0.97, f"topography field corr {corr:.3f} too low"
+    assert relL2 < 0.12, f"topography field relL2 {relL2:.3f} too large"
     # symbolically usable (the free-surface integrator reads it via BdIntegral)
     bdl2 = float(np.sqrt(uw.maths.BdIntegral(
         mesh=mesh, fn=hf.sym[0] ** 2, boundary="Top").evaluate()))

--- a/tests/test_1018_rotated_freeslip.py
+++ b/tests/test_1018_rotated_freeslip.py
@@ -211,6 +211,47 @@ def test_rotated_freeslip_sigma_nn_lumped_no_overshoot():
     assert tv_l < tv_c, f"lumped TV {tv_l:.3f} not smoother than consistent {tv_c:.3f}"
 
 
+def test_rotated_freeslip_nonlinear_guard_raises():
+    """Step-0 safety guard: the rotated free-slip path is a single LINEAR solve
+    (it assembles J,F once at u=0). A nonlinear constitutive model would be
+    silently linearised, so solve() must fail fast with a clear NotImplementedError
+    rather than return a single-linearisation answer. A linear model must NOT trip
+    the guard (covered by the other tests, checked directly here too)."""
+    mesh = uw.meshing.StructuredQuadBox(
+        elementRes=(12, 12), minCoords=(0, 0), maxCoords=(1, 1), qdegree=3)
+
+    # nonlinear (viscoplastic yield) -> guard must raise
+    vN = uw.discretisation.MeshVariable("vNg", mesh, mesh.dim, degree=2, continuous=True)
+    pN = uw.discretisation.MeshVariable("pNg", mesh, 1, degree=1, continuous=False)
+    sN = uw.systems.Stokes(mesh, velocityField=vN, pressureField=pN)
+    sN.constitutive_model = uw.constitutive_models.ViscoPlasticFlowModel
+    sN.constitutive_model.Parameters.shear_viscosity_0 = 1.0
+    sN.constitutive_model.Parameters.yield_stress = 1.0
+    sN.constitutive_model.Parameters.strainrate_inv_II_min = 1.0e-10
+    sN.bodyforce = sympy.Matrix([[0.0, -1.0]])
+    sN.tolerance = 1e-6
+    for wall in ("Top", "Bottom", "Left", "Right"):
+        sN.add_rotated_freeslip_bc(wall)
+    sN.petsc_use_pressure_nullspace = True
+    with pytest.raises(NotImplementedError, match="LINEAR"):
+        sN.solve()
+
+    # linear (constant viscosity) -> guard must NOT raise
+    vL = uw.discretisation.MeshVariable("vLg", mesh, mesh.dim, degree=2, continuous=True)
+    pL = uw.discretisation.MeshVariable("pLg", mesh, 1, degree=1, continuous=False)
+    sL = uw.systems.Stokes(mesh, velocityField=vL, pressureField=pL)
+    sL.constitutive_model = uw.constitutive_models.ViscousFlowModel
+    sL.constitutive_model.Parameters.shear_viscosity_0 = 1.0
+    sL.bodyforce = sympy.Matrix([[0.0, -1.0]])
+    sL.tolerance = 1e-9
+    for wall in ("Top", "Bottom", "Left", "Right"):
+        sL.add_rotated_freeslip_bc(wall)
+    sL.petsc_use_pressure_nullspace = True
+    sL.petsc_options["snes_type"] = "ksponly"
+    sL.solve()  # must not raise
+    assert sL._rotated_freeslip_info is not None
+
+
 def test_rotated_freeslip_dynamic_topography_field():
     """dynamic_topography writes h = -(sigma_nn - mean)/(rho g) onto a scalar surface
     MeshVariable (the free-surface hand-off): the field at the top vertices reproduces


### PR DESCRIPTION
## Rotated strong free-slip inside the nonlinear Stokes solve

Rotated strong free-slip (`add_rotated_freeslip_bc`, per-node `v·n̂ = 0` in a
rotated frame) now works as an ordinary boundary condition **inside** the
nonlinear SNES iteration, so nonlinear rheology, warm-start and time-stepping
"just work" with it — exactly as for native axis-aligned essential BCs. This is
the gate for promoting rotated free-slip to the **default** free-slip BC
(reserving Nitsche / penalty for BCs that must *evolve* in time).

Previously the rotated path was a single LINEAR solve: it assembled `J(0)`,
`F(0)` once, rotated the operator + RHS, imposed `v_n=0` on the rotated normal
rows, and did one KSP solve — bypassing `snes.solve()`. Exact for Newtonian
Stokes, but a nonlinear model solved with defaults silently returned one
linearisation from `u=0`.

### What changed

**Fail-fast probe.** A numerical nonlinearity probe (`_residual_is_nonlinear`)
assembles the Jacobian at two velocity states and compares (a symbolic test on
`F1.sym` cannot see it — the viscosity's strain-rate dependence is a
JIT-substituted placeholder, decoupled from the velocity gradient in the symbolic
flux). Landed first, on its own, as interim safety.

**Nonlinear integration.** A manual outer nonlinear loop
(`solve_rotated_freeslip_nonlinear`): each iteration computes the Cartesian
residual `F(u)` and Jacobian `J(u)` via the DM callbacks, rotates them
(`F̂ = Q F`, `Ĵ = Q J Qᵀ`), zeros the constrained normal rows, and solves the
increment with the already-validated self-contained rotated fieldsplit-Schur KSP
(custom geometric FMG / GAMG velocity block + rotated coupled null space). That
KSP is reused because the DM-coupled fieldsplit cannot precondition a DM-less
`ptap`'d operator (SUBPC_ERROR). A backtracking line search, a step-norm
convergence exit (fast, correct warm start), a divergence warning if it does not
converge, and exact re-imposition of `v_n=0` each iterate complete the loop. `Q`,
the rotated FMG prolongation and the null space depend only on geometry, so they
are built once and reused across iterations.

**Tangent controls (transparent to the rotated constraint).** The driver honours
`solver.consistent_jacobian` exactly as the standard solve path does, so the
rotated constraint does not alter the tangent:

- **`consistent_jacobian=True` — consistent Newton** (recommended for smooth
  nonlinear rheologies): the rotated solve reaches the same solution in the same
  small iteration count as the native *essential* Newton solve on the
  unconstrained problem — the constraint is transparent to convergence.
- **`"continuation"` — staged Picard→Newton** (α=0 phase to `newton_switch_rtol`,
  then α=1), for robustness far from the solution; `solve(picard=N)` sets the
  length of the warm-up phase.
- **default frozen tangent** — the globally-robust defect-correction path.

A `picard>0` warm-up requested with the pure Newton tangent raises a clear error
pointing to `"continuation"` rather than being silently ignored. (This also
surfaced and fixed a pre-existing bug: `SNES_Stokes.solve` dropped `picard` for
plain — non-viscoelastic — Stokes.)

Dispatch: a linear model takes the unchanged one-shot linear solve; a nonlinear
model takes the driver. σ_nn recovery stashes the converged Cartesian residual as
the constraint reaction (identical to `A·u−b` for the affine linear case).

### Validation

Power-law rheology (η = ε̇_II^(1/n−1)) with the consistent Newton tangent, against
the native essential Newton solve:

| case | result |
|---|---|
| box, GAMG velocity block | matches essential Newton to machine precision (`~1e-13`); wall-normal leakage machine-zero on every wall |
| box, custom **geometric FMG** | converges via geometric FMG — **5–6 outer fieldsplit iterations per solve**, angle-independent; matches essential |
| annulus, per-node radial free-slip (genuinely-rotated frame) | radial leakage `~2e-16`, rigid-rotation gauge removed |
| warm-start (2-step time loop) | ≤ 3 iterations |
| parallel np = 1 / 2 / 4 | byte-identical velocity `L2`, partition-independent |

### Tests

- `test_1018` (serial): nonlinear coverage — Newton tangent vs essential,
  continuation (incl. Picard-phase length), Picard-warm-up guard, warm-start,
  geometric FMG, and the genuinely-rotated annulus. The cases share one essential
  reference and use small meshes.
- `test_1064` (parallel np2/4): nonlinear partition-independence.
- The linear SolCx tests were run at a lower resolution — SolCx breakage is
  catastrophic (correlation collapses, error blows up to O(1)) rather than
  gradual, so a coarse mesh still catches it — bringing the suite from ~9 min to
  ~1 min.

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)
