### PR TITLE
fix(meshing): honest 2D-only guard for the MMPDE mover (BF-09)

### DIFF
--- a/src/underworld3/meshing/smoothing.py
+++ b/src/underworld3/meshing/smoothing.py
@@ -2717,6 +2717,11 @@ def smooth_mesh_interior(
           *separable* feature the explicit 1-D OT is exact and
           cheaper — ``"anisotropic"`` earns its keep on the general
           non-separable case.
+        * ``"mmpde"`` — variational moving-mesh (Huang–Kamenski
+          MMPDE) with a full tensor (or scalar) metric; the
+          recommended production mover for adaptive meshing.
+          **Currently 2D-only** (triangle meshes) — a 3D mesh
+          raises ``NotImplementedError``.
 
         With a fixed node count neither can exceed ≈1.3–1.8×
         deep/near grading (the optimal-transport ≈10× needs *more
@@ -2930,8 +2935,9 @@ def smooth_mesh_interior(
 # ===== grafted from feature/elliptic-ma: mmpde mover + helpers =====
 def _tet_cells(dm):
     """Tetrahedron vertex-index quadruples (local-chart), or ``None`` if the
-    mesh is not all-tet. The 3D analogue of :func:`_tri_cells` — used for the
-    signed-volume backtrack of the equidistribution mover in 3D."""
+    mesh is not all-tet. The 3D analogue of :func:`_tri_cells` — used by the
+    3D boundary-face extraction in ``_ot_adapt`` (the MMPDE mover itself is
+    currently 2D-only)."""
     cStart, cEnd = dm.getHeightStratum(0)
     pStart, pEnd = dm.getDepthStratum(0)
     tets = []
@@ -2999,7 +3005,10 @@ def _winslow_mmpde(mesh, metric, pinned_labels, verbose,
                    **_ignored):
     r"""Anisotropic variational moving-mesh adaptation (Huang–Kamenski
     MMPDE; the direct simplex discretization of JCP 301 (2015) 322,
-    arXiv:1410.7872). Dimension-general (`d = 2, 3`) and parallel-safe.
+    arXiv:1410.7872). **2D (triangle meshes) only** and parallel-safe.
+    The underlying method is dimension-general, but the 3D (tetrahedral)
+    discretization has not been implemented — a 3D mesh raises
+    ``NotImplementedError`` immediately.
 
     Generates the physical mesh as the image of a **fixed computational
     (reference) mesh** under the inverse coordinate map, minimizing
@@ -3051,9 +3060,14 @@ def _winslow_mmpde(mesh, metric, pinned_labels, verbose,
     from petsc4py import PETSc
     pinned_labels = tuple(pinned_labels)
     cdim = mesh.cdim
-    if cdim not in (2, 3):
+    if cdim != 2:
+        # Guard here, before any metric parsing or DM work, so a 3D caller
+        # gets an honest message rather than a NameError from the (never
+        # implemented) 3D discretization deeper in the mover (READ-01).
         raise NotImplementedError(
-            "_winslow_mmpde supports 2D/3D simplex meshes only")
+            "MMPDE mesh movement is currently 2D-only (triangle meshes): "
+            "the 3D tetrahedral discretization of the mover has not been "
+            f"implemented. Got a mesh with cdim={cdim}.")
     p = float(p); theta = float(theta); tau = float(tau)
     q = cdim * p / 2.0
     dq = float(cdim) ** q
@@ -3116,15 +3130,14 @@ def _winslow_mmpde(mesh, metric, pinned_labels, verbose,
     dm = mesh.dm
     pStart, pEnd = dm.getDepthStratum(0)
     n_verts = pEnd - pStart
-    if cdim == 2:
-        cells_all = _tri_cells(dm)
-        signed_vol = _signed_areas
-    else:
-        cells_all = _tet_cells(dm)
-        signed_vol = _signed_volumes
+    # cdim == 2 is guaranteed by the guard at the top of this function.
+    # (The former 3D branch here referenced `_signed_volumes`, which was
+    # never implemented — READ-01.)
+    cells_all = _tri_cells(dm)
+    signed_vol = _signed_areas
     if cells_all is None:
         return
-    fact = 2.0 if cdim == 2 else 6.0           # d! → |K| = |detE|/d!
+    fact = 2.0                                 # d! → |K| = |detE|/d!
     owned_cell = _owned_cell_mask(dm)
     cells_own = cells_all[owned_cell]
     is_owned_v = _owned_vertex_mask(dm)

--- a/tests/test_0850_mesh_smoothing.py
+++ b/tests/test_0850_mesh_smoothing.py
@@ -186,3 +186,53 @@ class TestPinningAPI:
                              n_iters=1, alpha=0.5)
         after = np.asarray(mesh.X.coords)
         assert np.allclose(before[is_bnd], after[is_bnd])
+
+
+class TestMMPDEDimensionGuard:
+    """The MMPDE mover is 2D-only (READ-01/BF-09, 2026-07 audit): the 3D
+    branch used to reference `_signed_volumes`, which was never implemented,
+    so any 3D invocation died with a NameError deep in the mover. The
+    contract is now an immediate, honest NotImplementedError for cdim != 2,
+    while 2D invocation keeps working."""
+
+    def test_mmpde_3d_raises_not_implemented(self):
+        import sympy
+        mesh = uw.meshing.UnstructuredSimplexBox(
+            minCoords=(0.0, 0.0, 0.0),
+            maxCoords=(1.0, 1.0, 1.0),
+            cellSize=0.5,
+        )
+        with pytest.raises(NotImplementedError,
+                           match="MMPDE mesh movement is currently 2D-only"):
+            smooth_mesh_interior(
+                mesh, metric=sympy.sympify(1), method="mmpde",
+                method_kwargs=dict(n_outer=1))
+
+    def test_mmpde_3d_guard_fires_before_any_mesh_work(self):
+        """The guard reads only mesh.cdim, before metric parsing or DM
+        access, so a minimal cdim stand-in locks the contract
+        deterministically (same pattern as test_0762's non2d tests)."""
+        from underworld3.meshing.smoothing import _winslow_mmpde
+
+        class _Mesh3D:
+            cdim = 3
+
+        with pytest.raises(NotImplementedError,
+                           match="MMPDE mesh movement is currently 2D-only"):
+            _winslow_mmpde(_Mesh3D(), metric=1, pinned_labels=(),
+                           verbose=False)
+
+    def test_mmpde_2d_smoke_still_works(self):
+        """A small 2D mmpde invocation still runs and leaves a valid mesh."""
+        import sympy
+        mesh = _box_mesh(resolution=6)
+        x, y = mesh.CoordinateSystem.X
+        rho = 1 + 4 * sympy.exp(-(((x - 0.5) ** 2 + (y - 0.5) ** 2)
+                                  / 0.05))
+        before = np.asarray(mesh.X.coords).copy()
+        smooth_mesh_interior(
+            mesh, metric=rho, method="mmpde",
+            method_kwargs=dict(n_outer=3, metric_eval="rbf"))
+        after = np.asarray(mesh.X.coords)
+        assert np.all(np.isfinite(after))
+        assert not np.allclose(before, after)   # the mover actually moved


### PR DESCRIPTION
## Finding

**BF-09 / READ-01** from the 2026-07 quality audit
(`docs/reviews/2026-07/REMEDIATION-WORKLIST.md`,
`docs/reviews/2026-07/READABILITY-REVIEW.md`).

`_winslow_mmpde` (`src/underworld3/meshing/smoothing.py`) claimed
"Dimension-general (d = 2, 3)" in its docstring, but the `cdim == 3` branch
assigned `signed_vol = _signed_volumes` — a function that is defined nowhere in
the package — so any 3D MMPDE invocation died with a `NameError` deep inside
the mover. Maintainer decision (D8): do NOT implement the 3D discretization;
make the mover honestly 2D-only.

## Reproduction

On the unfixed build:

```python
mesh = uw.meshing.UnstructuredSimplexBox(minCoords=(0,0,0), maxCoords=(1,1,1), cellSize=0.5)
smooth_mesh_interior(mesh, metric=sympy.sympify(1), method="mmpde")
# NameError: name '_signed_volumes' is not defined
```

The new regression test fails with exactly this NameError on the unfixed
build (confirmed in the pre-fix gate run).

## Fix

- Raise a clear `NotImplementedError` ("MMPDE mesh movement is currently
  2D-only ...") at the top of `_winslow_mmpde`, before any metric parsing or
  DM work, so both the public `smooth_mesh_interior(method="mmpde")` path and
  the bare dispatch hit an honest message immediately.
- Remove the dead 3D branch that referenced the phantom `_signed_volumes`;
  the 2D path collapses to the identical `_tri_cells` / `_signed_areas` /
  `fact = 2.0` assignments (no behaviour change in 2D).
- Docstrings made honestly 2D-only: the `_winslow_mmpde` docstring, a new
  `"mmpde"` bullet in `smooth_mesh_interior`'s method documentation, and the
  `_tet_cells` helper note (that helper stays — `_ot_adapt.py` uses it for 3D
  boundary-face extraction).

No solver or 2D mover numerics are touched.

## Tests

New `TestMMPDEDimensionGuard` in `tests/test_0850_mesh_smoothing.py`
(level_1, tier_a):

- `test_mmpde_3d_raises_not_implemented` — real small 3D simplex box through
  the public API raises `NotImplementedError` matching "MMPDE mesh movement is
  currently 2D-only" (fails with `NameError` pre-fix).
- `test_mmpde_3d_guard_fires_before_any_mesh_work` — cdim stand-in locks the
  guard-runs-first contract (same pattern as test_0762's non2d tests).
- `test_mmpde_2d_smoke_still_works` — small 2D mmpde invocation runs, moves
  nodes, leaves finite coordinates.

Gate results (serial, worktree env):

- Pre-fix `pytest tests/ -m "level_1 and tier_a" -x -q`: 217 passed; the ONLY
  failure is the new 3D regression test hitting the pre-fix `NameError`
  (the intended failing-first reproduction).
- Post-fix same gate: **298 passed, 7 skipped, 4 xfailed, 1 xpassed, 0
  failed** (skips/xfails/xpass all pre-existing).
- Existing mover tests (test_0850, test_0750, test_0760, test_0762,
  test_0855) + new tests: 50 passed.

MPI runs not required for this item: the change is a dimension guard plus
dead-branch removal; the executable 2D path is byte-for-byte semantically
identical, so no partition-sensitive behaviour changes.

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)