### PR TITLE
fix(container): bump environment.yaml dependencies to match pixi.toml

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -2,46 +2,46 @@ name: uw3
 channels:
   - conda-forge
 dependencies:
-  - python <= 3.11
+  - python=3.12.*
   - compilers
   - mpich
-  - petsc=3.21.5
-  - petsc4py=3.21.5
-  - cython=3.*
+  - petsc=3.24
+  - petsc4py=3.24
+  - cython>=3.1,<4
   - mpmath<=1.3
   - mesalib
-  - pyvista
+  - pyvista>=0.46,<0.47
   - pykdtree
-  - pytest
-  - pytest-mpi
-  - numpy<2
-  - scipy>=1.15
-  - sympy>=1.13
+  - pytest>=8.3,<9
+  - pytest-mpi>=0.6,<0.7
+  - numpy>=2,<2.5
+  - scipy>=1.15,<2
+  - sympy>=1.13,<2
   - ipython
-  - mpi4py
+  - mpi4py>=4,<5
   - h5py=*=mpi*
   - gmsh
   - python-gmsh
-  - python-xxhash
-  - jupytext
+  - python-xxhash>=3.0
+  - jupytext>=1.16,<2
   - pygments
-  - pint>=0.24
+  - pint>=0.24,<0.25
   - cmocean
   - colorcet
   - imageio
   - imageio-ffmpeg
-  - ipywidgets<9.0.0
-  - jupyter-server-proxy
-  - jupyterlab<5.0.0
-  - trame>=2.5.2
-  - trame-vtk>=2.5.8
-  - trame-vuetify>=2.3.1
+  - ipywidgets>=8.1,<9
+  - jupyter-server-proxy>=4,<5
+  - jupyterlab>=4.3,<5
+  - trame>=3.8,<4
+  - trame-vtk>=2.8,<3
+  - trame-vuetify>=2.8,<3
   - trimesh
-  - typeguard
-  - pydantic>=2
-  - pyyaml
+  - typeguard>=4.4,<5
+  - pydantic>=2.0,<3
+  - pyyaml>=6.0,<7
   - pip
   - pip:
-      - rich<14
-      - meshio
-      - pygmsh
+      - rich
+      - meshio>=5.3,<6
+      - pygmsh>=7.1,<8


### PR DESCRIPTION
Fixes #355. Container build failing since PR #242 added PETSc APIs unavailable in the pinned 3.21.5.

- `petsc`/`petsc4py` 3.21.5 → 3.24 (primary fix)
- `python` `<=3.11` → `3.12.*`, `numpy` `<2` → `>=2,<2.5`, `trame` 2.x → 3.x
- Added upper bounds to align with `pixi.toml`

Only affects the container — developers use pixi.

## Test plan
- [ ] Container build succeeds
- [ ] `import underworld3` works inside the container

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)