### PR TITLE
ci(container): multi-arch support (amd64 + arm64) and version tagging

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -70,6 +70,8 @@ jobs:
           file: container/Containerfile
           platforms: linux/amd64,linux/arm64
           no-cache: ${{ inputs.force_rebuild || false }}
+          build-args: |
+            SETUPTOOLS_SCM_PRETEND_VERSION=${{ steps.meta.outputs.version }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # tags: |

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -23,6 +23,8 @@ on:
         description: 'Force full rebuild (no cache)'
         type: boolean
         default: false
+  release:
+    types: [published]
 
 jobs:
   build-and-push:
@@ -35,11 +37,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Extract branch name
-        run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
+      #- name: Extract branch name
+      #  run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/underworldcode/underworld3
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -54,8 +68,10 @@ jobs:
           context: .
           push: true
           file: container/Containerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           no-cache: ${{ inputs.force_rebuild || false }}
-          tags: |
-            ghcr.io/underworldcode/underworld3:${{ env.BRANCH }}
-            ghcr.io/underworldcode/underworld3:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # tags: |
+          #   ghcr.io/underworldcode/underworld3:${{ env.BRANCH }}
+          #   ghcr.io/underworldcode/underworld3:latest

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -37,9 +37,12 @@ RUN micromamba install -y -v -n base -f /tmp/env.yaml && \
 # activate mamba env during podman build
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
 
-# pyvista - taken from pyvista docker files
+# pyvista - vtk-osmesa only available for amd64; arm64 falls back to conda-forge vtk
 # see https://github.com/pyvista/pyvista/tree/main/docker
-RUN pip install --no-cache-dir --extra-index-url https://wheels.vtk.org vtk-osmesa
+ARG TARGETARCH
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+    pip install --no-cache-dir --extra-index-url https://wheels.vtk.org vtk-osmesa; \
+    fi
 
 # install UW3
 COPY --chown=$MAMBA_USER:$MAMBA_USER \

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -49,7 +49,9 @@ COPY --chown=$MAMBA_USER:$MAMBA_USER \
      --exclude=**/.git \
      . /home/$MAMBA_USER/underworld3
 WORKDIR /home/$MAMBA_USER/underworld3
-RUN pip install --no-build-isolation --no-cache-dir .
+ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0+unknown
+RUN SETUPTOOLS_SCM_PRETEND_VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION} \
+    pip install --no-build-isolation --no-cache-dir .
 
 # allow jupyterlab for ipyvtk
 ENV PYVISTA_OFF_SCREEN=true

--- a/src/underworld3/_version.py
+++ b/src/underworld3/_version.py
@@ -1,2 +1,0 @@
-## On initial, official release, let __version__ for underworld3 move to 3.0 (of underworld)
-__version__ = "0.99.0b"


### PR DESCRIPTION
Three improvements to the command-line container workflow:

- **Multi-arch**: builds for both `linux/amd64` and `linux/arm64` via QEMU; `vtk-osmesa` install skipped on arm64 (wheels unavailable) via `TARGETARCH` build arg
- **Version tagging**: replaces hardcoded tags with `docker/metadata-action`; adds `release: [published]` trigger so pushing a `v*` tag automatically builds a versioned image (`:3.1.0`, `:3.1`) via the `release.yml` chain
- **Version reporting**: removes committed `src/underworld3/_version.py` (already in `.gitignore`); passes `SETUPTOOLS_SCM_PRETEND_VERSION` as a build arg so containers report the correct version instead of the stale hardcoded `0.99.0b`

---
Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)