### PR TITLE
fix(rotated-bc): warn on non-converged linear KSP

### DIFF
--- a/src/underworld3/utilities/rotated_bc.py
+++ b/src/underworld3/utilities/rotated_bc.py
@@ -31,6 +31,27 @@ from underworld3.utilities.boundary_flux import (
 _ROT_SOLVE_COUNT = 0
 
 
+def _warn_if_ksp_diverged(ksp, kind):
+    """Emit a rank-0 warning if a KSP finished on a KSP_DIVERGED_* reason
+    (negative converged-reason). ``ksp.solve`` never raises on divergence, so
+    without this the linear rotated-freeslip solvers here would return a
+    partial answer to the caller silently — which is exactly what let the 3D
+    rotation-nullspace bug (#306) go unnoticed until it produced clearly-wrong
+    physics in a downstream test."""
+    reason = int(ksp.getConvergedReason())
+    if reason >= 0:
+        return
+    its = int(ksp.getIterationNumber())
+    try:
+        rnorm = float(ksp.getResidualNorm())
+    except Exception:
+        rnorm = float("nan")
+    from underworld3 import mpi
+    mpi.pprint(f"[rotated_bc] WARNING: {kind} KSP did NOT converge "
+               f"(reason={reason}, iterations={its}, |r|={rnorm:.3e}); "
+               f"proceeding with the last iterate.")
+
+
 # --------------------------------------------------------------------------- #
 #  Rotation construction
 # --------------------------------------------------------------------------- #
@@ -291,6 +312,7 @@ def solve_rotated_freeslip(solver, boundaries, remove_rotation_gauge=True, verbo
         pc = ksp.getPC(); pc.setType("lu"); pc.setFactorSolverType("mumps")
         Uhat = dm.createGlobalVec(); ksp.solve(bhat, Uhat)   # returned in info → own it
         ksp_reason = ksp.getConvergedReason(); ksp_its = ksp.getIterationNumber()
+        _warn_if_ksp_diverged(ksp, kind="rotated direct-LU")
     else:
         Mp = _pressure_mass_schur_pmat(solver)
         Uhat, ksp_reason, ctx = _solve_rotated_iterative(
@@ -797,6 +819,7 @@ def _solve_rotated_iterative(solver, Ahat, bhat, Q, Qt, normal_rows, verbose=Fal
 
     Uhat = Ahat.createVecRight(); Uhat.set(0.0)
     ksp.solve(bhat, Uhat)
+    _warn_if_ksp_diverged(ksp, kind="rotated fieldsplit-Schur")
     # An identity constraint row in an ITERATIVE solve only drives its residual
     # (= û_i) below tolerance, so û_i ~ tol, not exactly 0. Because zeroRowsColumns
     # made these DOFs fully decoupled (row AND column zeroed), û_i affects no other

--- a/src/underworld3/utilities/rotated_bc.py
+++ b/src/underworld3/utilities/rotated_bc.py
@@ -39,7 +39,10 @@ def _warn_if_ksp_diverged(ksp, kind):
     rotation-nullspace bug (#306) go unnoticed until it produced clearly-wrong
     physics in a downstream test."""
     reason = int(ksp.getConvergedReason())
-    if reason >= 0:
+    # Convention: > 0 == converged, < 0 == diverged, 0 == KSP_CONVERGED_ITERATING
+    # (should not happen after ksp.solve() returns; warn if it does). Matches
+    # petsc_generic_snes_solvers.pyx:2979.
+    if reason > 0:
         return
     its = int(ksp.getIterationNumber())
     try:


### PR DESCRIPTION
## Summary

`ksp.solve` never raises on `KSP_DIVERGED_*`, so the two linear paths in
`src/underworld3/utilities/rotated_bc.py` (the default fieldsplit-Schur iterative
solve in `_solve_rotated_iterative` and the opt-in direct MUMPS LU in
`solve_rotated_freeslip`) both returned partial answers silently.

That silence is what let the 3D rotation-nullspace bug fixed by #306 look
like a working solve for as long as it did: on the 3D Zhong
`SphericalShellInternalBoundary` case (`test_1064` setup) the outer Krylov
hit its \`ksp_max_it\` ceiling (300 in the pre-#306 code) with a residual
around 2.7e-7 (target rtol was 1e-7) while producing rotated-frame
solutions that the caller then rotated back and returned. Diagnosed under
[the /remote-control session that surfaced #306](https://github.com/underworldcode/underworld3/pull/306).

## Change

Add a small `_warn_if_ksp_diverged(ksp, kind)` helper at the top of the
module and call it immediately after each of the two \`ksp.solve\` sites.
Rank-0 warning only (via \`uw.mpi.pprint\`), same style as the existing
nonlinear-driver warning at the tail of \`solve_rotated_freeslip_nonlinear\`.

## Impact

* Happy path: no behaviour change — the helper is a no-op unless the
  KSP finished on a negative converged-reason.
* Failure path: a divergence that previously was silent now emits a clear
  rank-0 warning with the reason code, iteration count, and final
  residual, so a caller inspecting stdout can see it.

## Tests

\`tests/test_1018_rotated_freeslip.py\`: **14/14 pass** (13 linear + 1
nonlinear-guard, unchanged from post-#306 tip). No new tests here — the
guard fires only on divergence, and forcing a divergence in-test would
require patching in a deliberately-broken preconditioner.

## Related

* Follows #306 (which fixed the underlying non-convergence in 3D).
* Same silent-return pattern likely worth checking elsewhere in the
  codebase, but this PR is scoped to \`rotated_bc\` only.

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)