### PR TITLE
fix: medium Track-0 misc — parallel BoxInternalBoundary, SL theta restore, viewer crash, projection double-count, units-boundary honesty (BF-10a/12/13/15/18, D9)

### DIFF
--- a/docs/developer/design/UNITS_SIMPLIFIED_DESIGN_2025-11.md
+++ b/docs/developer/design/UNITS_SIMPLIFIED_DESIGN_2025-11.md
@@ -203,6 +203,16 @@ Gateway function that:
 - Re-dimensionalizes result
 - Returns `UnitAwareArray` with correct units
 
+**Coordinate input forms** (maintainer ruling D7, 2026-07-06 — the
+coordinate-units family is unsupported): `coords` must be a plain numpy
+array of model-unit (non-dimensional) values with shape `(n_points, dim)`,
+or a unit-aware array (`UnitAwareArray`, e.g. `mesh.X.coords`, or an
+array-valued `UWQuantity`), which is non-dimensionalised automatically.
+Python lists/tuples of coordinates — including quantity-valued lists such
+as `[(x_qty, y_qty)]` — raise `TypeError`. Convert dimensional
+coordinates explicitly (`float(uw.non_dimensionalise(x_qty))`) and pass
+an array.
+
 ## What We Deleted
 
 The following are **no longer used** (preserved as `*_old.py` for reference):

--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -3659,72 +3659,22 @@ class Mesh(Stateful, uw_object):
 
     @points.setter
     def points(self, value):
+        """Removed. Move mesh nodes with :meth:`deform`.
+
+        The deprecated setter rebound ``self._coords`` to a plain ndarray,
+        silently discarding the ``NDArray_With_Callback`` wrapper: the
+        deform callback never fired, so PETSc coordinates, kd-trees and
+        dependent caches were never updated — writes looked accepted but
+        changed nothing downstream (2026-07 audit, BF-18 / READ-43).
+        Rather than repair an already-deprecated write path, it now
+        refuses loudly.
         """
-        Set mesh node coordinates from physical units.
-
-        .. deprecated:: 0.99.0
-            Use :attr:`X.coords` instead.
-
-        When the mesh has coordinate scaling applied (via model units),
-        this property automatically converts from physical coordinates
-        to internal model coordinates for PETSc storage.
-
-        Args:
-            value (numpy.ndarray or UnitAwareArray): Node coordinates in physical units
-        """
-        import warnings
-        import underworld3 as uw
-
-        warnings.warn(
-            "mesh.points is deprecated, use mesh.X.coords instead", DeprecationWarning, stacklevel=2
+        raise AttributeError(
+            "Assigning to mesh.points has been removed: it never propagated "
+            "the new coordinates to PETSc (2026-07 audit, BF-18). "
+            "Use mesh.deform(new_coords) to move mesh nodes; read "
+            "coordinates via mesh.X.coords."
         )
-
-        # PRINCIPLE (2025-11-27): When units are active, require unit-aware input
-        # to avoid ambiguity about whether values are dimensional or non-dimensional.
-        has_unit_info = hasattr(value, 'magnitude') or hasattr(value, 'value')
-        model = uw.get_default_model()
-        units_active = model.has_units() and uw.is_nondimensional_scaling_active()
-        mesh_has_units = hasattr(self, 'units') and self.units is not None
-
-        if not has_unit_info and mesh_has_units and units_active:
-            # Plain array assigned when units are active - ambiguous
-            mesh_units = self.units
-            raise ValueError(
-                f"Cannot assign plain array to mesh coordinates when units are active.\n"
-                f"\n"
-                f"The mesh has coordinate units '{mesh_units}', but the assigned\n"
-                f"value has no unit information. This is ambiguous: should the values be\n"
-                f"interpreted as dimensional (in {mesh_units}) or non-dimensional?\n"
-                f"\n"
-                f"Solutions:\n"
-                f"  1. Wrap with units: UnitAwareArray(coords, units='{mesh_units}')\n"
-                f"  2. Use uw.quantity() for coordinate values\n"
-                f"  3. For non-dimensional values, assign directly to mesh._coords\n"
-            )
-
-        # Handle unit-aware input
-        if has_unit_info:
-            # Extract numerical value from unit-aware object
-            if hasattr(value, 'magnitude'):
-                coord_values = value.magnitude
-            elif hasattr(value, 'value'):
-                coord_values = value.value
-            else:
-                coord_values = value
-
-            # Convert to non-dimensional units if needed
-            if units_active and mesh_has_units:
-                coord_values = uw.scaling.non_dimensionalise(value)
-        else:
-            coord_values = value
-
-        # Apply inverse scaling to convert physical coordinates to model coordinates
-        if hasattr(self.CoordinateSystem, "_scaled") and self.CoordinateSystem._scaled:
-            scale_factor = self.CoordinateSystem._length_scale
-            model_coords = coord_values / scale_factor
-            self._coords = model_coords
-        else:
-            self._coords = coord_values
 
     @property
     def physical_coordinates(self):

--- a/src/underworld3/function/functions_unit_system.py
+++ b/src/underworld3/function/functions_unit_system.py
@@ -29,6 +29,30 @@ import numpy as np
 import underworld3 as uw
 
 
+def _validate_coords_not_sequence(coords):
+    """Reject Python list/tuple coordinate input with a clear error.
+
+    Coordinate lists — in particular quantity-valued lists such as
+    ``[(x_qty, y_qty)]`` — are NOT a supported coordinate form
+    (maintainer ruling D7, 2026-07-06: the coordinate-units family is
+    unsupported). Supported forms are documented on :func:`evaluate`.
+    Without this guard a list falls through to
+    ``uw.non_dimensionalise(list)`` whose error message does not tell
+    the user what to pass instead.
+    """
+    if isinstance(coords, (list, tuple)):
+        raise TypeError(
+            "evaluate()/global_evaluate() coordinates must be a numpy array "
+            "of model-unit values with shape (n_points, dim), or a "
+            "unit-aware array (UnitAwareArray, or an array-valued "
+            "UWQuantity). Python lists/tuples of coordinates — including "
+            "quantity-valued lists such as [(x_qty, y_qty)] — are not "
+            "supported. Convert first, e.g. "
+            "np.asarray(coords, dtype=float) for plain model-unit numbers, "
+            "or uw.non_dimensionalise(quantity) per dimensional coordinate."
+        )
+
+
 def _evaluate_impl(
     expr,
     coords,
@@ -60,11 +84,19 @@ def _evaluate_impl(
     ----------
     expr : sympy expression or UWexpression
         Expression to evaluate
-    coords : array-like
-        Coordinates at which to evaluate. Can be:
-        - numpy array of doubles (shape: n_points x n_dims) in non-dimensional form
+    coords : numpy.ndarray or UnitAwareArray
+        Coordinates at which to evaluate. Supported forms:
+        - numpy array of doubles (shape: n_points x n_dims) in model
+          (non-dimensional) units
         - UnitAwareArray with dimensional coordinates (e.g., from mesh.X.coords)
         - Both work transparently - dimensional coords are auto-converted
+
+        Python lists/tuples of coordinates — including quantity-valued
+        lists such as ``[(x_qty, y_qty)]`` — are NOT supported and raise
+        ``TypeError`` (the coordinate-units family is unsupported;
+        maintainer ruling D7, 2026-07). Convert dimensional coordinates
+        explicitly, e.g. ``float(uw.non_dimensionalise(x_qty))``, and
+        pass a plain array.
     coord_sys : mesh.N vector coordinate system, optional
         Coordinate system to use (default: None)
     other_arguments : dict, optional
@@ -119,6 +151,8 @@ def _evaluate_impl(
     >>> if hasattr(result, 'to'):
     ...     result_K = result.to('K')  # Unit conversion
     """
+    _validate_coords_not_sequence(coords)
+
     from ._function import evaluate_nd as _evaluate_nd
     from .unit_conversion import has_units
     from underworld3.units import get_units
