### PR TITLE
refactor(api): Wave C harmonization — value-first BCs, conds datum, quantity factory (WC-01..13)

### DIFF
--- a/docs/developer/UW3_STYLE_CHARTER.md
+++ b/docs/developer/UW3_STYLE_CHARTER.md
@@ -82,8 +82,8 @@ These settle the June-2026 drift (see `docs/reviews/2026-07/API-CONSISTENCY-REVI
 
 | Topic | Rule |
 |---|---|
-| BC argument order | `add_<kind>_bc(value, boundary, ...)` — value first, matching the original trio, the published examples/benchmarks, and previous major versions (maintainer decision 2026-07-04). The newer boundary-first methods (`add_nitsche_bc`, `add_rotated_freeslip_bc`, `add_constraint_bc`) migrate to it; their current signatures are shimmed. |
-| BC value parameter | ONE name across all BC methods ⟨pending maintainer confirmation: `conds` (implied by the original-order decision) vs `value`⟩. Until decided, do not introduce a third spelling. |
+| BC argument order | `add_<kind>_bc(conds, boundary, ...)` — value first, matching the original trio, the published examples/benchmarks, and previous major versions (maintainer decision 2026-07-04). The newer boundary-first methods (`add_nitsche_bc`, `add_rotated_freeslip_bc`, `add_constraint_bc`) migrate to it; their current signatures are shimmed. |
+| BC value parameter | ONE name across all BC methods: **`conds`** (maintainer decision 2026-07-06, recorded in `docs/reviews/2026-07/REMEDIATION-WORKLIST.md`). Other spellings (`g`, `value`, ...) exist only as deprecated keyword aliases where they existed before the decision; never introduce a new spelling. |
 | Direction selection | Component masking via `None`/`sympy.oo` entries in the value vector; `direction=` only for a scalar constraint along a vector (defaults to outward normal); `normal=` strictly overrides the geometric surface-normal source. `components=` is deprecated — never in new code. |
 | Solver capabilities | Anything that configures or reads one solver is a METHOD on that solver, lazily importing its `utilities/*` implementation (the `boundary_flux` pattern) — never a free function as the documented entry point. |
 | Namespaces | Every user-facing module is exported from its subpackage `__init__`/`__all__` in the PR that creates it. No deep-import-only features. |

--- a/src/underworld3/__init__.py
+++ b/src/underworld3/__init__.py
@@ -219,7 +219,9 @@ from .model import (
 from .parameters import ParameterRegistry, ParameterType
 from .materials import MaterialRegistry, MaterialProperty
 from .constitutive_models import MultiMaterialConstitutiveModel
-from .function import quantity, expression, with_units, expand, unwrap
+# uw.quantity is THE quantity factory (returns UWQuantity, exposed alongside
+# for isinstance checks); uw.create_quantity is deprecated (see units.py).
+from .function import quantity, UWQuantity, expression, with_units, expand, unwrap
 from .coordinates import uwdiff  # Differentiation helper for UWCoordinates
 from .utilities import retention_curves
 

--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -2311,8 +2311,13 @@ class SolverBaseClass(uw_object):
         MeshVariable ``field`` at the boundary nodes (interior untouched), multiplied by
         ``scale``. This is the field hand-off for downstream machinery (surface heat
         flux for coupling, or — with ``remove_mean=True`` and ``scale=-1/(\Delta\rho g)``
-        — dynamic topography). Returns ``field``."""
-        from underworld3.utilities.boundary_flux import boundary_flux_to_field as _bff
+        — dynamic topography). Returns ``field``.
+
+        Note that ``scale`` is a generic multiplier, NOT the ``buoyancy_scale``
+        taken by :meth:`dynamic_topography` / ``topography``: for topography the
+        relationship is ``scale = -1 / buoyancy_scale`` (there the division by
+        :math:`\Delta\rho\,g` and the minus sign are internal)."""
+        from underworld3.utilities.boundary_flux import boundary_flux_field as _bff
         return _bff(self, boundary, field, mass=mass, remove_mean=remove_mean,
                     scale=scale, normal=normal)
 

--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -324,7 +324,19 @@ class SolverBaseClass(uw_object):
         ``setFromOptions`` / nullspace attach) via
         :func:`underworld3.utilities.custom_mg.inject_custom_mg`. See
         :mod:`underworld3.utilities.custom_mg`.
+
+        .. deprecated:: 2026-07
+            This is the legacy **serial-only, finest-only-reduction,
+            single-field** path; the Stokes velocity-block support described
+            above is delivered by :meth:`set_custom_fmg`, which is the
+            canonical entry point (parallel-capable, BC-per-level reduction).
         """
+        import warnings
+        warnings.warn(
+            "set_custom_mg is deprecated (legacy serial-only, single-field "
+            "custom-MG path); use set_custom_fmg(coarse_meshes, "
+            "builder=..., field_id=...) instead",
+            DeprecationWarning, stacklevel=2)
         if kind not in ("barycentric", "rbf"):
             raise ValueError("kind must be 'barycentric' or 'rbf'")
         if not coarse_meshes:
@@ -332,6 +344,41 @@ class SolverBaseClass(uw_object):
         self._custom_mg = {"coarse_meshes": list(coarse_meshes),
                            "kind": kind, "verbose": verbose}
         self.is_setup = False
+
+    def set_custom_fmg(self, coarse_meshes, *, builder="barycentric",
+                       field_id=None, verbose=False):
+        r"""Drive geometric multigrid with a prolongation built from
+        ``coarse_meshes`` — the canonical custom-MG entry point.
+
+        Registers a BC-per-level reduced hierarchy on the solver so the next
+        :meth:`solve` builds and installs it (build-time injection). Works in
+        parallel and on the **Stokes velocity block** (pass ``field_id=0`` on a
+        saddle-point solver). This supersedes the legacy
+        :meth:`set_custom_mg` path (serial-only, finest-only reduction,
+        single-field).
+
+        Parameters
+        ----------
+        coarse_meshes : list of Mesh
+            Coarsest-first list of coarse meshes (the finest level is the
+            solver's own mesh). They need only carry the same boundary labels
+            as the solver's mesh.
+        builder : {"barycentric", "rbf"}, default "barycentric"
+            Prolongation builder. ``barycentric`` is FE-exact; ``rbf`` is a
+            polyharmonic RBF (Shepard-normalised).
+        field_id : int, optional
+            Target field for a multi-field (saddle-point) solver; ``0`` is the
+            Stokes velocity block. ``None`` (default) for single-field solvers.
+        verbose : bool, default False
+            Print the per-level DOF counts at injection.
+
+        See Also
+        --------
+        underworld3.utilities.custom_mg.set_custom_fmg : the implementation.
+        """
+        from underworld3.utilities.custom_mg import set_custom_fmg as _set_custom_fmg
+        _set_custom_fmg(self, coarse_meshes, builder=builder,
+                        field_id=field_id, verbose=verbose)
 
     def add_update_callback(self, callback):
         r"""Register a callback fired at the start of every nonlinear (SNES) iteration.

--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -68,27 +68,8 @@ class SolverBaseClass(uw_object):
         self.compiled_extensions = None
         self.constants_manifest = []
 
-        # Jacobian tangent selection: False | True | "continuation".
-        #
-        #   False (default): differentiate the residual flux *as wrapped* — the
-        #     effective viscosity is frozen, giving a Picard / defect-correction
-        #     tangent. BIT-IDENTICAL to the long-standing behaviour. Globally
-        #     robust; load-bearing for the tuned hard-yield viscoplastic paths.
-        #   True: unwrap the flux before differentiation so the tangent captures
-        #     d(eta)/d(grad v) (full Newton). Fast near the solution; its yield
-        #     kink can stall the line search far from it.
-        #   "continuation": Picard -> Newton. Blend J(alpha) = J_picard +
-        #     alpha*(J_newton - J_picard) with alpha a constants[] parameter
-        #     ramped 0 -> 1 by a SNES monitor as the residual drops. Picard
-        #     locates the basin, Newton gives quadratic convergence inside it
-        #     (cf. Spiegelman et al. 2016; ASPECT defect-correction-then-Newton).
-        #     alpha=0 is bit-identical to Picard, so no recompile to switch.
-        #
-        # The Newton flux for a model whose flux has a non-smooth yield kink is
-        # the model's own smooth law (constitutive_model.flux_jacobian) when it
-        # provides one; otherwise the exact unwrapped flux.
-        #
-        # See docs/developer/design/jacobian-unwrap-constants-bug.md.
+        # Jacobian tangent selection — validated property, see the
+        # consistent_jacobian docstring below for the mode semantics.
         self.consistent_jacobian = False
         # Picard->Newton continuation parameter (constants[]-routed so it can be
         # ramped at solve time without a JIT recompile). 0 = Picard, 1 = Newton.
@@ -156,6 +137,60 @@ class SolverBaseClass(uw_object):
         # Custom multigrid prolongation hierarchy (see set_custom_mg /
         # utilities.custom_mg). None => standard FMG/GAMG path, unchanged.
         self._custom_mg = None
+
+    @property
+    def consistent_jacobian(self):
+        r"""Jacobian tangent selection: ``False`` | ``True`` | ``"continuation"``.
+
+        Selects the tangent used by :meth:`_jacobian_source` and the solve
+        dispatch; the residual is never affected, so the converged solution
+        always satisfies the exact constitutive law.
+
+        ``False`` (default)
+            Differentiate the residual flux *as wrapped* — the effective
+            viscosity is frozen, giving a Picard / defect-correction tangent.
+            Bit-identical to the long-standing behaviour. Globally robust;
+            load-bearing for the tuned hard-yield viscoplastic paths.
+        ``True``
+            Unwrap the flux before differentiation so the tangent captures
+            :math:`\partial\eta/\partial(\nabla v)` (full Newton). Fast near
+            the solution; its yield kink can stall the line search far from it.
+        ``"continuation"``
+            Picard :math:`\rightarrow` Newton. Blend
+            :math:`J(\alpha) = J_{\mathrm{picard}} + \alpha\,(J_{\mathrm{newton}}
+            - J_{\mathrm{picard}})` with :math:`\alpha` a ``constants[]``
+            parameter ramped :math:`0 \rightarrow 1` by a SNES monitor as the
+            residual drops. Picard locates the basin, Newton gives quadratic
+            convergence inside it (cf. Spiegelman et al. 2016; ASPECT
+            defect-correction-then-Newton). :math:`\alpha = 0` is bit-identical
+            to Picard, so no recompile is needed to switch.
+
+        The Newton flux for a model whose flux has a non-smooth yield kink is
+        the model's own smooth law (``constitutive_model.flux_jacobian``) when
+        it provides one; otherwise the exact unwrapped flux. See
+        ``docs/developer/design/jacobian-unwrap-constants-bug.md``.
+
+        Raises
+        ------
+        ValueError
+            On assignment of anything other than ``False``, ``True`` or
+            ``"continuation"``. Falsy values (``None``, ``0``, ``""``)
+            normalize to ``False`` (they already selected the Picard tangent).
+            Before validation, any other truthy value (``1``, ``"picard"``,
+            ``"Continuation"``) silently selected the full-Newton tangent.
+        """
+        return self._consistent_jacobian
+
+    @consistent_jacobian.setter
+    def consistent_jacobian(self, mode):
+        if not mode:
+            self._consistent_jacobian = False
+        elif mode is True or mode == "continuation":
+            self._consistent_jacobian = mode
+        else:
+            raise ValueError(
+                f"consistent_jacobian must be False, True or 'continuation'; "
+                f"got {mode!r}")
 
     def _jacobian_source(self, expr, newton_expr=None):
         """Prepare a residual flux for Jacobian differentiation.

--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -1447,12 +1447,12 @@ class SolverBaseClass(uw_object):
                   "sympy.Matrix, i.e. conds = sympy.Matrix([sympy.oo, 5, 1.2])\n")
 
         if isinstance(components, (tuple, list, int)):
-            # TODO: DECPRECATE
             import warnings
-            warnings.warn(category=DeprecationWarning,
-                          message="Using the 'components' argument is being DEPRECATED in the next release\n" +
-                                  "The same functionality can be setup with the 'conds' argument and using\n" +
-                                  "'sympy.oo' or 'None', see docstring")
+            warnings.warn(
+                "The 'components' argument is deprecated; select components "
+                "with None / sympy.oo entries in 'conds' instead, e.g. "
+                "conds=(None, 5, 1.2)",
+                DeprecationWarning, stacklevel=3)
             components = np.array(components, dtype=np.int32, ndmin=1)
 
         elif components is None:
@@ -1524,6 +1524,49 @@ class SolverBaseClass(uw_object):
             BC = namedtuple('EssentialBC', ['f_id', 'components', 'fn', 'boundary', 'boundary_label_val', 'type', 'PETScID'])
             self.essential_bcs.append(BC(f_id, components,sympy_fn, label, -1,  'essential', -1))
 
+
+    def _value_first_bc_args(self, method, conds, boundary, alias=None,
+                             alias_name="g"):
+        """Normalize BC arguments to the canonical value-first order.
+
+        The canonical BC signature is ``method(conds, boundary, ...)`` with the
+        prescribed datum named ``conds`` (Style Charter, API conventions;
+        maintainer decisions D2/D3, 2026-07). Two legacy spellings are shimmed
+        here, each with exactly one DeprecationWarning:
+
+        * **boundary-first order** — detected conservatively: the first
+          positional argument is a string (a boundary label; a BC datum is
+          never a string — see :meth:`add_condition`) while the second is not.
+          The two arguments are swapped.
+        * **the** ``g=`` **keyword alias** for the datum — forwarded to
+          ``conds``. Supplying both ``conds`` and ``g`` is an error.
+
+        Returns the normalized ``(conds, boundary)`` pair; ``boundary`` is
+        required to be a string on exit.
+        """
+        legacy = False
+        if isinstance(conds, str) and not isinstance(boundary, str):
+            conds, boundary = boundary, conds
+            legacy = True
+        if alias is not None:
+            if conds is not None:
+                raise TypeError(
+                    f"{method}() received the boundary datum twice "
+                    f"(positionally and as '{alias_name}='); pass it once, "
+                    f"as 'conds'")
+            conds = alias
+            legacy = True
+        if legacy:
+            import warnings
+            warnings.warn(
+                f"{method}(boundary, {alias_name}=...) is deprecated; "
+                f"use {method}(conds, boundary, ...)",
+                DeprecationWarning, stacklevel=3)
+        if not isinstance(boundary, str):
+            raise TypeError(
+                f"{method}() requires a boundary label string; "
+                f"got {type(boundary).__name__}")
+        return conds, boundary
 
     # Use FE terminology note f_id is 0.
     @timing.routine_timer_decorator
@@ -3314,19 +3357,21 @@ class SNES_Vector(SolverBaseClass):
         self.petsc_options["ksp_atol"]  = self._tolerance * 1.0e-6
 
 
-    def add_nitsche_bc(self, boundary, g=None, direction=None, gamma=10.0, theta=1, local_h=True):
+    def add_nitsche_bc(self, conds=None, boundary=None, direction=None,
+                       gamma=10.0, theta=1, local_h=True, g=None):
         r"""Add Nitsche weak enforcement of a velocity constraint along a direction.
 
         For vector solvers (no pressure field), this constrains
-        :math:`\mathbf{u} \cdot \mathbf{d} = g` on the boundary using
-        Nitsche's method with penalty, consistency, and symmetry terms.
+        :math:`\mathbf{u} \cdot \mathbf{d} = \mathrm{conds}` on the boundary
+        using Nitsche's method with penalty, consistency, and symmetry terms.
 
         Parameters
         ----------
+        conds : sympy expression or float, optional
+            Prescribed velocity along the constraint direction. Default zero
+            (free-slip when the direction is the surface normal).
         boundary : str
             Boundary label.
-        g : sympy expression or float, optional
-            Prescribed velocity along constraint direction. Default zero.
         direction : sympy.Matrix or list, optional
             Constraint direction. Default ``None`` uses surface normal.
         gamma : float, default=10.0
@@ -3338,11 +3383,20 @@ class SNES_Vector(SolverBaseClass):
             (:meth:`Mesh.cell_size`) rather than the global minimum
             (:meth:`Mesh.get_min_radius`). See
             ``SNES_Stokes_SaddlePt.add_nitsche_bc`` for details.
+        g : sympy expression or float, optional
+            Deprecated keyword alias for ``conds`` (one DeprecationWarning).
 
         Warnings
         --------
         Exterior boundaries only. See ``SNES_Stokes_SaddlePt.add_nitsche_bc``
         for details on why internal boundaries are not supported.
+
+        Notes
+        -----
+        The legacy boundary-first call ``add_nitsche_bc(boundary, g=...)`` is
+        detected conservatively (first positional argument a string while the
+        second is not — a BC datum is never a string) and shimmed with one
+        DeprecationWarning; see :meth:`_value_first_bc_args`.
 
         See Also
         --------
@@ -3350,6 +3404,10 @@ class SNES_Vector(SolverBaseClass):
         """
         import sympy
         from collections import namedtuple
+
+        conds, boundary = self._value_first_bc_args(
+            "add_nitsche_bc", conds, boundary, alias=g)
+        g = conds
 
         self.is_setup = False
 
@@ -5167,7 +5225,7 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
     #     BC = namedtuple('EssentialBC', ['components', 'fn', 'boundary', 'boundary_label_val', 'type', 'PETScID'])
     #     self.essential_p_bcs.append(BC(components, sympy_fn, boundary, -1,  'essential', -1))
 
-    def add_rotated_freeslip_bc(self, boundary, normal=None):
+    def add_rotated_freeslip_bc(self, conds=None, boundary=None, normal=None):
         r"""Add STRONG free-slip (:math:`\mathbf{u}\cdot\hat{\mathbf n}=0`) by rotating
         the boundary velocity DOFs into a per-node (normal, tangential) frame and
         imposing the rotated normal component as an exact Dirichlet constraint.
@@ -5181,6 +5239,14 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
 
         Parameters
         ----------
+        conds : float or None, optional
+            Prescribed wall-normal velocity datum, in the canonical value-first
+            BC order (Style Charter, API conventions). Only the homogeneous
+            free-slip constraint :math:`\mathbf{u}\cdot\hat{\mathbf n}=0` is
+            implemented, so this must be zero (or ``None``, meaning zero); a
+            non-zero datum raises ``NotImplementedError`` (use
+            :meth:`add_nitsche_bc` or ``add_constraint_bc`` for prescribed
+            normal in/outflow).
         boundary : str
             Boundary label to constrain.
         normal : None or sympy 1×dim Matrix or array, optional
@@ -5197,7 +5263,38 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
         face frees two tangential directions, a 3D edge frees one (the edge
         tangent), a corner is fully pinned. Registering delegates the solve to
         :mod:`underworld3.utilities.rotated_bc`.
+
+        The legacy boundary-first call ``add_rotated_freeslip_bc(boundary,
+        normal)`` is detected conservatively (the first positional argument is
+        a string — the datum is never a string) and shimmed with one
+        DeprecationWarning: the string becomes ``boundary`` and a second
+        positional argument, if present, becomes ``normal``.
         """
+        if isinstance(conds, str):
+            # legacy boundary-first call: (boundary[, normal])
+            if boundary is not None:
+                if normal is not None:
+                    raise TypeError(
+                        "add_rotated_freeslip_bc() received 'normal' twice "
+                        "(positionally, legacy order, and as a keyword)")
+                normal = boundary
+            boundary = conds
+            conds = None
+            import warnings
+            warnings.warn(
+                "add_rotated_freeslip_bc(boundary, normal) is deprecated; "
+                "use add_rotated_freeslip_bc(conds, boundary, normal=...) "
+                "with conds=0 (or boundary=... by keyword)",
+                DeprecationWarning, stacklevel=2)
+        if not isinstance(boundary, str):
+            raise TypeError(
+                f"add_rotated_freeslip_bc() requires a boundary label string; "
+                f"got {type(boundary).__name__}")
+        if conds is not None and sympy.sympify(conds) != 0:
+            raise NotImplementedError(
+                "add_rotated_freeslip_bc imposes u.n = 0 only; a non-zero "
+                "wall-normal datum is not implemented (use add_nitsche_bc or "
+                "add_constraint_bc for prescribed normal in/outflow)")
         self._rotated_freeslip_bcs.append((boundary, normal))
         self.is_setup = False
         return
@@ -5290,7 +5387,8 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
         return _dtf(self, boundary, self._rotated_freeslip_info, field,
                     buoyancy_scale=buoyancy_scale, mass=mass)
 
-    def add_nitsche_bc(self, boundary, g=None, direction=None, normal=None, gamma=10.0, theta=1, mask=None, local_h=True):
+    def add_nitsche_bc(self, conds=None, boundary=None, direction=None, normal=None,
+                       gamma=10.0, theta=1, mask=None, local_h=True, g=None):
         r"""Add Nitsche weak enforcement of a velocity constraint along a direction.
 
         Nitsche's method provides a variationally consistent alternative to
@@ -5298,9 +5396,10 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
         and gives optimal convergence rates.
 
         By default, constrains the normal velocity component
-        :math:`\mathbf{u} \cdot \mathbf{n} = g` (free-slip when *g* = 0).
-        When *direction* is provided, constrains
-        :math:`\mathbf{u} \cdot \mathbf{d} = g` along that direction instead.
+        :math:`\mathbf{u} \cdot \mathbf{n} = \mathrm{conds}` (free-slip when
+        ``conds`` is zero). When *direction* is provided, constrains
+        :math:`\mathbf{u} \cdot \mathbf{d} = \mathrm{conds}` along that
+        direction instead.
 
         The method constructs boundary residuals and Jacobians for:
 
@@ -5313,11 +5412,11 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
 
         Parameters
         ----------
-        boundary : str
-            Boundary label (e.g., ``"Upper"``, ``"Lower"``).
-        g : sympy expression or float, optional
+        conds : sympy expression or float, optional
             Prescribed velocity along the constraint direction. Default
             ``None`` means zero (:math:`\mathbf{u} \cdot \mathbf{d} = 0`).
+        boundary : str
+            Boundary label (e.g., ``"Upper"``, ``"Lower"``).
         direction : sympy.Matrix or list, optional
             Constraint direction vector. Default ``None`` uses the boundary
             surface normal (free-slip). Can be spatially varying (e.g.,
@@ -5347,18 +5446,27 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
             adaptive mesh the local size scales the stabilisation correctly
             on every facet; on a uniform mesh the two coincide. Set ``False``
             to restore the legacy global-h behaviour exactly.
+        g : sympy expression or float, optional
+            Deprecated keyword alias for ``conds`` (one DeprecationWarning).
 
         Examples
         --------
         >>> # Free-slip (u.n = 0)
-        >>> stokes.add_nitsche_bc("Upper", gamma=10)
+        >>> stokes.add_nitsche_bc(0.0, "Upper", gamma=10)
 
         >>> # Prescribed normal inflow
-        >>> stokes.add_nitsche_bc("Left", g=1.0, gamma=10)
+        >>> stokes.add_nitsche_bc(1.0, "Left", gamma=10)
 
         >>> # Constrain along a specific direction (e.g. fault normal)
         >>> fault_normal = sympy.Matrix([0.6, 0.8])
-        >>> stokes.add_nitsche_bc("Fault", direction=fault_normal, gamma=10)
+        >>> stokes.add_nitsche_bc(0.0, "Fault", direction=fault_normal, gamma=10)
+
+        Notes
+        -----
+        The legacy boundary-first call ``add_nitsche_bc(boundary, g=...)`` is
+        detected conservatively (first positional argument a string while the
+        second is not — a BC datum is never a string) and shimmed with one
+        DeprecationWarning; see :meth:`_value_first_bc_args`.
 
         Warnings
         --------
@@ -5375,6 +5483,10 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
         """
         import sympy
         from collections import namedtuple
+
+        conds, boundary = self._value_first_bc_args(
+            "add_nitsche_bc", conds, boundary, alias=g)
+        g = conds
 
         self.is_setup = False
 

--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -3358,7 +3358,8 @@ class SNES_Vector(SolverBaseClass):
 
 
     def add_nitsche_bc(self, conds=None, boundary=None, direction=None,
-                       gamma=10.0, theta=1, local_h=True, g=None):
+                       normal=None, gamma=10.0, theta=1, mask=None,
+                       local_h=True, g=None):
         r"""Add Nitsche weak enforcement of a velocity constraint along a direction.
 
         For vector solvers (no pressure field), this constrains
@@ -3374,10 +3375,19 @@ class SNES_Vector(SolverBaseClass):
             Boundary label.
         direction : sympy.Matrix or list, optional
             Constraint direction. Default ``None`` uses surface normal.
+        normal : sympy.Matrix or list, optional
+            Boundary unit normal used in the Nitsche consistency and symmetry
+            terms — the same geometric-normal override as on the Stokes
+            variant. Default ``None`` uses the per-boundary,
+            deformation-tracking ``mesh.boundary_normal(boundary)``.
         gamma : float, default=10.0
             Dimensionless stabilisation parameter.
         theta : {-1, 0, 1}, default=1
             Symmetry parameter (1=symmetric, -1=skew-symmetric).
+        mask : sympy expression, optional
+            Accepted for signature parity with the Stokes variant, but
+            one-sided masking is **not implemented** on vector solvers:
+            passing a mask raises ``NotImplementedError``.
         local_h : bool, default=True
             Scale the penalty by a local per-cell mesh size
             (:meth:`Mesh.cell_size`) rather than the global minimum
@@ -3409,6 +3419,12 @@ class SNES_Vector(SolverBaseClass):
             "add_nitsche_bc", conds, boundary, alias=g)
         g = conds
 
+        if mask is not None:
+            raise NotImplementedError(
+                "mask= (one-sided internal-boundary application) is not "
+                "implemented on SNES_Vector.add_nitsche_bc; it is supported "
+                "on SNES_Stokes_SaddlePt.add_nitsche_bc only")
+
         self.is_setup = False
 
         mesh = self.mesh
@@ -3419,10 +3435,17 @@ class SNES_Vector(SolverBaseClass):
         dim = mesh.cdim
 
         # Surface normal components — use this boundary's own deformation-
-        # tracking facet normal (see Mesh.boundary_normal); the legacy global
+        # tracking facet normal (see Mesh.boundary_normal) unless the caller
+        # overrides the geometric-normal source; the legacy global
         # mesh.Gamma_P1 stays radial on a deformed surface.
-        bnorm = mesh.boundary_normal(boundary)
-        n = [bnorm[i] for i in range(dim)]
+        if normal is not None:
+            if isinstance(normal, sympy.MatrixBase):
+                n = [normal[i] for i in range(dim)]
+            else:
+                n = list(normal)
+        else:
+            bnorm = mesh.boundary_normal(boundary)
+            n = [bnorm[i] for i in range(dim)]
 
         # Constraint direction: defaults to surface normal
         if direction is not None:

--- a/src/underworld3/meshing/__init__.py
+++ b/src/underworld3/meshing/__init__.py
@@ -64,6 +64,13 @@ from .smoothing import (
     ADAPT_STRATEGIES,
 )
 
+from .bounding_surface import (
+    BoundingSurface,
+    register_radial_surfaces,
+    register_plane_surfaces,
+    register_box_face_surfaces,
+)
+
 # Make all functions available at module level for backward compatibility
 __all__ = [
     # Cartesian meshes
@@ -108,4 +115,9 @@ __all__ = [
     "mesh_metric_mismatch",
     "follow_metric",
     "ADAPT_STRATEGIES",
+    # Bounding surfaces (tangent-slip providers for deforming boundaries)
+    "BoundingSurface",
+    "register_radial_surfaces",
+    "register_plane_surfaces",
+    "register_box_face_surfaces",
 ]

--- a/src/underworld3/meshing/smoothing.py
+++ b/src/underworld3/meshing/smoothing.py
@@ -504,8 +504,9 @@ def _edge_pairs(dm):
 
 
 def _winslow_spring(mesh, metric, pinned_labels, verbose,
-                    n_sweeps=300, relax=None, step_frac=None,
-                    boundary_slip=False, shape_w=1.0, size_w=8.0):
+                    max_cg_iters=300,
+                    boundary_slip=False, shape_w=1.0, size_w=8.0,
+                    n_sweeps=None):
     r"""Metric-driven mesh grading by elastic-spring equilibrium.
 
     Every mesh edge is a linear spring whose *rest length* is set
@@ -540,12 +541,20 @@ def _winslow_spring(mesh, metric, pinned_labels, verbose,
     the mean edge length ⇒ only a benign mild regularisation toward
     uniform spacing (no grading change).
 
-    ``n_sweeps`` caps the CG iterations (CG converges far faster
-    than the old Jacobi sweep budget). ``relax`` / ``step_frac`` are
-    unused on the equilibrium path (the CG line search controls the
-    step and the inversion guard) and are kept only for signature
-    stability. ``n_iters`` / ``alpha`` do not apply.
+    ``max_cg_iters`` caps the CG iterations (CG converges far faster
+    than the old Jacobi sweep budget); ``n_sweeps`` is its deprecated
+    former name, accepted for one cycle with a DeprecationWarning.
+    The old ``relax`` / ``step_frac`` parameters were unused on the
+    equilibrium path (the CG line search controls the step and the
+    inversion guard) and have been removed. ``n_iters`` / ``alpha``
+    do not apply.
     """
+    if n_sweeps is not None:
+        warnings.warn(
+            "the 'n_sweeps' argument is renamed; use max_cg_iters= "
+            "(it caps the nonlinear-CG iterations, not Jacobi sweeps)",
+            DeprecationWarning, stacklevel=2)
+        max_cg_iters = n_sweeps
     pinned_labels = tuple(pinned_labels)
     dm = mesh.dm
     pStart, pEnd = dm.getDepthStratum(0)
@@ -738,7 +747,7 @@ def _winslow_spring(mesh, metric, pinned_labels, verbose,
         dmax = uw.mpi.comm.allreduce(dmax, op=_MPI.MAX)
     t0 = 0.5 * L0_mean / dmax
     c_arm = 1.0e-4
-    max_iter = int(n_sweeps)
+    max_iter = int(max_cg_iters)
     for it in range(max_iter):
         gnorm = _allsum((G * G).sum()) ** 0.5
         if gnorm <= 1.0e-8 * g0:

--- a/src/underworld3/swarm.py
+++ b/src/underworld3/swarm.py
@@ -397,7 +397,7 @@ class SwarmVariable(DimensionalityMixin, MathematicalMixin, Stateful, uw_object)
             Array object with callback for automatic PETSc synchronization
         """
         if initial_data is None:
-            initial_data = self.unpack_uw_data_from_petsc(squeeze=False, sync=True)
+            initial_data = self.unpack_uw_data_from_petsc(squeeze=False)
 
         # Create NDArray_With_Callback (following swarm._points pattern)
         array_obj = uw.utilities.NDArray_With_Callback(
@@ -432,7 +432,7 @@ class SwarmVariable(DimensionalityMixin, MathematicalMixin, Stateful, uw_object)
                 return
 
             # Persist changes to PETSc (like swarm callback updates coordinates)
-            var.pack_uw_data_to_petsc(array, sync=True)
+            var.pack_uw_data_to_petsc(array)
 
         # Register the callback (following swarm.points pattern)
         array_obj.add_callback(variable_update_callback)
@@ -457,7 +457,7 @@ class SwarmVariable(DimensionalityMixin, MathematicalMixin, Stateful, uw_object)
         """
         if initial_data is None:
             # Use unpack_raw to get flat format (-1, num_components)
-            initial_data = self.unpack_raw_data_from_petsc(squeeze=False, sync=True)
+            initial_data = self.unpack_raw_data_from_petsc(squeeze=False)
 
             # Handle case where unpack returns None (swarm not initialized)
             if initial_data is None:
@@ -504,7 +504,7 @@ class SwarmVariable(DimensionalityMixin, MathematicalMixin, Stateful, uw_object)
                 canonical_array = canonical_array.reshape(-1, self.num_components)
 
             # STEP 1: Sync to PETSc using established method with correct shape
-            self.pack_raw_data_to_petsc(canonical_array, sync=True)
+            self.pack_raw_data_to_petsc(canonical_array)
 
             # Coordinate writes may strand particles on the wrong rank. Mark
             # the swarm for DEFERRED migration — migrate() itself is
@@ -1271,7 +1271,18 @@ class SwarmVariable(DimensionalityMixin, MathematicalMixin, Stateful, uw_object)
 
     #     return
 
-    def pack_uw_data_to_petsc(self, data_array, sync=True):
+    @staticmethod
+    def _warn_deprecated_sync(sync):
+        """One-cycle keyword shim for the removed no-op ``sync=`` argument on
+        the four pack/unpack methods (it never had an effect)."""
+        if sync is not None:
+            import warnings
+            warnings.warn(
+                "the 'sync' argument never had an effect and is deprecated; "
+                "remove it",
+                DeprecationWarning, stacklevel=3)
+
+    def pack_uw_data_to_petsc(self, data_array, sync=None):
         """
         Enhanced pack method that directly accesses PETSc field without access() context.
         Designed for the new swarmVariable.array interface.
@@ -1280,9 +1291,10 @@ class SwarmVariable(DimensionalityMixin, MathematicalMixin, Stateful, uw_object)
         ----------
         data_array : numpy.ndarray
             Array data to pack into PETSc field
-        sync : bool
-            Whether to sync parallel operations (default True)
+        sync : deprecated
+            Never had an effect; deprecated (one DeprecationWarning if passed).
         """
+        self._warn_deprecated_sync(sync)
         shape = self.shape
         data_array_3d = data_array.reshape(-1, *self.shape)
 
@@ -1301,11 +1313,6 @@ class SwarmVariable(DimensionalityMixin, MathematicalMixin, Stateful, uw_object)
 
             # Update the proxy mesh variable if one exists (for integral calculations)
             self._update()
-
-            # Sync parallel operations if requested
-            if sync:
-                # TODO: Add parallel sync logic here if needed
-                pass
 
         finally:
             # Always restore the field
@@ -1334,7 +1341,7 @@ class SwarmVariable(DimensionalityMixin, MathematicalMixin, Stateful, uw_object)
     #     else:
     #         return data_array_3d
 
-    def unpack_uw_data_from_petsc(self, squeeze=True, sync=True):
+    def unpack_uw_data_from_petsc(self, squeeze=True, sync=None):
         """
         Enhanced unpack method that directly accesses PETSc field without access() context.
         Designed for the new swarmVariable.array interface.
@@ -1343,20 +1350,16 @@ class SwarmVariable(DimensionalityMixin, MathematicalMixin, Stateful, uw_object)
         ----------
         squeeze : bool
             Whether to squeeze singleton dimensions (default True)
-        sync : bool
-            Whether to sync parallel operations (default True)
+        sync : deprecated
+            Never had an effect; deprecated (one DeprecationWarning if passed).
         """
+        self._warn_deprecated_sync(sync)
         shape = self.shape
 
         # Direct PETSc field access without context manager
         petsc_data = self.swarm.dm.getField(self.clean_name).reshape((-1, self.num_components))
 
         try:
-            # Sync parallel operations if requested
-            if sync:
-                # TODO: Add parallel sync logic here if needed
-                pass
-
             # Unpack data using same layout as original method
             points = petsc_data.shape[0]
             data_array_3d = np.empty(shape=(points, *shape), dtype=petsc_data.dtype)
@@ -1375,7 +1378,7 @@ class SwarmVariable(DimensionalityMixin, MathematicalMixin, Stateful, uw_object)
         else:
             return data_array_3d
 
-    def pack_raw_data_to_petsc(self, data_array, sync=True):
+    def pack_raw_data_to_petsc(self, data_array, sync=None):
         """
         Pack data array to PETSc using traditional data shape (-1, num_components).
         Direct PETSc access without access() context for backward compatibility.
@@ -1384,9 +1387,10 @@ class SwarmVariable(DimensionalityMixin, MathematicalMixin, Stateful, uw_object)
         ----------
         data_array : numpy.ndarray
             Array data in traditional flat format (-1, num_components)
-        sync : bool
-            Whether to sync parallel operations (default True)
+        sync : deprecated
+            Never had an effect; deprecated (one DeprecationWarning if passed).
         """
+        self._warn_deprecated_sync(sync)
         import numpy as np
 
         # Convert to expected shape: (-1, num_components)
@@ -1409,18 +1413,13 @@ class SwarmVariable(DimensionalityMixin, MathematicalMixin, Stateful, uw_object)
             # Update the proxy mesh variable if one exists (for integral calculations)
             self._update()
 
-            # Sync parallel operations if requested
-            if sync:
-                # TODO: Add parallel sync logic here if needed
-                pass
-
         finally:
             # Always restore the field
             self.swarm.dm.restoreField(self.clean_name)
 
         return
 
-    def unpack_raw_data_from_petsc(self, squeeze=True, sync=True):
+    def unpack_raw_data_from_petsc(self, squeeze=True, sync=None):
         """
         Unpack data from PETSc in traditional data shape (-1, num_components).
         Direct PETSc access without access() context for backward compatibility.
@@ -1429,14 +1428,15 @@ class SwarmVariable(DimensionalityMixin, MathematicalMixin, Stateful, uw_object)
         ----------
         squeeze : bool
             Whether to remove singleton dimensions (default True)
-        sync : bool
-            Whether to sync parallel operations (default True)
+        sync : deprecated
+            Never had an effect; deprecated (one DeprecationWarning if passed).
 
         Returns
         -------
         numpy.ndarray
             Array data in traditional flat format (-1, num_components)
         """
+        self._warn_deprecated_sync(sync)
         import numpy as np
 
         # Check if swarm has any particles before accessing field
@@ -1457,11 +1457,6 @@ class SwarmVariable(DimensionalityMixin, MathematicalMixin, Stateful, uw_object)
         try:
             # Return data in traditional flat format
             result = petsc_data.copy()
-
-            # Sync parallel operations if requested
-            if sync:
-                # TODO: Add parallel sync logic here if needed
-                pass
 
         finally:
             # Always restore the field
@@ -1522,7 +1517,7 @@ class SwarmVariable(DimensionalityMixin, MathematicalMixin, Stateful, uw_object)
         import numpy as np
 
         # Get data directly from PETSc to avoid circular callback dependencies
-        raw_data = self.unpack_raw_data_from_petsc(squeeze=False, sync=False)
+        raw_data = self.unpack_raw_data_from_petsc(squeeze=False)
         data_size = raw_data.shape
 
         # What to do if there are no particles: never SILENTLY return zeros
@@ -2897,7 +2892,7 @@ class Swarm(Stateful, uw_object):
                     f"DMSwarm holds {self.dm.getLocalSize()} particles. The "
                     "particle layout changed while migration was disabled."
                 )
-            var.pack_raw_data_to_petsc(arr, sync=True)
+            var.pack_raw_data_to_petsc(arr)
             if self._coord_var is var:
                 self._needs_migration = True
             if hasattr(var, "_on_data_changed"):

--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -2332,22 +2332,25 @@ class SNES_Stokes_Constrained(SNES_Stokes):
         except (TypeError, ValueError, AttributeError):
             return 1.0
 
-    def add_constraint_bc(self, boundary, g=0.0, normal=None, screening=None,
-                          augmentation=None, augmentation_base=1.0e4, degree=None):
+    def add_constraint_bc(self, conds=None, boundary=None, normal=None, screening=None,
+                          augmentation=None, augmentation_base=1.0e4, degree=None,
+                          g=None):
         r"""Register a multiplier-enforced normal-velocity constraint on ``boundary``.
 
         Adds a scalar multiplier field ``h`` coupled into the saddle-point system
-        so that :math:`\mathbf{u}\cdot\mathbf{n}=g` is enforced on ``boundary`` in
-        the coupled solve; at convergence ``h`` on the boundary is the normal
-        traction (dynamic topography), recoverable via :meth:`multiplier` /
-        :meth:`topography`.
+        so that :math:`\mathbf{u}\cdot\mathbf{n}=\mathrm{conds}` is enforced on
+        ``boundary`` in the coupled solve; at convergence ``h`` on the boundary
+        is the normal traction (dynamic topography), recoverable via
+        :meth:`multiplier` / :meth:`topography`.
 
         Parameters
         ----------
+        conds : float or sympy expression, optional
+            Prescribed normal velocity :math:`\mathbf{u}\cdot\mathbf{n}`,
+            in the canonical value-first BC order. Default ``None`` means zero
+            (free-slip).
         boundary : str
             Mesh boundary label (e.g. ``"Upper"``).
-        g : float or sympy expression, default 0.0
-            Prescribed normal velocity :math:`\mathbf{u}\cdot\mathbf{n} = g`.
         normal : sympy matrix, optional
             Row-vector constraint normal. Defaults to ``mesh.Gamma_P1``.
         screening : float or sympy expression, optional
@@ -2366,12 +2369,25 @@ class SNES_Stokes_Constrained(SNES_Stokes):
             independent of this value (the multiplier carries the exact
             constraint); larger values reduce the iteration count up to a broad
             plateau, well below the roundoff limit.
+        g : float or sympy expression, optional
+            Deprecated keyword alias for ``conds`` (one DeprecationWarning).
 
         Returns
         -------
         h : MeshVariable
             The scalar multiplier field.
+
+        Notes
+        -----
+        The legacy boundary-first call ``add_constraint_bc(boundary, g=...)``
+        is detected conservatively (first positional argument a string while
+        the second is not — a BC datum is never a string) and shimmed with one
+        DeprecationWarning; see
+        ``SolverBaseClass._value_first_bc_args``.
         """
+        conds, boundary = self._value_first_bc_args(
+            "add_constraint_bc", conds, boundary, alias=g)
+        g = conds if conds is not None else 0.0
         # Parallel-safe: the interior-multiplier reduction
         # (_constrain_interior_multipliers_in_section) is rank-local section
         # surgery (it uses the distributed boundary label IS and iterates the

--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -175,14 +175,23 @@ class SNES_Poisson(SNES_Scalar):
         The computational mesh.
     u_Field : MeshVariable, optional
         Pre-existing mesh variable for the solution. If None, one is created.
-    verbose : bool, optional
-        Enable verbose output during solve.
     degree : int, optional
         Polynomial degree for the solution field (default: 2).
+    verbose : bool, optional
+        Enable verbose output during solve.
     DuDt : SemiLagrangian_DDt or Lagrangian_DDt, optional
         Time derivative operator for time-dependent problems.
     DFDt : SemiLagrangian_DDt or Lagrangian_DDt, optional
         Time derivative operator for the flux.
+
+    Notes
+    -----
+    The constructor follows the family-wide parameter order
+    ``(mesh, u_Field, degree, verbose, ...)`` (Style Charter, API
+    conventions); SNES_Poisson historically inverted ``(verbose, degree)``.
+    A legacy positional call is detected by ``type(degree) is bool`` (a
+    polynomial degree is never a bool) and shimmed with one
+    DeprecationWarning.
 
     """
 
@@ -191,12 +200,22 @@ class SNES_Poisson(SNES_Scalar):
         self,
         mesh: uw.discretisation.Mesh,
         u_Field: uw.discretisation.MeshVariable = None,
-        verbose=False,
         degree=2,
+        verbose=False,
         DuDt: Union[SemiLagrangian_DDt, Lagrangian_DDt] = None,
         DFDt: Union[SemiLagrangian_DDt, Lagrangian_DDt] = None,
     ):
-        ## Keep track
+        if type(degree) is bool:
+            # Legacy positional order (mesh, u_Field, verbose, degree): the
+            # bool in the degree slot is the legacy verbose flag; a legacy
+            # positional degree, if present, landed in the verbose slot.
+            import warnings
+            warnings.warn(
+                "SNES_Poisson(mesh, u_Field, verbose, degree) is deprecated; "
+                "use SNES_Poisson(mesh, u_Field, degree, verbose)",
+                DeprecationWarning, stacklevel=2)
+            degree, verbose = (
+                verbose if type(verbose) is not bool else 2), degree
 
         ## Parent class will set up default values etc
         super().__init__(

--- a/src/underworld3/units.py
+++ b/src/underworld3/units.py
@@ -1122,18 +1122,29 @@ def create_quantity(value, units: Union[str, Any], backend: Optional[str] = None
     """
     Create a dimensional quantity from a value and units.
 
+    .. deprecated:: 2026-07
+        ``uw.quantity`` is THE quantity factory (maintainer decision D14):
+        it returns a :class:`~underworld3.function.quantities.UWQuantity`,
+        which composes with expressions and non-dimensionalisation. This
+        function returns a raw Pint ``Quantity`` and will be removed after one
+        deprecation cycle.
+
     Args:
         value: Numeric value or array
         units: Units specification (string or units object)
         backend: Backend to use ('pint' or 'sympy'), defaults to 'pint'
 
     Returns:
-        Dimensional quantity
+        Dimensional quantity (raw Pint ``Quantity``)
 
     Examples:
         >>> velocity_qty = create_quantity([1.0, 2.0], "m/s")
         >>> pressure_qty = create_quantity(101325, "Pa")
     """
+    warnings.warn(
+        "create_quantity is deprecated; use uw.quantity(value, units) — note "
+        "it returns a UWQuantity rather than a raw Pint Quantity",
+        DeprecationWarning, stacklevel=2)
     # backend parameter is deprecated - Pint is the only supported backend
     if backend is not None and backend.lower() != "pint":
         raise ValueError(f"Unknown backend: {backend}. Only 'pint' is supported.")

--- a/src/underworld3/utilities/__init__.py
+++ b/src/underworld3/utilities/__init__.py
@@ -84,3 +84,13 @@ from .unit_aware_array import (
 
 from . import retention_curves
 from . import memprobe
+
+# Solver-scoped capability modules (rotated strong free-slip, consistent
+# boundary-flux recovery, custom multigrid). Their documented entry points are
+# methods on the solvers, which lazy-import these implementations; exporting
+# the modules here makes the docstring cross-references resolvable without a
+# deep import (Style Charter, API conventions: namespaces).
+from . import rotated_bc
+from . import boundary_flux
+from . import custom_mg
+from .custom_mg import set_custom_fmg

--- a/src/underworld3/utilities/boundary_flux.py
+++ b/src/underworld3/utilities/boundary_flux.py
@@ -253,10 +253,21 @@ def write_boundary_scalar_field(solver, field, value_by_key, dim):
     return field
 
 
-def boundary_flux_to_field(solver, boundary, field, mass="lumped",
-                           remove_mean=False, scale=1.0, normal=None):
-    """See ``SolverBaseClass.boundary_flux_field``. Writes ``scale * flux`` onto the
-    scalar MeshVariable ``field`` at the boundary nodes (interior untouched)."""
+def boundary_flux_field(solver, boundary, field, mass="lumped",
+                        remove_mean=False, scale=1.0, normal=None):
+    r"""See ``SolverBaseClass.boundary_flux_field`` (the documented entry point;
+    this free function is its implementation and shares its name). Writes
+    ``scale * flux`` onto the scalar MeshVariable ``field`` at the boundary
+    nodes (interior untouched).
+
+    ``scale`` is a generic multiplier on the recovered flux. For dynamic
+    topography it is the **negated reciprocal** of the buoyancy scale used by
+    the expression-return paths: ``scale = -1 / buoyancy_scale``, where
+    ``buoyancy_scale`` is :math:`\Delta\rho\, g` as taken by
+    ``dynamic_topography`` / ``topography`` (there the division and the minus
+    sign are internal). The two parameters are deliberately NOT aliased —
+    treating them as one factor invites sign/reciprocal errors.
+    """
     dim = solver.mesh.dim
     xs, flux = boundary_flux(solver, boundary, mass=mass, remove_mean=remove_mean, normal=normal)
     flux = np.asarray(flux)
@@ -270,3 +281,13 @@ def boundary_flux_to_field(solver, boundary, field, mass="lumped",
             "component, or use boundary_flux() directly for the full vector.")
     fmap = {_key(x, dim): scale * float(f) for x, f in zip(np.asarray(xs), flux.ravel())}
     return write_boundary_scalar_field(solver, field, fmap, dim)
+
+
+def boundary_flux_to_field(*args, **kwargs):
+    """Deprecated alias for :func:`boundary_flux_field` (renamed 2026-07 so the
+    free function matches the solver method it implements; kept one cycle)."""
+    import warnings
+    warnings.warn(
+        "boundary_flux_to_field is renamed; use boundary_flux_field(...)",
+        DeprecationWarning, stacklevel=2)
+    return boundary_flux_field(*args, **kwargs)

--- a/tests/test_0640_api_consistency_regression.py
+++ b/tests/test_0640_api_consistency_regression.py
@@ -137,7 +137,7 @@ class TestFactoryFunctionPatterns:
 
         factory_functions = [
             "create_enhanced_mesh_variable",
-            "create_quantity",  # From units system
+            "create_quantity",  # deprecated alias for one cycle (D14); see uw.quantity
         ]
 
         for func_name in factory_functions:
@@ -145,6 +145,12 @@ class TestFactoryFunctionPatterns:
 
             func = getattr(uw, func_name)
             assert callable(func), f"{func_name} is not callable"
+
+    def test_quantity_is_the_factory(self):
+        """uw.quantity is THE quantity factory (maintainer decision D14)."""
+
+        q = uw.quantity(1.0, "m")
+        assert isinstance(q, uw.UWQuantity)  # type exposed at top level
 
     def test_factory_function_documentation(self):
         """Test that factory functions have proper documentation."""
@@ -249,13 +255,18 @@ class TestUnitsSystemAPIConsistency:
     def test_units_creation_patterns(self):
         """Test consistent patterns for creating unit-aware objects."""
 
-        # Pattern 1: Direct units specification
+        # Pattern 1: Direct units specification (THE factory, decision D14)
         try:
-            quantity1 = uw.create_quantity(10.0, "m/s")
+            quantity1 = uw.quantity(10.0, "m/s")
             assert quantity1 is not None
 
         except Exception as e:
             pytest.fail(f"Direct units creation failed: {e}")
+
+        # Deprecated spelling still works for one cycle, with a warning
+        with pytest.warns(DeprecationWarning, match="uw.quantity"):
+            legacy = uw.create_quantity(10.0, "m/s")
+        assert legacy is not None
 
         # Pattern 2: uw.units multiplication
         try:
@@ -271,7 +282,9 @@ class TestUnitsSystemAPIConsistency:
         # Core units functionality should be accessible
         units_api = [
             "units",  # Units registry
-            "create_quantity",  # Factory function
+            "quantity",  # THE factory function (D14)
+            "UWQuantity",  # the factory's return type
+            "create_quantity",  # deprecated alias, kept one cycle
         ]
 
         for api_item in units_api:

--- a/tests/test_0641_wave_c_api_shims.py
+++ b/tests/test_0641_wave_c_api_shims.py
@@ -1,0 +1,423 @@
+"""Wave C API-harmonization contract tests (WC-01..WC-13).
+
+Every deprecation shim introduced by the 2026-07 Wave C API harmonization
+carries the two-test contract here:
+
+1. the OLD signature/spelling produces the identical result and emits exactly
+   one ``DeprecationWarning`` naming the replacement;
+2. the NEW canonical signature emits no ``DeprecationWarning`` at all.
+
+Canonical conventions under test (see ``docs/developer/UW3_STYLE_CHARTER.md``
+paragraph 6 and ``docs/reviews/2026-07/API-CONSISTENCY-REVIEW.md``):
+
+- BC argument order is value-first: ``add_<kind>_bc(conds, boundary, ...)``
+  (maintainer decision D2, 2026-07-04); the datum name is ``conds`` (D3).
+- ``consistent_jacobian`` is a validated property (WC-03).
+- ``set_custom_fmg`` is the solver-method entry point for custom MG (WC-04).
+- ``uw.quantity`` is THE quantity factory (D14, WC-06).
+"""
+
+import warnings
+
+import pytest
+import sympy
+
+import underworld3 as uw
+
+pytestmark = [pytest.mark.level_1, pytest.mark.tier_a]
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _one_deprecation(record):
+    """Count the DeprecationWarnings in a pytest.warns record."""
+    return sum(
+        1 for w in record if issubclass(w.category, DeprecationWarning)
+    )
+
+
+class _no_deprecation(warnings.catch_warnings):
+    """Context manager: any DeprecationWarning inside is a test failure."""
+
+    def __enter__(self):
+        log = super().__enter__()
+        warnings.simplefilter("error", DeprecationWarning)
+        return log
+
+
+@pytest.fixture(scope="module")
+def mesh():
+    return uw.meshing.StructuredQuadBox(
+        elementRes=(2, 2), minCoords=(0.0, 0.0), maxCoords=(1.0, 1.0)
+    )
+
+
+@pytest.fixture()
+def stokes(mesh):
+    solver = uw.systems.Stokes(mesh)
+    solver.constitutive_model = uw.constitutive_models.ViscousFlowModel
+    return solver
+
+
+# ---------------------------------------------------------------------------
+# WC-01 / WC-02 - value-first BC argument order, `conds` datum name
+# ---------------------------------------------------------------------------
+
+class TestStokesNitscheValueFirst:
+    def test_new_order_no_warning(self, mesh, stokes):
+        with _no_deprecation():
+            stokes.add_nitsche_bc(0.5, "Top")
+        assert stokes.natural_bcs[-1].boundary == "Top"
+
+    def test_legacy_positional_order_warns_once(self, mesh, stokes):
+        with pytest.warns(DeprecationWarning, match=r"add_nitsche_bc\(conds, boundary") as rec:
+            stokes.add_nitsche_bc("Top", 0.5)
+        assert _one_deprecation(rec) == 1
+
+    def test_legacy_g_keyword_warns_once(self, mesh, stokes):
+        with pytest.warns(DeprecationWarning, match=r"add_nitsche_bc\(conds, boundary") as rec:
+            stokes.add_nitsche_bc("Top", g=0.5)
+        assert _one_deprecation(rec) == 1
+
+    def test_legacy_and_new_give_identical_bc(self, mesh, stokes):
+        # Register the same condition through both spellings on ONE solver so
+        # every symbol (velocity, pressure, viscosity, normals) is shared -
+        # the stored BC tuples must be identical.
+        with pytest.warns(DeprecationWarning):
+            stokes.add_nitsche_bc("Top", 0.5)
+        with _no_deprecation():
+            stokes.add_nitsche_bc(0.5, "Top")
+
+        bc_old = stokes.natural_bcs[-2]
+        bc_new = stokes.natural_bcs[-1]
+        assert bc_old.boundary == bc_new.boundary
+        assert bc_old.fn_f == bc_new.fn_f
+        assert bc_old.fn_F == bc_new.fn_F
+        assert bc_old.fn_p == bc_new.fn_p
+
+    def test_datum_given_twice_is_an_error(self, mesh, stokes):
+        with pytest.raises(TypeError, match="conds"):
+            stokes.add_nitsche_bc(0.5, "Top", g=0.5)
+
+    def test_missing_boundary_is_an_error(self, mesh, stokes):
+        with pytest.raises(TypeError, match="boundary"):
+            stokes.add_nitsche_bc(0.5)
+
+
+class TestRotatedFreeslipValueFirst:
+    def test_new_order_no_warning(self, mesh, stokes):
+        with _no_deprecation():
+            stokes.add_rotated_freeslip_bc(0, "Top")
+        assert stokes._rotated_freeslip_bcs[-1] == ("Top", None)
+
+    def test_boundary_keyword_no_warning(self, mesh, stokes):
+        with _no_deprecation():
+            stokes.add_rotated_freeslip_bc(boundary="Bottom")
+        assert stokes._rotated_freeslip_bcs[-1] == ("Bottom", None)
+
+    def test_legacy_boundary_first_warns_once(self, mesh, stokes):
+        with pytest.warns(DeprecationWarning, match=r"add_rotated_freeslip_bc\(conds, boundary") as rec:
+            stokes.add_rotated_freeslip_bc("Top")
+        assert _one_deprecation(rec) == 1
+        assert stokes._rotated_freeslip_bcs[-1] == ("Top", None)
+
+    def test_legacy_positional_normal_is_preserved(self, mesh, stokes):
+        n = sympy.Matrix([[0, 1]])
+        with pytest.warns(DeprecationWarning) as rec:
+            stokes.add_rotated_freeslip_bc("Top", n)
+        assert _one_deprecation(rec) == 1
+        assert stokes._rotated_freeslip_bcs[-1] == ("Top", n)
+
+    def test_nonzero_datum_not_implemented(self, mesh, stokes):
+        with pytest.raises(NotImplementedError):
+            stokes.add_rotated_freeslip_bc(1.0, "Top")
+
+
+class TestConstraintBCValueFirst:
+    def test_new_order_no_warning(self, mesh):
+        solver = uw.systems.Stokes_Constrained(mesh)
+        solver.constitutive_model = uw.constitutive_models.ViscousFlowModel
+        with _no_deprecation():
+            h = solver.add_constraint_bc(0.0, "Top")
+        assert solver._block_constraint_bcs[-1].boundary == "Top"
+        assert h is not None
+
+    def test_legacy_order_warns_once(self, mesh):
+        solver = uw.systems.Stokes_Constrained(mesh)
+        solver.constitutive_model = uw.constitutive_models.ViscousFlowModel
+        with pytest.warns(DeprecationWarning, match=r"add_constraint_bc\(conds, boundary") as rec:
+            solver.add_constraint_bc("Top", 0.0)
+        assert _one_deprecation(rec) == 1
+        cbc = solver._block_constraint_bcs[-1]
+        assert cbc.boundary == "Top"
+        assert float(cbc.g) == 0.0
+
+    def test_legacy_g_keyword_warns_once(self, mesh):
+        solver = uw.systems.Stokes_Constrained(mesh)
+        solver.constitutive_model = uw.constitutive_models.ViscousFlowModel
+        with pytest.warns(DeprecationWarning) as rec:
+            solver.add_constraint_bc(boundary="Top", g=0.5)
+        assert _one_deprecation(rec) == 1
+        assert solver._block_constraint_bcs[-1].g == sympy.Float(0.5)
+
+
+class TestLegacyTrioUnchanged:
+    """The original trio is already canonical - it must NOT warn."""
+
+    def test_dirichlet_no_warning(self, mesh):
+        solver = uw.systems.Poisson(mesh)
+        with _no_deprecation():
+            solver.add_dirichlet_bc(0.0, "Top")
+            solver.add_essential_bc(1.0, "Bottom")
+            solver.add_natural_bc(0.0, "Left")
+
+    def test_components_kwarg_warns_once(self, mesh, stokes):
+        with pytest.warns(DeprecationWarning, match="components") as rec:
+            stokes.add_dirichlet_bc((0.0, 0.0), "Top", components=(0,))
+        assert _one_deprecation(rec) == 1
+
+
+# ---------------------------------------------------------------------------
+# WC-03 - consistent_jacobian validated property
+# ---------------------------------------------------------------------------
+
+class TestConsistentJacobianValidation:
+    def test_valid_values_round_trip(self, mesh, stokes):
+        for value in (False, True, "continuation"):
+            stokes.consistent_jacobian = value
+            assert stokes.consistent_jacobian == value
+
+    def test_falsy_normalizes_to_false(self, mesh, stokes):
+        for value in (None, 0, 0.0, ""):
+            stokes.consistent_jacobian = value
+            assert stokes.consistent_jacobian is False
+
+    def test_invalid_values_raise(self, mesh, stokes):
+        for value in ("picard", "Continuation", 1, "newton", 2.0):
+            with pytest.raises(ValueError, match="consistent_jacobian"):
+                stokes.consistent_jacobian = value
+
+    def test_default_is_false(self, mesh):
+        solver = uw.systems.Poisson(mesh)
+        assert solver.consistent_jacobian is False
+
+
+# ---------------------------------------------------------------------------
+# WC-04 - set_custom_fmg solver method; set_custom_mg deprecated
+# ---------------------------------------------------------------------------
+
+class TestCustomMGEntryPoint:
+    def test_set_custom_fmg_method_no_warning(self, mesh):
+        coarse = uw.meshing.StructuredQuadBox(
+            elementRes=(1, 1), minCoords=(0.0, 0.0), maxCoords=(1.0, 1.0)
+        )
+        solver = uw.systems.Poisson(mesh)
+        with _no_deprecation():
+            solver.set_custom_fmg([coarse])
+        assert solver._custom_mg["mode"] == "hierarchy"
+
+    def test_set_custom_mg_warns_once_and_still_registers(self, mesh):
+        coarse = uw.meshing.StructuredQuadBox(
+            elementRes=(1, 1), minCoords=(0.0, 0.0), maxCoords=(1.0, 1.0)
+        )
+        solver = uw.systems.Poisson(mesh)
+        with pytest.warns(DeprecationWarning, match="set_custom_fmg") as rec:
+            solver.set_custom_mg([coarse])
+        assert _one_deprecation(rec) == 1
+        assert solver._custom_mg["kind"] == "barycentric"
+
+
+# ---------------------------------------------------------------------------
+# WC-05 - namespace exposure (no deep imports needed)
+# ---------------------------------------------------------------------------
+
+class TestNamespaceExposure:
+    def test_utilities_modules_exposed(self):
+        assert hasattr(uw.utilities, "rotated_bc")
+        assert hasattr(uw.utilities, "boundary_flux")
+        assert hasattr(uw.utilities, "custom_mg")
+        assert callable(uw.utilities.set_custom_fmg)
+
+    def test_meshing_bounding_surface_exposed(self):
+        assert hasattr(uw.meshing, "BoundingSurface")
+        for name in (
+            "register_radial_surfaces",
+            "register_plane_surfaces",
+            "register_box_face_surfaces",
+        ):
+            assert callable(getattr(uw.meshing, name))
+            assert name in uw.meshing.__all__
+        assert "BoundingSurface" in uw.meshing.__all__
+
+
+# ---------------------------------------------------------------------------
+# WC-06 - uw.quantity is THE factory (D14)
+# ---------------------------------------------------------------------------
+
+class TestQuantityFactory:
+    def test_quantity_no_warning_and_type_exposed(self):
+        with _no_deprecation():
+            q = uw.quantity(1.0, "m")
+        assert isinstance(q, uw.UWQuantity)
+
+    def test_create_quantity_warns_once(self):
+        with pytest.warns(DeprecationWarning, match="uw.quantity") as rec:
+            q = uw.create_quantity(10.0, "m/s")
+        assert _one_deprecation(rec) == 1
+        # behaviour preserved for one cycle: still the raw Pint quantity
+        assert float(q.magnitude) == 10.0
+        assert str(q.units) in ("meter / second", "m / s")
+
+
+# ---------------------------------------------------------------------------
+# WC-07 - SNES_Poisson constructor order (mesh, u_Field, degree, verbose)
+# ---------------------------------------------------------------------------
+
+class TestPoissonConstructorOrder:
+    def test_positional_degree_no_warning(self, mesh):
+        with _no_deprecation():
+            solver = uw.systems.Poisson(mesh, None, 3)
+        assert solver.u.degree == 3
+        assert solver.verbose is False
+
+    def test_legacy_positional_verbose_warns_once(self, mesh):
+        with pytest.warns(DeprecationWarning, match=r"degree, verbose") as rec:
+            solver = uw.systems.Poisson(mesh, None, True)
+        assert _one_deprecation(rec) == 1
+        assert solver.verbose is True
+        assert solver.u.degree == 2  # legacy default preserved
+
+    def test_legacy_four_positional_args(self, mesh):
+        with pytest.warns(DeprecationWarning) as rec:
+            solver = uw.systems.Poisson(mesh, None, True, 3)
+        assert _one_deprecation(rec) == 1
+        assert solver.verbose is True
+        assert solver.u.degree == 3
+
+    def test_keyword_calls_unchanged(self, mesh):
+        with _no_deprecation():
+            solver = uw.systems.Poisson(mesh, degree=1, verbose=False)
+        assert solver.u.degree == 1
+
+
+# ---------------------------------------------------------------------------
+# WC-08 - SNES_Vector.add_nitsche_bc aligned with the Stokes variant
+# ---------------------------------------------------------------------------
+
+class TestVectorNitscheAlignment:
+    @pytest.fixture()
+    def vector_solver(self, mesh):
+        v = uw.discretisation.MeshVariable(
+            "v_wc08", mesh, mesh.dim, degree=2, vtype=uw.VarType.VECTOR
+        )
+        solver = uw.systems.Vector_Projection(mesh, v)
+        solver.constitutive_model = uw.constitutive_models.ViscousFlowModel
+        return solver
+
+    def test_normal_kwarg_accepted(self, mesh, vector_solver):
+        n = sympy.Matrix([[0, 1]])
+        with _no_deprecation():
+            vector_solver.add_nitsche_bc(0.0, "Top", normal=n)
+        assert vector_solver.natural_bcs[-1].boundary == "Top"
+
+    def test_mask_raises_not_implemented(self, mesh, vector_solver):
+        with pytest.raises(NotImplementedError, match="mask"):
+            vector_solver.add_nitsche_bc(0.0, "Top", mask=sympy.Integer(1))
+
+    def test_legacy_order_warns_once(self, mesh, vector_solver):
+        with pytest.warns(DeprecationWarning, match=r"add_nitsche_bc\(conds, boundary") as rec:
+            vector_solver.add_nitsche_bc("Top", 0.0)
+        assert _one_deprecation(rec) == 1
+
+
+# ---------------------------------------------------------------------------
+# WC-09 - boundary_flux_to_field renamed boundary_flux_field
+# ---------------------------------------------------------------------------
+
+class TestBoundaryFluxRename:
+    def test_new_name_importable_no_warning(self):
+        with _no_deprecation():
+            from underworld3.utilities.boundary_flux import boundary_flux_field
+        assert callable(boundary_flux_field)
+
+    def test_old_name_warns_once(self):
+        from underworld3.utilities.boundary_flux import boundary_flux_to_field
+
+        with pytest.warns(DeprecationWarning, match="boundary_flux_field") as rec:
+            # The warning is emitted before any work; the junk arguments then
+            # fail inside the real implementation, which is fine here.
+            with pytest.raises(Exception):
+                boundary_flux_to_field(None, "Top", None)
+        assert _one_deprecation(rec) == 1
+
+
+# ---------------------------------------------------------------------------
+# WC-12 - no-op `sync=` kwarg deprecated on swarm pack/unpack
+# ---------------------------------------------------------------------------
+
+class TestSwarmSyncDeprecated:
+    @pytest.fixture(scope="class")
+    def swarm_var(self, mesh):
+        swarm = uw.swarm.Swarm(mesh)
+        var = swarm.add_variable("s_wc12", 1)
+        swarm.populate(fill_param=1)
+        # yield keeps the parent swarm alive for the lifetime of the tests
+        # (the variable holds only a weak link to it)
+        yield var
+        del swarm
+
+    def test_unpack_no_sync_no_warning(self, swarm_var):
+        with _no_deprecation():
+            data = swarm_var.unpack_uw_data_from_petsc(squeeze=False)
+        assert data is not None
+
+    def test_unpack_sync_warns_once_identical_result(self, swarm_var):
+        import numpy as np
+
+        clean = swarm_var.unpack_uw_data_from_petsc(squeeze=False)
+        with pytest.warns(DeprecationWarning, match="sync") as rec:
+            legacy = swarm_var.unpack_uw_data_from_petsc(squeeze=False, sync=True)
+        assert _one_deprecation(rec) == 1
+        assert np.array_equal(np.asarray(clean), np.asarray(legacy))
+
+    def test_pack_sync_warns_once(self, swarm_var):
+        data = swarm_var.unpack_uw_data_from_petsc(squeeze=False)
+        with pytest.warns(DeprecationWarning, match="sync") as rec:
+            swarm_var.pack_uw_data_to_petsc(data, sync=True)
+        assert _one_deprecation(rec) == 1
+        with _no_deprecation():
+            swarm_var.pack_uw_data_to_petsc(data)
+
+
+# ---------------------------------------------------------------------------
+# WC-13 - smoothing: dead params dropped, n_sweeps renamed max_cg_iters
+# ---------------------------------------------------------------------------
+
+class TestWinslowSpringSignature:
+    def test_dead_params_gone_new_name_present(self):
+        import inspect
+
+        from underworld3.meshing.smoothing import _winslow_spring
+
+        params = inspect.signature(_winslow_spring).parameters
+        assert "relax" not in params
+        assert "step_frac" not in params
+        assert "max_cg_iters" in params
+        assert "n_sweeps" in params  # deprecated alias, one cycle
+
+    def test_n_sweeps_alias_warns_once(self):
+        import numpy as np
+
+        from underworld3.meshing.smoothing import _winslow_spring
+
+        tri_mesh = uw.meshing.UnstructuredSimplexBox(
+            minCoords=(0.0, 0.0), maxCoords=(1.0, 1.0), cellSize=0.5
+        )
+        pinned = ("Top", "Bottom", "Left", "Right")
+        with pytest.warns(DeprecationWarning, match="max_cg_iters") as rec:
+            _winslow_spring(tri_mesh, sympy.Integer(1), pinned, False, n_sweeps=1)
+        assert _one_deprecation(rec) == 1
+        with _no_deprecation():
+            _winslow_spring(tri_mesh, sympy.Integer(1), pinned, False, max_cg_iters=1)


### PR DESCRIPTION
Wave C of the 2026-07 quality campaign: harmonize the public API per the
maintainer decision record in `docs/reviews/2026-07/REMEDIATION-WORKLIST.md`
(D2 value-first BC order, D3 `conds` datum, D14 quantity factory) with the
evidence in `docs/reviews/2026-07/API-CONSISTENCY-REVIEW.md`. Every change is
shimmed — no hard breaks; legacy spellings keep working for at least one cycle
with exactly one `DeprecationWarning` naming the replacement.

## Item status

| Item | Status | Summary |
|------|--------|---------|
| WC-01 | resolved | `add_nitsche_bc` (Vector + Stokes), `add_rotated_freeslip_bc`, `add_constraint_bc` migrate to value-first `(conds, boundary, ...)`; conservative boundary-first shim (first positional is a `str` while the second is not) in shared `SolverBaseClass._value_first_bc_args` |
| WC-02 | resolved | ONE datum name `conds` (D3); `g=` kept as deprecated keyword alias on the three methods that had it; `components=` warning brought to Charter form (stacklevel, replacement named); Charter paragraph 6 placeholder replaced with the confirmed `conds` ruling |
| WC-03 | resolved | `consistent_jacobian` is a validated property accepting exactly `{False, True, "continuation"}`; falsy normalizes to `False`; anything else raises `ValueError` (previously silently selected full Newton); NumPy docstring from the former comment block |
| WC-04 | resolved | thin `SolverBaseClass.set_custom_fmg(...)` method (lazy-import, `boundary_flux` pattern); `set_custom_mg` warns naming the replacement; `utilities/custom_mg.py` itself untouched (coordination with `bugfix/custom-mg-parallel`) |
| WC-05 | resolved | `utilities/__init__` exports `rotated_bc`, `boundary_flux`, `custom_mg` (+ `set_custom_fmg`); `meshing/__init__`/`__all__` gain `BoundingSurface` + the three `register_*_surfaces` |
| WC-06 | resolved | `uw.quantity` is THE factory (D14); `uw.create_quantity` warns one cycle; `uw.UWQuantity` exposed; `test_0640` updated in the same commit |
| WC-07 | resolved | `SNES_Poisson.__init__` reordered to `(mesh, u_Field, degree, verbose)`; legacy shim keyed on `type(degree) is bool`; positional regression tests |
| WC-08 | resolved | `SNES_Vector.add_nitsche_bc` accepts `normal=` (same geometric-normal-override semantics as Stokes); `mask=` raises a clear `NotImplementedError` |
| WC-09 | resolved | free function `boundary_flux_to_field` renamed `boundary_flux_field` (old name warns one cycle); `scale = -1/buoyancy_scale` relationship documented on both the free function and the solver method; parameters deliberately NOT aliased |
| WC-10 | already resolved | `SNES_Vector.__init__` auto-creates the unknown when `u_Field` is None (landed before this branch; verified at the WC base) |
| WC-11 | already resolved | `units=` mesh kwarg deprecated-and-ignored with `DeprecationWarning` in `Mesh.__init__` and consistent docstrings (Wave A #325, ruling D7; verified at the WC base) |
| WC-12 | resolved | no-op `sync=` kwarg on the four swarm pack/unpack methods deprecated via `None`-sentinel keyword shim; dead `if sync: pass` stubs removed; internal call sites cleaned. The same-named MeshVariable copies belong to the FO-01 shared array-view refactor and are untouched |
| WC-13 | resolved | `_winslow_spring` drops dead `relax`/`step_frac`; `n_sweeps` renamed `max_cg_iters` with one-cycle alias warning |

## Shim contract

Every shim carries the two-test pattern in `tests/test_0641_wave_c_api_shims.py`
(markers `level_1` + `tier_a`): (1) the old spelling produces the identical
result and exactly one `DeprecationWarning` (checked with `pytest.warns` +
`match=` + a warning count); (2) the canonical spelling runs clean under
`warnings.simplefilter("error", DeprecationWarning)`. The file was validated
against the pre-shim build: 34/40 tests failed before the shims existed (the
6 pre-passers are the deliberate already-canonical regression checks).

All legacy positional patterns of the migrated methods are handled by a single
conservative swap because the old and new signatures align from the third
positional onward; detection is "first positional is a boundary-label string
while the second is not" (a BC datum is never a string — `add_condition`
rejects string conds).

## Gates

All run in this worktree's single `amr-dev` pixi env, with `rm -rf build/` +
`./uw build` after the `.pyx` edits and the installed extension verified
against source before trusting any run. The gate is scoped to `tests/`
(a pre-existing WIP script under `docs/examples/` fails bare-repo pytest
collection at the base commit — unrelated to this branch).

| Gate | Before | After |
|------|--------|-------|
| `pytest tests/ -m "level_1 and tier_a" -q` | 329 passed, 10 skipped, 2 xfailed, 1 xpassed | **369 passed** (329 + 40 new contract tests), 10 skipped, 2 xfailed, 1 xpassed |
| `pytest tests/test_00*.py tests/test_01*.py -q` | — | 181 passed |
| BC solver files (`test_1015/1017/1018/1019/1020/1060/1061/1062/1064/1065x2`) | — | 57 passed, 2 xfailed |
| `mpirun -np 2 python -m pytest --with-mpi` on `parallel/test_1017,1062,1063,1064,1065` | — | 17 passed (per rank) |
| Shim-test validation against the pre-shim build | 34 failed / 6 passed (as designed) | 40/40 passed |

No dependency or lockfile changes.

Refs: `docs/reviews/2026-07/API-CONSISTENCY-REVIEW.md`,
`docs/reviews/2026-07/REMEDIATION-WORKLIST.md` (Wave C + decision record),
`docs/developer/UW3_STYLE_CHARTER.md` paragraph 6.

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)
