### PR TITLE
Fix internal boundary integral MPI test deform API

### DIFF
--- a/tests/parallel/test_0765_internal_boundary_integral_mpi.py
+++ b/tests/parallel/test_0765_internal_boundary_integral_mpi.py
@@ -87,7 +87,7 @@ def test_deformed_spherical_shell_boundary_area_parallel():
     a = math.log(2.0)
     mapped = (np.exp(a * t) - 1.0) / (math.exp(a) - 1.0)
     new_radii = 0.5 + thickness * mapped
-    mesh._deform_mesh(coords * (new_radii / radii)[:, None])
+    mesh.deform(coords * (new_radii / radii)[:, None])
 
     lower = float(uw.maths.BdIntegral(mesh=mesh, fn=1.0, boundary="Lower").evaluate())
     upper = float(uw.maths.BdIntegral(mesh=mesh, fn=1.0, boundary="Upper").evaluate())


### PR DESCRIPTION
This PR updates tests/parallel/test_0765_internal_boundary_integral_mpi.py so the deformed spherical-shell boundary-area MPI test uses the public mesh.deform() API instead of calling the internal Mesh._deform_mesh() method directly.

The previous test path is rejected by the coordinate-mutation capability guard on current development. This keeps the test aligned with the public mesh-deformation API without changing the purpose of the regression test.

Validation:

- pixi run mpirun -np 2 python -m pytest -q --with-mpi tests/parallel/test_0765_internal_boundary_integral_mpi.py::test_deformed_spherical_shell_boundary_area_parallel
- pixi run mpirun -np 4 python -m pytest -q --with-mpi tests/parallel/test_0765_internal_boundary_integral_mpi.py::test_deformed_spherical_shell_boundary_area_parallel
- pixi run mpirun -np 2 python -m pytest -q --with-mpi tests/parallel/test_0765_internal_boundary_integral_mpi.py
- pixi run mpirun -np 4 python -m pytest -q --with-mpi tests/parallel/test_0765_internal_boundary_integral_mpi.py