@@ -452,6 +486,8 @@ def _global_evaluate_impl(
     -----
     See :func:`evaluate` for details on evaluation modes.
     """
+    _validate_coords_not_sequence(coords)
+
     from ._function import global_evaluate_nd as _global_evaluate_nd
     from ..units import get_units
     from .quantities import quantity, UWQuantity

--- a/src/underworld3/meshing/cartesian.py
+++ b/src/underworld3/meshing/cartesian.py
@@ -522,6 +522,15 @@ def BoxInternalBoundary(
 
     dim = len(minCoords)
 
+    # Every rank passes these Enums to Mesh() below, so they must be bound
+    # on every rank — only the gmsh geometry construction is rank-0 work.
+    if dim == 2:
+        boundaries = boundaries_2D
+        boundary_normals = boundary_normals_2D
+    else:
+        boundaries = boundaries_3D
+        boundary_normals = boundary_normals_3D
+
     if filename is None:
         if uw.mpi.rank == 0:
             os.makedirs(".meshes", exist_ok=True)
@@ -544,8 +553,6 @@ def BoxInternalBoundary(
             xmin, ymin = minCoords
             xmax, ymax = maxCoords
             yint = zintCoord
-            boundaries = boundaries_2D
-            boundary_normals = boundary_normals_2D
 
             if not simplex:
                 cellSize = 0.0
@@ -639,8 +646,6 @@ def BoxInternalBoundary(
             xmin, ymin, zmin = minCoords
             xmax, ymax, zmax = maxCoords
             zint = zintCoord
-            boundaries = boundaries_3D
-            boundary_normals = boundary_normals_3D
 
             if not simplex:
                 cellSize = 0.0

--- a/src/underworld3/systems/ddt.py
+++ b/src/underworld3/systems/ddt.py
@@ -1930,10 +1930,7 @@ class SemiLagrangian(uw_object):
         _update_bdf_values(
             self._bdf_coeffs, self.effective_order, self._dt, self._dt_history
         )
-        # SemiLagrangian's update_pre_solve uses theta=0.5 directly
-        # (it doesn't take a theta argument in __init__), so the setter
-        # matches that.
-        _update_am_values(self._am_coeffs, self.effective_order, 0.5)
+        _update_am_values(self._am_coeffs, self.effective_order, self.theta)
 
     @property
     def psi_fn(self):

--- a/src/underworld3/systems/ddt.py
+++ b/src/underworld3/systems/ddt.py
@@ -1021,13 +1021,6 @@ class Eulerian(uw_object):
         super()._object_viewer()
 
         ## feedback on this instance
-        # display(Latex(r"$\quad\psi = $ " + self.psi._repr_latex_()))
-        # display(
-        #     Latex(
-        #         r"$\quad\Delta t_{\textrm{phys}} = $ "
-        #         + sympy.sympify(self.dt_physical)._repr_latex_()
-        #     )
-        # )
         display(Latex(rf"$\quad$History steps = {self.order}"))
 
     def _setup_projections(self):
@@ -3161,13 +3154,9 @@ class Lagrangian(uw_object):
         super()._object_viewer()
 
         ## feedback on this instance
-        display(Latex(r"$\quad\psi = $ " + self.psi._repr_latex_()))
-        display(
-            Latex(
-                r"$\quad\Delta t_{\textrm{phys}} = $ "
-                + sympy.sympify(self.dt_physical)._repr_latex_()
-            )
-        )
+        # Note: dt_physical is not tracked on the Lagrangian DDt classes,
+        # so the viewer reports the expression and history depth only.
+        display(Latex(r"$\quad\psi = $ " + sympy.sympify(self.psi_fn)._repr_latex_()))
         display(Latex(rf"$\quad$History steps = {self.order}"))
 
     @property
@@ -3522,13 +3511,9 @@ class Lagrangian_Swarm(uw_object):
         super()._object_viewer()
 
         ## feedback on this instance
-        display(Latex(r"$\quad\psi = $ " + self.psi._repr_latex_()))
-        display(
-            Latex(
-                r"$\quad\Delta t_{\textrm{phys}} = $ "
-                + sympy.sympify(self.dt_physical)._repr_latex_()
-            )
-        )
+        # Note: dt_physical is not tracked on the Lagrangian DDt classes,
+        # so the viewer reports the expression and history depth only.
+        display(Latex(r"$\quad\psi = $ " + sympy.sympify(self.psi_fn)._repr_latex_()))
         display(Latex(rf"$\quad$History steps = {self.order}"))
 
     @property

--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -2969,27 +2969,6 @@ class SNES_Vector_Projection(SNES_Vector):
         "Vector projection pointwise smoothing term: F_1(u)",
     )
 
-    @timing.routine_timer_decorator
-    def projection_problem_description(self):
-        """Build residual terms for vector projection FEM assembly."""
-        # residual terms - defines the problem:
-        # solve for a best fit to the continuous mesh
-        # variable given the values in self.function
-        # F0 is left in place for the user to inject
-        # non-linear constraints if required
-
-        self._f0 = self.F0.sym
-
-        # F1 is left in the users control ... e.g to add other gradient constraints to the stiffness matrix
-
-        self._f1 = (
-            self.F1.sym
-            + self.smoothing * self.Unknowns.E
-            + self.penalty * self.mesh.vector.divergence(self.u.sym) * sympy.eye(self.mesh.dim)
-        )
-
-        return
-
     # Use SymbolicProperty for automatic unwrapping
     uw_function = SymbolicProperty(matrix_wrap=True, doc="Vector function to project onto mesh")
 

--- a/src/underworld3/units.py
+++ b/src/underworld3/units.py
@@ -851,6 +851,12 @@ def non_dimensionalise(expression, model=None) -> Any:
             try:
                 scale = model.get_scale_for_dimensionality(dimensionality)
                 result_qty = expression / scale
+                # TODO(BUG): UWQuantity.__init__ has no `dimensionality`
+                # kwarg, so this raises TypeError whenever a raw
+                # pint.Quantity is non-dimensionalised with active scaling
+                # and a resolvable scale. Found while verifying BF-12
+                # (2026-07 audit). The uw.quantity (UWQuantity) path works
+                # and is the workaround.
                 # Return UWQuantity to preserve dimensionality
                 return UWQuantity(float(result_qty.magnitude), units="dimensionless", dimensionality=dimensionality)
             except ValueError as e:

--- a/src/underworld3/utilities/mathematical_mixin.py
+++ b/src/underworld3/utilities/mathematical_mixin.py
@@ -792,6 +792,13 @@ class MathematicalMixin:
         )
 
 
+# TODO(DESIGN): UnitAwareDerivativeMatrix defines no __mul__/__neg__, and
+# sympy's DomainMatrix element-wise path bypasses _sympy_(), so expressions
+# like `UnitAwareDerivativeMatrix * NegativeOne` raise TypeError inside the
+# Projection residual template (2026-07 audit, LE-06 / BF-10). Part (a) —
+# the units-free rewrite of tests/test_0813 — restored the DM-corruption
+# coverage; part (b) implements the arithmetic here and re-unitizes those
+# tests. See docs/reviews/2026-07/REMEDIATION-WORKLIST.md (BF-10).
 class UnitAwareDerivativeMatrix:
     """
     Wrapper for SymPy Matrix derivatives that provides unit-aware indexing.

--- a/tests/parallel/test_0766_box_internal_boundary_mpi.py
+++ b/tests/parallel/test_0766_box_internal_boundary_mpi.py
@@ -1,0 +1,51 @@
+"""
+MPI regression test for BoxInternalBoundary construction (BF-13).
+
+BoxInternalBoundary used to bind its ``boundaries``/``boundary_normals``
+Enums only inside the rank-0 gmsh block, so every rank > 0 raised
+``UnboundLocalError`` before the mesh existed and the job hung in the
+subsequent collective (2026-07 audit, ``docs/reviews/2026-07/
+REMEDIATION-WORKLIST.md`` BF-13). This test constructs the mesh on
+2+ ranks and checks the internal-boundary integral is rank-consistent.
+"""
+
+import numpy as np
+import pytest
+import underworld3 as uw
+
+
+pytestmark = [
+    pytest.mark.level_2,
+    pytest.mark.tier_a,
+    pytest.mark.mpi(min_size=2),
+    pytest.mark.timeout(120),
+]
+
+
+@pytest.mark.mpi(min_size=2)
+def test_box_internal_boundary_constructs_on_all_ranks():
+    """Mesh construction must succeed on every rank (regression: BF-13)."""
+    mesh = uw.meshing.BoxInternalBoundary(
+        elementRes=(8, 8),
+        zelementRes=(4, 4),
+        minCoords=(0.0, 0.0),
+        maxCoords=(1.0, 1.0),
+        zintCoord=0.5,
+    )
+    # The boundary Enum must be bound (and identical) on all ranks.
+    names = [b.name for b in mesh.boundaries]
+    gathered = uw.mpi.comm.allgather(names)
+    assert all(g == gathered[0] for g in gathered), f"Rank mismatch in boundaries: {gathered}"
+    assert "Internal" in names
+
+    # PETSc integration path requires at least one variable on the mesh.
+    uw.discretisation.MeshVariable("T_boxIB_mpi", mesh, 1, degree=1)
+
+    # Internal boundary at y=0.5 across a unit box has length 1.
+    value = float(uw.maths.BdIntegral(mesh=mesh, fn=1.0, boundary="Internal").evaluate())
+    assert abs(value - 1.0) < 1.0e-3, f"Internal boundary length {value} != 1.0"
+
+    gathered_vals = uw.mpi.comm.allgather(value)
+    assert max(gathered_vals) - min(gathered_vals) < 1.0e-12, (
+        f"Rank mismatch in integral values: {gathered_vals}"
+    )

--- a/tests/test_0058_mesh_points_setter_removed.py
+++ b/tests/test_0058_mesh_points_setter_removed.py
@@ -1,0 +1,54 @@
+"""Regression tests for the removed ``mesh.points`` setter (BF-18).
+
+The deprecated setter ended with ``self._coords = model_coords``, rebinding
+the coordinate store to a plain ndarray and silently discarding the
+``NDArray_With_Callback`` wrapper — so the deform callback never fired and
+PETSc coordinates were never updated. Writes looked accepted but changed
+nothing downstream (2026-07 audit, BF-18 / READ-43). The setter now raises
+``AttributeError`` pointing at :meth:`Mesh.deform`.
+"""
+
+import numpy as np
+import pytest
+
+import underworld3 as uw
+
+pytestmark = [pytest.mark.level_1, pytest.mark.tier_a]
+
+
+def _make_mesh():
+    return uw.meshing.StructuredQuadBox(
+        elementRes=(4, 4), minCoords=(0.0, 0.0), maxCoords=(1.0, 1.0)
+    )
+
+
+def test_points_setter_raises_with_guidance():
+    mesh = _make_mesh()
+    shifted = np.asarray(mesh._coords) + 0.1
+    with pytest.raises(AttributeError, match="mesh.deform"):
+        mesh.points = shifted
+
+
+def test_points_setter_leaves_state_intact():
+    """The refused write must not touch the coordinate store or PETSc."""
+    mesh = _make_mesh()
+    wrapper_type = type(mesh._coords)
+    petsc_before = mesh.dm.getCoordinatesLocal().array.copy()
+    coords_before = np.array(mesh._coords)
+
+    with pytest.raises(AttributeError):
+        mesh.points = np.asarray(mesh._coords) + 0.1
+
+    assert type(mesh._coords) is wrapper_type  # wrapper not discarded
+    assert np.array_equal(np.array(mesh._coords), coords_before)
+    assert np.array_equal(mesh.dm.getCoordinatesLocal().array, petsc_before)
+
+
+def test_deform_is_the_supported_write_path():
+    """mesh.deform() propagates the same write the setter used to swallow."""
+    mesh = _make_mesh()
+    new_coords = np.array(mesh._coords) + 0.1
+    mesh.deform(new_coords)
+    assert np.allclose(np.array(mesh._coords), new_coords)
+    petsc_coords = mesh.dm.getCoordinatesLocal().array.reshape(-1, mesh.dim)
+    assert abs(petsc_coords.min() - 0.1) < 1e-12

--- a/tests/test_0502_boundary_integrals.py
+++ b/tests/test_0502_boundary_integrals.py
@@ -112,9 +112,10 @@ def test_bd_integral_invalid_boundary():
 
 
 # --- Internal boundary tests (BoxInternalBoundary) ---
-# BoxInternalBoundary has a pre-existing MPI bug (UnboundLocalError in the mesh
-# constructor) so these tests are skipped under MPI. They use lazy initialization
-# to avoid crashing the entire module if the mesh constructor fails.
+# These run in serial and parallel: the BoxInternalBoundary rank>0
+# UnboundLocalError (2026-07 audit, BF-13) is fixed. Two signed-normal
+# tests remain serial-only — see the TODO(BUG) on
+# test_bd_integral_internal_normal_ny.
 
 from underworld3.meshing import BoxInternalBoundary
 
@@ -138,7 +139,6 @@ def _get_internal_mesh():
     return _mesh_internal, _x_i, _y_i
 
 
-@pytest.mark.skipif(uw.mpi.size > 1, reason="BoxInternalBoundary has pre-existing MPI bug")
 def test_bd_integral_internal_boundary_length():
     """Internal boundary at y=0.5 across a unit box should have length 1.0."""
 
@@ -149,7 +149,6 @@ def test_bd_integral_internal_boundary_length():
     assert abs(value - 1.0) < 0.001, f"Expected 1.0, got {value}"
 
 
-@pytest.mark.skipif(uw.mpi.size > 1, reason="BoxInternalBoundary has pre-existing MPI bug")
 def test_bd_integral_internal_coordinate_fn():
     """Integrate x along internal boundary at y=0.5: int_0^1 x dx = 0.5."""
 
@@ -160,7 +159,16 @@ def test_bd_integral_internal_coordinate_fn():
     assert abs(value - 0.5) < 0.01, f"Expected 0.5, got {value}"
 
 
-@pytest.mark.skipif(uw.mpi.size > 1, reason="BoxInternalBoundary has pre-existing MPI bug")
+# TODO(BUG): internal-boundary facet-normal orientation is rank-dependent at
+# partition seams: at np2 one seam facet contributes with flipped sign, so
+# |integral of n_y| = 1 - 2/32 = 0.9375. Scalar integrands (length,
+# coordinate functions) are exact in parallel; only signed-normal integrands
+# are affected. Found while unskipping after the BF-13 constructor fix
+# (2026-07 audit) — separate defect, not covered by BF-13.
+@pytest.mark.skipif(
+    uw.mpi.size > 1,
+    reason="Internal-boundary normal orientation is rank-dependent at partition seams (see TODO(BUG) above)",
+)
 def test_bd_integral_internal_normal_ny():
     """Integrate n_y along internal boundary at y=0.5.
     The internal boundary has normals pointing in +y or -y direction,
@@ -178,7 +186,6 @@ def test_bd_integral_internal_normal_ny():
     assert abs(abs(value) - 1.0) < 0.01, f"Expected |n_y integral| = 1.0, got {value}"
 
 
-@pytest.mark.skipif(uw.mpi.size > 1, reason="BoxInternalBoundary has pre-existing MPI bug")
 def test_bd_integral_internal_normal_nx():
     """Integrate n_x along internal boundary at y=0.5.
     The internal boundary is horizontal, so n_x should be ~0."""
@@ -193,7 +200,10 @@ def test_bd_integral_internal_normal_nx():
     assert abs(value) < 0.01, f"Expected ~0, got {value}"
 
 
-@pytest.mark.skipif(uw.mpi.size > 1, reason="BoxInternalBoundary has pre-existing MPI bug")
+@pytest.mark.skipif(
+    uw.mpi.size > 1,
+    reason="Internal-boundary normal orientation is rank-dependent at partition seams (see TODO(BUG) above)",
+)
 def test_bd_integral_internal_normal_weighted():
     """Integrate x * n_y along internal boundary at y=0.5.
     int_0^1 x * n_y dx = n_y * 0.5. Since |n_y| = 1, result should be ~0.5."""
@@ -208,7 +218,6 @@ def test_bd_integral_internal_normal_weighted():
     assert abs(abs(value) - 0.5) < 0.01, f"Expected |value| = 0.5, got {value}"
 
 
-@pytest.mark.skipif(uw.mpi.size > 1, reason="BoxInternalBoundary has pre-existing MPI bug")
 def test_bd_integral_internal_does_not_affect_external():
     """External boundaries should still work on the internal-boundary mesh."""
 

--- a/tests/test_0812_poisson_with_units.py
+++ b/tests/test_0812_poisson_with_units.py
@@ -1,260 +1,178 @@
 """
 Test Poisson solver with unit-aware boundary conditions.
 
-This test replicates the exact workflow from Notebook 13 to ensure
-unit-aware BCs produce correct results, not just that they are accepted.
+This test replicates the workflow from Notebook 13 to ensure unit-aware BCs
+produce correct results, not just that they are accepted.
 
-STATUS (2025-11-15):
-- Tests pass BCs correctly but fail at uw.function.evaluate()
-- Error: Cannot non-dimensionalise list of UWQuantity coordinates
-- Issue: evaluate(expr, [(x_qty, y_qty)]) doesn't handle UWQuantity in list format
-- Need to convert coordinates to proper format (numpy array or extract magnitudes)
-- Marked as Tier C until coordinate formatting is fixed
+Coordinate forms (2026-07 audit, BF-12 / maintainer ruling D7): quantity-valued
+coordinate LISTS — ``[(x_qty, y_qty)]`` — are an UNSUPPORTED input to
+``uw.function.evaluate()`` and raise ``TypeError``. These tests use the
+supported form: plain numpy arrays of model-unit (non-dimensional)
+coordinates. ``test_quantity_coordinate_lists_are_rejected`` pins the
+rejection contract.
 """
 
 import pytest
 
-# Physics solver tests - full solver execution
-pytestmark = pytest.mark.level_3
 import underworld3 as uw
 import numpy as np
 
+pytestmark = [pytest.mark.level_2, pytest.mark.tier_b]
 
-@pytest.mark.level_2  # Intermediate - Poisson solver with units
-@pytest.mark.tier_c   # Experimental - test has coordinate formatting issues
-@pytest.mark.skip(reason="BUG: evaluate() cannot handle UWQuantity coordinates in [(x, y)] format. Fix coordinate handling, then remove skip.")
-def test_poisson_linear_gradient_with_pint_quantities():
-    """
-    Test that Poisson solver with Pint Quantity BCs produces correct gradient.
 
-    This replicates Notebook 13: solve ∇²T = 0 with linear BC,
-    expecting constant gradient ∂T/∂y = ΔT/Ly.
-    """
+def _nd(quantity):
+    """Model-unit (non-dimensional) float for a UWQuantity."""
+    result = uw.non_dimensionalise(quantity)
+    return float(getattr(result, "value", result))
+
+
+def _set_reference_quantities():
     uw.reset_default_model()
-
-    # Set reference quantities for units support
-    model = uw.get_default_model()
-    model.set_reference_quantities(
+    orchestration_model = uw.get_default_model()
+    orchestration_model.set_reference_quantities(
         domain_depth=uw.quantity(500, "m"),  # Matches L_y
-        material_density=uw.quantity(3300, "kg/m**3"),  # For complete dimensional analysis
+        material_density=uw.quantity(3300, "kg/m**3"),
     )
 
-    # Physical parameters using Pint Quantities (like Notebook 13)
-    L_x = 1000 * uw.units("m")
-    L_y = 500 * uw.units("m")
-    T_bottom = 300 * uw.units("K")
-    T_top = 1600 * uw.units("K")
-    Delta_T = T_top - T_bottom
 
-    # Expected gradient
-    expected_gradient = (Delta_T / L_y).magnitude  # Should be 2.6 K/m
+def _setup_and_solve(L_x, L_y, T_bottom, T_top, gradient_variable=True):
+    """Build the Notebook-13 Poisson problem with unit-aware BCs and solve it.
 
-    # Create mesh - USING STRUCTURED MESH (Unstructured has gradient projection bugs)
+    Returns (mesh, T, gradT). All four physical inputs are quantities
+    (Pint or UWQuantity) — passing them through the BC path IS the test.
+    """
     mesh = uw.meshing.StructuredQuadBox(
         elementRes=(10, 10), minCoords=(0.0, 0.0), maxCoords=(L_x, L_y), units="metre"
     )
-
-    # Create temperature variable
     T = uw.discretisation.MeshVariable("T", mesh, 1, degree=2, units="kelvin")
+    gradT = (
+        uw.discretisation.MeshVariable("gradT", mesh, mesh.dim, degree=1)
+        if gradient_variable
+        else None
+    )
 
-    # CRITICAL: Create gradient variable BEFORE solving
-    # (creating it after causes mesh state corruption)
-    gradT = uw.discretisation.MeshVariable("gradT", mesh, mesh.dim, degree=1)
-
-    # Set up Poisson solver
     poisson = uw.systems.Poisson(mesh, u_Field=T)
     poisson.constitutive_model = uw.constitutive_models.DiffusionModel
     poisson.constitutive_model.Parameters.diffusivity = 1
     poisson.f = 0.0
-
-    # Apply BCs with Pint Quantities (THE KEY TEST)
     poisson.add_dirichlet_bc(T_bottom, "Bottom")
     poisson.add_dirichlet_bc(T_top, "Top")
-
-    # Solve
     poisson.solve()
     assert poisson.snes.getConvergedReason() > 0, "Solver did not converge"
+    return mesh, T, gradT
 
-    # Compute gradient via projection (variable already created)
-    x, y = mesh.X
+
+def _project_gradient(mesh, T, gradT):
     gradient_proj = uw.systems.Vector_Projection(mesh, gradT)
     gradient_proj.uw_function = mesh.vector.gradient(T.sym)
     gradient_proj.solve()
 
-    # Evaluate at center
-    x_center = L_x / 2
-    y_center = L_y / 2
-    grad = uw.function.evaluate(gradT.sym, [(x_center, y_center)])
+
+def _check_linear_gradient(mesh, gradT, delta_T_kelvin, L_y_model):
+    """Evaluate the projected gradient at the domain centre (supported
+    coordinate form: plain model-unit array) and compare against the exact
+    linear solution dT/dy = ΔT / L_y in the model frame.
+
+    The temperature variable carries kelvin with no temperature reference
+    scale, so model-frame temperature values ARE kelvin values and the
+    expected model-frame gradient is ΔT[K] / L_y[model units].
+    """
+    coords = np.asarray(mesh._coords)
+    centre = np.array([[0.5 * (coords[:, 0].min() + coords[:, 0].max()),
+                        0.5 * (coords[:, 1].min() + coords[:, 1].max())]])
+    grad = np.asarray(uw.function.evaluate(gradT.sym, centre))
 
     dT_dx = grad[0, 0, 0]
     dT_dy = grad[0, 0, 1]
+    expected = delta_T_kelvin / L_y_model  # 1300 K over 1 model unit
 
-    print(f"\nPoisson with Pint Quantity BCs:")
-    print(f"  Expected gradient: {expected_gradient:.3f} K/m")
-    print(f"  Computed ∂T/∂x: {dT_dx:.6f} K/m (expected: 0)")
-    print(f"  Computed ∂T/∂y: {dT_dy:.6f} K/m (expected: {expected_gradient:.3f})")
-
-    # Check results
-    assert abs(dT_dx) < 0.1, f"∂T/∂x should be ~0, got {dT_dx}"
-    assert (
-        abs(dT_dy - expected_gradient) < 0.1
-    ), f"∂T/∂y should be {expected_gradient:.3f}, got {dT_dy:.3f}"
-
-
-@pytest.mark.level_2  # Intermediate - Poisson solver with units
-@pytest.mark.tier_c   # Experimental - test has coordinate formatting issues
-@pytest.mark.skip(reason="BUG: evaluate() cannot handle UWQuantity coordinates in [(x, y)] format. Fix coordinate handling, then remove skip.")
-def test_poisson_linear_gradient_with_uwquantity():
-    """
-    Same test but using uw.quantity() instead of uw.units().
-    """
-    uw.reset_default_model()
-
-    # Set reference quantities for units support
-    model = uw.get_default_model()
-    model.set_reference_quantities(
-        domain_depth=uw.quantity(500, "m"),  # Matches L_y
-        material_density=uw.quantity(3300, "kg/m**3"),  # For complete dimensional analysis
+    assert abs(dT_dx) < 1e-2 * abs(expected), f"dT/dx should be ~0, got {dT_dx}"
+    assert abs(dT_dy - expected) < 1e-2 * abs(expected), (
+        f"dT/dy should be {expected:.3f}, got {dT_dy:.3f}"
     )
 
-    # Physical parameters using UWQuantity
+
+def test_poisson_linear_gradient_with_pint_quantities():
+    """Poisson with Pint Quantity BCs produces the exact linear gradient."""
+    _set_reference_quantities()
+
+    L_x = 1000 * uw.units("m")
+    L_y = 500 * uw.units("m")
+    T_bottom = 300 * uw.units("K")
+    T_top = 1600 * uw.units("K")
+
+    mesh, T, gradT = _setup_and_solve(L_x, L_y, T_bottom, T_top)
+    _project_gradient(mesh, T, gradT)
+
+    L_y_model = _nd(uw.quantity(500.0, "m"))
+    _check_linear_gradient(mesh, gradT, (T_top - T_bottom).magnitude, L_y_model)
+
+
+def test_poisson_linear_gradient_with_uwquantity():
+    """Same problem with uw.quantity() BCs instead of Pint quantities."""
+    _set_reference_quantities()
+
     L_x = uw.quantity(1000, "m")
     L_y = uw.quantity(500, "m")
     T_bottom = uw.quantity(300, "K")
     T_top = uw.quantity(1600, "K")
-    Delta_T = T_top - T_bottom
 
-    # Expected gradient
-    expected_gradient = (Delta_T / L_y).value
+    mesh, T, gradT = _setup_and_solve(L_x, L_y, T_bottom, T_top)
+    _project_gradient(mesh, T, gradT)
 
-    # Create mesh - USING STRUCTURED MESH (Unstructured has gradient projection bugs)
-    mesh = uw.meshing.StructuredQuadBox(
-        elementRes=(10, 10), minCoords=(0.0, 0.0), maxCoords=(L_x, L_y), units="metre"
-    )
-
-    # Create temperature variable
-    T = uw.discretisation.MeshVariable("T", mesh, 1, degree=2, units="kelvin")
-
-    # CRITICAL: Create gradient variable BEFORE solving
-    gradT = uw.discretisation.MeshVariable("gradT", mesh, mesh.dim, degree=1)
-
-    # Set up Poisson solver
-    poisson = uw.systems.Poisson(mesh, u_Field=T)
-    poisson.constitutive_model = uw.constitutive_models.DiffusionModel
-    poisson.constitutive_model.Parameters.diffusivity = 1
-    poisson.f = 0.0
-
-    # Apply BCs with UWQuantity
-    poisson.add_dirichlet_bc(T_bottom, "Bottom")
-    poisson.add_dirichlet_bc(T_top, "Top")
-
-    # Solve
-    poisson.solve()
-    assert poisson.snes.getConvergedReason() > 0
-
-    # Compute gradient (variable already created)
-    x, y = mesh.X
-    gradient_proj = uw.systems.Vector_Projection(mesh, gradT)
-    gradient_proj.uw_function = mesh.vector.gradient(T.sym)
-    gradient_proj.solve()
-
-    # Evaluate at center
-    x_center = L_x / 2
-    y_center = L_y / 2
-    grad = uw.function.evaluate(gradT.sym, [(x_center, y_center)])
-
-    dT_dx = grad[0, 0, 0]
-    dT_dy = grad[0, 0, 1]
-
-    print(f"\nPoisson with UWQuantity BCs:")
-    print(f"  Expected gradient: {expected_gradient:.3f} K/m")
-    print(f"  Computed ∂T/∂x: {dT_dx:.6f} K/m")
-    print(f"  Computed ∂T/∂y: {dT_dy:.6f} K/m")
-
-    # Check results
-    assert abs(dT_dx) < 0.1, f"∂T/∂x should be ~0, got {dT_dx}"
-    assert (
-        abs(dT_dy - expected_gradient) < 0.1
-    ), f"∂T/∂y should be {expected_gradient:.3f}, got {dT_dy:.3f}"
+    L_y_model = _nd(L_y)
+    _check_linear_gradient(mesh, gradT, (T_top - T_bottom).value, L_y_model)
 
 
-@pytest.mark.level_2  # Intermediate - Poisson solver with units
-@pytest.mark.tier_c   # Experimental - test has coordinate formatting issues
-@pytest.mark.skip(reason="BUG: evaluate() cannot handle UWQuantity coordinates in [(x, y)] format. Fix coordinate handling, then remove skip.")
 def test_poisson_check_bc_values():
-    """
-    Verify that the BC values are actually being set correctly in the solution.
-    """
-    uw.reset_default_model()
-
-    # Set reference quantities for units support
-    model = uw.get_default_model()
-    model.set_reference_quantities(
-        domain_depth=uw.quantity(500, "m"),  # Matches L_y
-        material_density=uw.quantity(3300, "kg/m**3"),  # For complete dimensional analysis
-    )
+    """The unit-aware BC values must appear in the solution at the boundaries."""
+    _set_reference_quantities()
 
     L_x = 1000 * uw.units("m")
     L_y = 500 * uw.units("m")
     T_bottom = 300 * uw.units("K")
     T_top = 1600 * uw.units("K")
 
-    # Create mesh - USING STRUCTURED MESH (Unstructured has gradient projection bugs)
-    mesh = uw.meshing.StructuredQuadBox(
-        elementRes=(10, 10), minCoords=(0.0, 0.0), maxCoords=(L_x, L_y), units="metre"
+    mesh, T, _ = _setup_and_solve(L_x, L_y, T_bottom, T_top, gradient_variable=False)
+
+    coords = np.asarray(mesh._coords)
+    x_mid = 0.5 * (coords[:, 0].min() + coords[:, 0].max())
+    y_min = coords[:, 1].min()
+    y_max = coords[:, 1].max()
+
+    T_at_bottom = np.asarray(uw.function.evaluate(T.sym, np.array([[x_mid, y_min]])))
+    # NOTE: a point exactly ON the top boundary is not claimed by
+    # point-location (evaluate returns its 1e-18 sentinel), so probe one
+    # part in 1e9 inside the domain.
+    T_at_top = np.asarray(uw.function.evaluate(T.sym, np.array([[x_mid, y_max * (1 - 1e-9)]])))
+
+    assert abs(T_at_bottom.ravel()[0] - 300.0) < 1.0, (
+        f"Bottom BC not applied correctly: {T_at_bottom.ravel()[0]} != 300"
+    )
+    assert abs(T_at_top.ravel()[0] - 1600.0) < 1.0, (
+        f"Top BC not applied correctly: {T_at_top.ravel()[0]} != 1600"
     )
 
-    T = uw.discretisation.MeshVariable("T", mesh, 1, degree=2, units="kelvin")
 
-    poisson = uw.systems.Poisson(mesh, u_Field=T)
-    poisson.constitutive_model = uw.constitutive_models.DiffusionModel
-    poisson.constitutive_model.Parameters.diffusivity = 1
-    poisson.f = 0.0
+def test_quantity_coordinate_lists_are_rejected():
+    """Regression (BF-12): evaluate() must reject coordinate lists — plain or
+    quantity-valued — with a TypeError that names the supported forms."""
+    _set_reference_quantities()
 
-    poisson.add_dirichlet_bc(T_bottom, "Bottom")
-    poisson.add_dirichlet_bc(T_top, "Top")
-    poisson.solve()
+    L_x = 1000 * uw.units("m")
+    L_y = 500 * uw.units("m")
 
-    # Check boundary values
-    x, y = mesh.X
+    mesh = uw.meshing.StructuredQuadBox(
+        elementRes=(4, 4), minCoords=(0.0, 0.0), maxCoords=(L_x, L_y), units="metre"
+    )
+    T = uw.discretisation.MeshVariable("T", mesh, 1, degree=1, units="kelvin")
+    T.data[:, 0] = 1.0
 
-    # Evaluate at bottom boundary
-    bottom_points = [(L_x / 2, uw.quantity(0, "m"))]
-    T_at_bottom = uw.function.evaluate(T.sym, bottom_points)
+    with pytest.raises(TypeError, match="not supported"):
+        uw.function.evaluate(T.sym, [(L_x / 2, L_y / 2)])
 
-    # Evaluate at top boundary
-    top_points = [(L_x / 2, L_y)]
-    T_at_top = uw.function.evaluate(T.sym, top_points)
+    with pytest.raises(TypeError, match="not supported"):
+        uw.function.evaluate(T.sym, [(uw.quantity(500, "m"), uw.quantity(250, "m"))])
 
-    print(f"\nBoundary value check:")
-    print(f"  T at bottom: {T_at_bottom[0,0,0]:.1f} K (expected: 300)")
-    print(f"  T at top: {T_at_top[0,0,0]:.1f} K (expected: 1600)")
-
-    assert (
-        abs(T_at_bottom[0, 0, 0] - 300) < 1.0
-    ), f"Bottom BC not applied correctly: {T_at_bottom[0,0,0]} != 300"
-    assert (
-        abs(T_at_top[0, 0, 0] - 1600) < 1.0
-    ), f"Top BC not applied correctly: {T_at_top[0,0,0]} != 1600"
-
-
-if __name__ == "__main__":
-    print("=" * 70)
-    print("Testing Poisson solver with unit-aware BCs (Notebook 13 replication)")
-    print("=" * 70)
-
-    print("\n1. Testing with Pint Quantities (uw.units())...")
-    test_poisson_linear_gradient_with_pint_quantities()
-    print("   ✓ Passed")
-
-    print("\n2. Testing with UWQuantity (uw.quantity())...")
-    test_poisson_linear_gradient_with_uwquantity()
-    print("   ✓ Passed")
-
-    print("\n3. Testing BC value application...")
-    test_poisson_check_bc_values()
-    print("   ✓ Passed")
-
-    print("\n" + "=" * 70)
-    print("All Poisson unit tests passed! ✅")
-    print("=" * 70)
+    with pytest.raises(TypeError, match="not supported"):
+        uw.function.evaluate(T.sym, [(1.0, 0.5)])

--- a/tests/test_0813_mesh_variable_ordering_regression.py
+++ b/tests/test_0813_mesh_variable_ordering_regression.py
@@ -1,271 +1,150 @@
 """
-REGRESSION TEST: Creating mesh variables after solving.
+REGRESSION TEST: Creating mesh variables after solving ("Batman" pattern).
 
 This test verifies that creating new MeshVariables on a mesh after solving
 produces correct results in subsequent projections.
 
 BUG STATUS: FIXED (2025-10-14)
-- Creating variables AFTER solve: NOW WORKS ✓
-- Creating variables BEFORE solve: Works ✓
+- Creating variables AFTER solve: NOW WORKS
+- Creating variables BEFORE solve: Works
 
-FIX: When rebuilding DM after adding new variables, properly invalidate all
-existing variables' vectors and restore their data from the new DM.
-(discretisation_mesh_variables.py lines 1220-1254)
+FIX: When rebuilding the DM after adding new variables, properly invalidate
+all existing variables' vectors and restore their data from the new DM.
+(discretisation_mesh_variables.py, DM rebuild path)
 
-CURRENT STATUS (2025-11-15):
-- Tests fail due to unit-aware derivative arithmetic bug
-- Error: TypeError: unsupported operand type(s) for *: 'UnitAwareDerivativeMatrix' and 'NegativeOne'
-- Marked as Tier B + skip until derivative units bug is fixed in the code
-- This is a REAL CODE BUG, not an expected failure - using skip, not xfail
+These tests are deliberately UNITS-FREE (2026-07 audit, BF-10a): the DM
+ordering/corruption behaviour they guard is independent of the units
+system, and the previous unit-aware setup was blocked by a separate bug
+(see the TODO(DESIGN) note on UnitAwareDerivativeMatrix in
+utilities/mathematical_mixin.py). Part (b) of BF-10 re-unitizes them once
+UnitAwareDerivativeMatrix arithmetic is implemented.
 """
 
 import pytest
 
-# Physics solver tests - full solver execution
-pytestmark = pytest.mark.level_3
 import underworld3 as uw
 import numpy as np
 
+# Projection-solver regression tests
+pytestmark = [pytest.mark.level_2, pytest.mark.tier_b]
 
-@pytest.mark.level_2  # Intermediate - projection solver
-@pytest.mark.tier_b   # Validated - core regression test
-@pytest.mark.skip(reason="BUG: UnitAwareDerivativeMatrix * NegativeOne not implemented. Fix code, then remove skip.")
-def test_kill_batman():
-    """
-    🦇 KILL BATMAN: Verify that variables can be created AFTER solve() without errors.
+# Domain and BCs: T = 300 at y=0, T = 1600 at y=500 on a 1000 x 500 box,
+# so the exact solution is linear with dT/dy = 1300/500 = 2.6.
+L_X = 1000.0
+L_Y = 500.0
+T_BOTTOM = 300.0
+T_TOP = 1600.0
+EXPECTED_GRADIENT = (T_TOP - T_BOTTOM) / L_Y  # 2.6
 
-    This test explicitly checks that the Batman Pattern anti-pattern is NOT required.
-    If this test fails, the DM state corruption bug has returned and you MUST NOT
-    work around it by declaring variables upfront - FIX THE BUG instead.
 
-    Batman Pattern = requiring all variables declared before any solve operations.
-    See CLAUDE.md "NO BATMAN" section for full documentation.
-    """
-    # Reset model to avoid test state pollution
-    uw.reset_default_model()
-
-    # Set reference quantities for units support
-    model = uw.get_default_model()
-    model.set_reference_quantities(
-        domain_depth=uw.quantity(500, "m"),  # Matches L_y
-        material_density=uw.quantity(3300, "kg/m**3"),  # For complete dimensional analysis
-    )
-
-    L_x = 1000 * uw.units("m")
-    L_y = 500 * uw.units("m")
-    T_bottom = 300 * uw.units("K")
-    T_top = 1600 * uw.units("K")
-
-    mesh = uw.meshing.StructuredQuadBox(
-        elementRes=(10, 10), minCoords=(0.0, 0.0), maxCoords=(L_x, L_y), units="metre"
-    )
-
-    # Create primary variable
-    T = uw.discretisation.MeshVariable("T", mesh, 1, degree=2, units="kelvin")
-
-    # Solve FIRST (this used to "finalize" the DM and prevent adding variables)
+def _solve_poisson(mesh, T):
     poisson = uw.systems.Poisson(mesh, u_Field=T)
     poisson.constitutive_model = uw.constitutive_models.DiffusionModel
     poisson.constitutive_model.Parameters.diffusivity = 1
     poisson.f = 0.0
-    poisson.add_dirichlet_bc(T_bottom, "Bottom")
-    poisson.add_dirichlet_bc(T_top, "Top")
+    poisson.add_dirichlet_bc(T_BOTTOM, "Bottom")
+    poisson.add_dirichlet_bc(T_TOP, "Top")
     poisson.solve()
+    assert poisson.snes.getConvergedReason() > 0, "Solver did not converge"
 
-    # NOW create a derived variable AFTER solving (the test for Batman Pattern)
+
+def _project_dTdy(mesh, T, gradT):
     x, y = mesh.X
-    gradT = uw.discretisation.MeshVariable("gradT", mesh, 1, degree=1)
-
-    # Compute gradient
     proj = uw.systems.Projection(mesh, gradT, degree=1)
-    proj.uw_function = T.diff(y)
+    # NOTE: T.sym.diff(y), not T.diff(y) — the MathematicalMixin diff path
+    # returns a UnitAwareDerivativeMatrix wrapper whose missing arithmetic
+    # is exactly the BF-10 part (b) bug (see the TODO(DESIGN) note in
+    # utilities/mathematical_mixin.py). The DM-ordering coverage here does
+    # not depend on that wrapper.
+    proj.uw_function = T.sym.diff(y)
     proj.solve()
 
-    # Check result
-    x_center = L_x / 2
-    y_center = L_y / 2
-    dT_dy = uw.function.evaluate(gradT.sym, [(x_center, y_center)])
-    expected_gradient = 2.6  # K/m
 
-    # This should work WITHOUT requiring Batman Pattern
-    try:
-        assert (
-            abs(dT_dy[0, 0, 0] - expected_gradient) < 0.1
-        ), f"Expected {expected_gradient:.3f}, got {dT_dy[0,0,0]:.3f}"
-        print(
-            f"✓ Batman is dead: Variables can be created after solve() [got {dT_dy[0,0,0]:.3f} K/m]"
-        )
-    except AssertionError as e:
-        pytest.fail(
-            f"🦇 BATMAN ERRORS DETECTED 🦇\n"
-            f"The DM state corruption bug has returned!\n"
-            f"DO NOT work around this by declaring variables upfront.\n"
-            f"FIX THE BUG in discretisation_mesh_variables.py _setup_ds() method.\n"
-            f"Error: {e}\n"
-            f"See: CLAUDE.md 'NO BATMAN' section and MESH-VARIABLE-ORDERING-BUG.md"
-        )
+def _dTdy_at_centre(gradT):
+    centre = np.array([[L_X / 2, L_Y / 2]])
+    return uw.function.evaluate(gradT.sym, centre)[0, 0, 0]
 
 
-@pytest.mark.level_2  # Intermediate - projection solver
-@pytest.mark.tier_b   # Validated - core regression test
-@pytest.mark.skip(reason="BUG: UnitAwareDerivativeMatrix * NegativeOne not implemented. Fix code, then remove skip.")
+def test_kill_batman():
+    """
+    KILL BATMAN: Verify that variables can be created AFTER solve() without errors.
+
+    This test explicitly checks that the Batman Pattern anti-pattern is NOT
+    required. If this test fails, the DM state corruption bug has returned and
+    you MUST NOT work around it by declaring variables upfront - FIX THE BUG
+    instead.
+
+    Batman Pattern = requiring all variables declared before any solve
+    operations.
+    """
+    uw.reset_default_model()
+
+    mesh = uw.meshing.StructuredQuadBox(
+        elementRes=(10, 10), minCoords=(0.0, 0.0), maxCoords=(L_X, L_Y)
+    )
+    T = uw.discretisation.MeshVariable("T", mesh, 1, degree=2)
+
+    # Solve FIRST (this used to "finalize" the DM and prevent adding variables)
+    _solve_poisson(mesh, T)
+
+    # NOW create a derived variable AFTER solving (the test for Batman Pattern)
+    gradT = uw.discretisation.MeshVariable("gradT", mesh, 1, degree=1)
+    _project_dTdy(mesh, T, gradT)
+
+    dT_dy = _dTdy_at_centre(gradT)
+    assert abs(dT_dy - EXPECTED_GRADIENT) < 0.1, (
+        "BATMAN ERRORS DETECTED: the DM state corruption bug has returned! "
+        "Do NOT work around this by declaring variables upfront - fix the "
+        "DM rebuild path in discretisation_mesh_variables.py. "
+        f"Expected {EXPECTED_GRADIENT:.3f}, got {dT_dy:.3f}"
+    )
+
+
 def test_gradient_projection_variable_created_after_solve():
     """
     Test creating gradient variable AFTER Poisson solve.
 
-    This test previously failed due to DM state corruption (Expected: 2.6 K/m, Got: 6.09 K/m).
-    FIX: When rebuilding DM after adding variables, now properly invalidates and restores
-    all existing variables' vectors from the new DM.
+    This previously failed due to DM state corruption
+    (Expected: 2.6, Got: 6.09).
     """
-    # Reset model to avoid test state pollution
     uw.reset_default_model()
 
-    # Set reference quantities for units support
-    model = uw.get_default_model()
-    model.set_reference_quantities(
-        domain_depth=uw.quantity(500, "m"),
-        material_density=uw.quantity(3300, "kg/m**3"),
-    )
-
-    L_x = 1000 * uw.units("m")
-    L_y = 500 * uw.units("m")
-    T_bottom = 300 * uw.units("K")
-    T_top = 1600 * uw.units("K")
-
     mesh = uw.meshing.StructuredQuadBox(
-        elementRes=(10, 10), minCoords=(0.0, 0.0), maxCoords=(L_x, L_y), units="metre"
+        elementRes=(10, 10), minCoords=(0.0, 0.0), maxCoords=(L_X, L_Y)
+    )
+    T = uw.discretisation.MeshVariable("T", mesh, 1, degree=2)
+
+    _solve_poisson(mesh, T)
+
+    # Create gradient variable AFTER solving (THIS IS THE BUG's trigger)
+    gradT = uw.discretisation.MeshVariable("gradT", mesh, 1, degree=1)
+    _project_dTdy(mesh, T, gradT)
+
+    dT_dy = _dTdy_at_centre(gradT)
+    assert abs(dT_dy - EXPECTED_GRADIENT) < 0.1, (
+        f"Gradient computation failed: expected {EXPECTED_GRADIENT:.3f}, got {dT_dy:.3f}"
     )
 
-    T = uw.discretisation.MeshVariable("T", mesh, 1, degree=2, units="kelvin")
 
-    # Solve Poisson FIRST
-    poisson = uw.systems.Poisson(mesh, u_Field=T)
-    poisson.constitutive_model = uw.constitutive_models.DiffusionModel
-    poisson.constitutive_model.Parameters.diffusivity = 1
-    poisson.f = 0.0
-    poisson.add_dirichlet_bc(T_bottom, "Bottom")
-    poisson.add_dirichlet_bc(T_top, "Top")
-    poisson.solve()
-
-    # Create gradient variable AFTER solving (THIS IS THE BUG)
-    x, y = mesh.X
-    gradT = uw.discretisation.MeshVariable("gradT", mesh, 1, degree=1)
-
-    # Compute gradient via scalar projection
-    proj = uw.systems.Projection(mesh, gradT, degree=1)
-    proj.uw_function = T.diff(y)
-    proj.solve()
-
-    # Evaluate at center
-    x_center = L_x / 2
-    y_center = L_y / 2
-    dT_dy = uw.function.evaluate(gradT.sym, [(x_center, y_center)])
-
-    expected_gradient = 2.6  # K/m
-
-    print(f"\nVariable created AFTER solve:")
-    print(f"  Expected: {expected_gradient:.3f} K/m")
-    print(f"  Got:      {dT_dy[0,0,0]:.3f} K/m")
-    print(f"  Status:   FIXED - Previously failed with 6.09 K/m due to DM state corruption")
-
-    # This assertion should now PASS after fix
-    assert (
-        abs(dT_dy[0, 0, 0] - expected_gradient) < 0.1
-    ), f"Gradient computation failed: expected {expected_gradient:.3f}, got {dT_dy[0,0,0]:.3f}"
-
-
-@pytest.mark.level_2  # Intermediate - projection solver
-@pytest.mark.tier_b   # Validated - core regression test
-@pytest.mark.skip(reason="BUG: UnitAwareDerivativeMatrix * NegativeOne not implemented. Fix code, then remove skip.")
 def test_gradient_projection_variable_created_before_solve():
     """
-    Test that PASSES: Creating gradient variable BEFORE Poisson solve gives correct results.
-
-    This documents the workaround. Expected: 2.6 K/m, Got: 2.6 K/m ✓
+    Control case: creating the gradient variable BEFORE the Poisson solve
+    has always worked and must keep working.
     """
-    # Reset model to avoid test state pollution
     uw.reset_default_model()
 
-    # Set reference quantities for units support
-    model = uw.get_default_model()
-    model.set_reference_quantities(
-        domain_depth=uw.quantity(500, "m"),
-        material_density=uw.quantity(3300, "kg/m**3"),
-    )
-
-    L_x = 1000 * uw.units("m")
-    L_y = 500 * uw.units("m")
-    T_bottom = 300 * uw.units("K")
-    T_top = 1600 * uw.units("K")
-
     mesh = uw.meshing.StructuredQuadBox(
-        elementRes=(10, 10), minCoords=(0.0, 0.0), maxCoords=(L_x, L_y), units="metre"
+        elementRes=(10, 10), minCoords=(0.0, 0.0), maxCoords=(L_X, L_Y)
     )
+    T = uw.discretisation.MeshVariable("T", mesh, 1, degree=2)
 
-    T = uw.discretisation.MeshVariable("T", mesh, 1, degree=2, units="kelvin")
-
-    # Create gradient variable BEFORE solving (WORKAROUND)
-    x, y = mesh.X
+    # Create gradient variable BEFORE solving
     gradT = uw.discretisation.MeshVariable("gradT", mesh, 1, degree=1)
 
-    # Now solve Poisson
-    poisson = uw.systems.Poisson(mesh, u_Field=T)
-    poisson.constitutive_model = uw.constitutive_models.DiffusionModel
-    poisson.constitutive_model.Parameters.diffusivity = 1
-    poisson.f = 0.0
-    poisson.add_dirichlet_bc(T_bottom, "Bottom")
-    poisson.add_dirichlet_bc(T_top, "Top")
-    poisson.solve()
+    _solve_poisson(mesh, T)
+    _project_dTdy(mesh, T, gradT)
 
-    # Compute gradient via scalar projection
-    proj = uw.systems.Projection(mesh, gradT, degree=1)
-    proj.uw_function = T.diff(y)
-    proj.solve()
-
-    # Evaluate at center
-    x_center = L_x / 2
-    y_center = L_y / 2
-    dT_dy = uw.function.evaluate(gradT.sym, [(x_center, y_center)])
-
-    expected_gradient = 2.6  # K/m
-
-    print(f"\nVariable created BEFORE solve:")
-    print(f"  Expected: {expected_gradient:.3f} K/m")
-    print(f"  Got:      {dT_dy[0,0,0]:.3f} K/m")
-    print(f"  SUCCESS:  Correct result when variable created before solve")
-
-    # This assertion SHOULD PASS
-    assert (
-        abs(dT_dy[0, 0, 0] - expected_gradient) < 0.1
-    ), f"Gradient computation failed: expected {expected_gradient:.3f}, got {dT_dy[0,0,0]:.3f}"
-
-
-if __name__ == "__main__":
-    print("=" * 80)
-    print("REGRESSION TEST: Mesh Variable Ordering Bug")
-    print("=" * 80)
-
-    print("\n" + "=" * 80)
-    print("Test 1: Variable created AFTER solve (SHOULD PASS)")
-    print("=" * 80)
-    try:
-        test_gradient_projection_variable_created_after_solve()
-        print("✓ Test passed (BUG IS FIXED!)")
-    except AssertionError as e:
-        print(f"✗ Test failed: {e}")
-
-    print("\n" + "=" * 80)
-    print("Test 2: Variable created BEFORE solve (SHOULD PASS)")
-    print("=" * 80)
-    try:
-        test_gradient_projection_variable_created_before_solve()
-        print("✓ Test passed")
-    except AssertionError as e:
-        print(f"✗ Test failed: {e}")
-
-    print("\n" + "=" * 80)
-    print("SUMMARY:")
-    print("  - Creating variables AFTER solve: FIXED ✓")
-    print("  - Creating variables BEFORE solve: Works ✓")
-    print("  - Fix: Properly invalidate and restore vectors when rebuilding DM")
-    print("=" * 80)
+    dT_dy = _dTdy_at_centre(gradT)
+    assert abs(dT_dy - EXPECTED_GRADIENT) < 0.1, (
+        f"Gradient computation failed: expected {EXPECTED_GRADIENT:.3f}, got {dT_dy:.3f}"
+    )

--- a/tests/test_0857_lagrangian_ddt_advecting_history.py
+++ b/tests/test_0857_lagrangian_ddt_advecting_history.py
@@ -215,3 +215,38 @@ def test_lagrangian_swarm_advecting_history_with_step_averaging():
         got1[interior], 0.5 * T2(x0[interior], y0[interior]) + 0.5 * T1(x0[interior], y0[interior]),
         atol=1e-8,
     )
+
+
+def test_lagrangian_object_viewers_do_not_raise():
+    """Regression (2026-07 audit, BF-15 / READ-46): ``_object_viewer`` on
+    both Lagrangian DDt classes referenced ``self.psi`` and
+    ``self.dt_physical``, which are never set — every view raised
+    AttributeError. The viewer must render from ``psi_fn``."""
+    pytest.importorskip("IPython")
+    mesh = _make_mesh()
+    T = _linear_scalar_field(mesh, "T_view", 1.0, 2.0)
+    V = _constant_velocity(mesh)
+
+    lag_ddt = ddt_module.Lagrangian(
+        mesh=mesh,
+        psi_fn=T.sym,
+        V_fn=V.sym,
+        vtype=uw.VarType.SCALAR,
+        degree=1,
+        continuous=True,
+        order=1,
+        fill_param=2,
+    )
+    lag_ddt._object_viewer()
+
+    swarm = uw.swarm.Swarm(mesh)
+    lag_swarm_ddt = ddt_module.Lagrangian_Swarm(
+        swarm=swarm,
+        psi_fn=T.sym,
+        vtype=uw.VarType.SCALAR,
+        degree=1,
+        continuous=True,
+        order=1,
+    )
+    swarm.populate(fill_param=2)
+    lag_swarm_ddt._object_viewer()

--- a/tests/test_1053_ddt_theta.py
+++ b/tests/test_1053_ddt_theta.py
@@ -91,3 +91,14 @@ class TestTheta:
         assert d.theta == 0.5
         assert float(d._am_coeffs[0].sym) == pytest.approx(0.5)
         assert float(d._am_coeffs[1].sym) == pytest.approx(0.5)
+
+    def test_state_restore_preserves_theta(self):
+        """Regression (2026-07 audit, D9a / READ-45): restoring a state
+        snapshot re-derives the AM coefficients — it must use the
+        instance's theta, not a hard-coded Crank-Nicolson 0.5."""
+        d = _make_sl(theta=1.0)
+        snapshot = d.state
+        d.state = snapshot
+        # Backward-Euler coefficients [1.0, 0.0] must survive the restore.
+        assert float(d._am_coeffs[0].sym) == pytest.approx(1.0)
+        assert float(d._am_coeffs[1].sym) == pytest.approx(0.0)


### PR DESCRIPTION
Track-0 medium-severity fixes from the 2026-07 quality audit
(`docs/reviews/2026-07/REMEDIATION-WORKLIST.md`; maintainer rulings 2026-07-06).
Seven items, one commit each; all reproduced/verified before fixing.

## BF-13 — BoxInternalBoundary UnboundLocalError on every rank > 0 (confirmed)

`boundaries`/`boundary_normals` were bound only inside the rank-0 gmsh block
while every rank passes them to `Mesh(...)`. Reproduced at np2: rank 1 raises
`UnboundLocalError` and the job hangs in the next collective. Fix binds the
Enums on all ranks from the dimension alone (`meshing/cartesian.py`).

- New np2 regression test `tests/parallel/test_0766_box_internal_boundary_mpi.py`
  (construction on all ranks + rank-consistent internal-boundary integral).
- Revisited the six `test_0502` MPI skips: **four unskipped** and passing at np2.
  The two signed-normal tests (`internal_normal_ny`, `internal_normal_weighted`)
  expose a **separate** defect — internal-facet normal orientation is
  rank-dependent at partition seams (|∫ n_y| = 1 − 2/32 = 0.9375 at np2, exactly
  one flipped seam facet; scalar integrands are exact). These stay serial-only
  with an accurate reason and a `TODO(BUG)` marker in the test file.

## D9(a) — SemiLagrangian state restore hard-coded theta = 0.5 (confirmed)

The state setter re-derived the Adams-Moulton coefficients with `0.5` (and a
stale comment claiming the class takes no theta). Restoring onto a
`theta = 1.0` (Backward-Euler) instance silently reset the flux integrator to
Crank-Nicolson. Fix passes `self.theta`, matching `update_pre_solve`.
Regression test in `tests/test_1053_ddt_theta.py` (snapshot/restore round-trip
preserves `[1.0, 0.0]`; failed with `[0.5, 0.5]` before the fix).

## BF-15 — Lagrangian DDt `_object_viewer` AttributeError (verified, confirmed)

Both `Lagrangian` and `Lagrangian_Swarm` viewers referenced `self.psi` /
`self.dt_physical`, never set on those classes — every view raised
AttributeError (verified live on both). Fixed to render from `psi_fn`; the
`dt_physical` line is dropped (not tracked on these classes). The Eulerian
class's dead commented-out copy is deleted; its viewer re-verified working.
Regression test in `tests/test_0857_lagrangian_ddt_advecting_history.py`.

## D9(b) — `SNES_Vector_Projection.projection_problem_description` (verified: dead + double-counting)

Confirmed the method sets `self._f1` = F1 template + smoothing + penalty again
(exactly 2x the template, symbolically verified), and that it is **dead**: the
solve path assembles from `self.F0.sym`/`self.F1.sym` and never reads
`self._f0`/`self._f1`; repository-wide grep finds no caller; a
`Vector_Projection` solve is identical whether or not the method was invoked.
Deleted per the worklist's grep-first-delete ruling — **no numbers change**
(this is the deletion branch of the ruling, not the behaviour-change branch).

## BF-10(a) — Batman DM-corruption tests restored units-free

The three skipped `test_0813` tests are rewritten without units and unskipped
(same geometry/BCs/expected gradient 2.6). Notable: the blocking
`UnitAwareDerivativeMatrix * NegativeOne` TypeError is **not units-gated** —
`MeshVariable.diff()` returns the wrapper unconditionally — so the tests use
`T.sym.diff(y)`. Part (b) (implement the wrapper arithmetic, re-unitize) is
marked with a `TODO(DESIGN)` on `UnitAwareDerivativeMatrix`
(`utilities/mathematical_mixin.py`), per the worklist. Not implemented here.

## BF-12 + D7 — quantity-valued coordinate lists ruled unsupported

`evaluate()`/`global_evaluate()` now reject list/tuple coordinates up front
with a TypeError naming the supported forms (plain model-unit numpy arrays;
unit-aware arrays). No previously-working input changes behaviour: every list
form already raised, with an unhelpful message. Documented in the `evaluate()`
docstring and `docs/developer/design/UNITS_SIMPLIFIED_DESIGN_2025-11.md`.
`tests/test_0812_poisson_with_units.py` rewritten with supported coordinate
forms and unskipped (3 substantive Poisson-with-quantity-BC tests + a new
rejection-contract test).

Found while verifying (flagged with `TODO(BUG)`, comment-only):
`uw.non_dimensionalise(pint.Quantity)` crashes — `units.py` protocol 5 passes
an invalid `dimensionality=` kwarg to `UWQuantity`. The `uw.quantity` path
works. Also observed (not changed): point-location `evaluate()` at a point
exactly ON the top boundary returns its 1e-18 sentinel (noted in the test).

## BF-18 — deprecated `mesh.points` setter removed (verified, confirmed)

Verified live: the setter rebound `self._coords` to a plain ndarray, discarding
the `NDArray_With_Callback` wrapper — PETSc coordinates never updated, writes
silently ineffective. Zero internal callers (src/tests/docs). Per the ruling,
removed rather than repaired: assignment now raises AttributeError pointing at
`mesh.deform(new_coords)` / `mesh.X.coords`. Regression tests in
`tests/test_0058_mesh_points_setter_removed.py` (refusal, state untouched,
deform as the supported path).

## Tests

- Serial `pytest tests/ -m "level_1 and tier_a"`: green **before** (318 passed,
  7 skipped, 4 xfailed, 1 xpassed) and **after** (323 passed, 7 skipped,
  4 xfailed, 1 xpassed — the +5 are this PR's new/unskipped level_1 tier_a
  regression tests).
- Full touched files serial: `test_0502`, `test_1053`, `test_0857`,
  `test_0813`, `test_0812`, `test_0058`, plus adjacent `test_1052`,
  `test_0007`: 71 passed.
- np2: `tests/parallel/test_0766_box_internal_boundary_mpi.py` +
  `tests/test_0502_boundary_integrals.py`: 21 passed, 2 skipped
  (the two seam-orientation tests, documented above).

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)
