### PR TITLE
fix(mesh): parallel plex-point→coord-row mapping in kd-tree/face navigation (#360)

### DIFF
--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -827,9 +827,11 @@ class Mesh(Stateful, uw_object):
         # coords. On volume meshes _nav_dm is None and we reuse the
         # main coords.
         if self._nav_dm is not None:
-            self._nav_coords = numpy.array(
-                self._nav_dm.getCoordinatesLocal().array.reshape(-1, self.cdim)
-            )
+            # distributeOverlap grew the coordinate section to the ghost
+            # vertices but left their coordinates unscattered, so build a
+            # section-consistent local array (incl. ghost rows) here — a plain
+            # getCoordinatesLocal() is short by the ghost rows (issue #360).
+            self._nav_coords = self._navigation_coords_from_dm(self._nav_dm)
         else:
             self._nav_coords = self._coords
 
@@ -2363,13 +2365,15 @@ class Mesh(Stateful, uw_object):
                 self.dm.getCoordinatesLocal().array
             ).reshape(-1, self.cdim)
         else:
-            # manifold mesh: the nav clone carries its own (ghosted) coords;
-            # refresh them from the rebuilt main DM where possible.
+            # manifold mesh: the nav clone carries its own (ghosted) coords.
+            # Push the rebuilt/deformed geometry onto the clone via its GLOBAL
+            # coordinate vector (owned points share numbering with the main
+            # DM), then rebuild the section-consistent local array incl. the
+            # ghost rows. setCoordinatesLocal(main-local) is size-mismatched on
+            # an overlapped clone and leaves ghost rows unfilled (issue #360).
             try:
-                self._nav_dm.setCoordinatesLocal(self.dm.getCoordinatesLocal())
-                self._nav_coords = numpy.asarray(
-                    self._nav_dm.getCoordinatesLocal().array
-                ).reshape(-1, self.cdim)
+                self._nav_dm.setCoordinates(self.dm.getCoordinates())
+                self._nav_coords = self._navigation_coords_from_dm(self._nav_dm)
             except Exception:
                 pass
 
@@ -4502,6 +4506,50 @@ class Mesh(Stateful, uw_object):
 
         return
 
+    def _coord_rows_for_points(self, nav_dm, points):
+        """Row indices into the navigation coordinate array (``_nav_coords``)
+        for the given vertex plex points, via the coordinate PetscSection
+        offsets.
+
+        Correct in parallel: on the 1-cell-overlap navigation clone (manifold
+        meshes) the local coordinate array is laid out by the coordinate
+        section, so mapping a vertex with the affine shift ``plex_point -
+        pStart`` runs negative or past the end across ghost/halo vertices
+        (issue #360). The section offset is the authoritative vertex->row map.
+        In serial the section offset equals ``(plex_point - pStart) * cdim``,
+        so the rows returned here are bit-identical to the previous affine
+        indexing (verified) and serial navigation is unchanged.
+        """
+        coord_section = nav_dm.getCoordinateSection()
+        cdim = self.cdim
+        return numpy.fromiter(
+            (coord_section.getOffset(p) // cdim for p in points),
+            dtype=numpy.int64,
+            count=len(points),
+        )
+
+    def _navigation_coords_from_dm(self, nav_dm):
+        """Section-consistent LOCAL coordinate rows for a navigation DM.
+
+        On the 1-cell-overlap navigation clone (manifold meshes, parallel)
+        ``distributeOverlap`` expands the coordinate section to cover the
+        ghost vertices but does NOT scatter their coordinates into the local
+        vector, so a plain ``getCoordinatesLocal()`` is short by the ghost
+        rows and any vertex->row map overruns it (issue #360). Rebuild the
+        full local coordinate vector through the coordinate DM's
+        global->local scatter so every ghost vertex referenced by a local
+        cell closure carries coordinates. In serial (no overlap) this equals
+        ``getCoordinatesLocal()``.
+        """
+        from petsc4py import PETSc
+
+        coord_dm = nav_dm.getCoordinateDM()
+        local_coords = coord_dm.createLocalVec()
+        coord_dm.globalToLocal(
+            nav_dm.getCoordinates(), local_coords, addv=PETSc.InsertMode.INSERT
+        )
+        return numpy.array(local_coords.array).reshape(-1, self.cdim)
+
     def _build_kd_tree_index(self):
 
         if hasattr(self, "_index") and self._index is not None:
@@ -4531,7 +4579,7 @@ class Mesh(Stateful, uw_object):
             cell_faces = nav_dm.getCone(cell_id)
             points = nav_dm.getTransitiveClosure(cell_id)[0][-cell_num_points:]
             # Use raw internal array for KD-tree construction (avoid unit-aware wrapping)
-            cell_point_coords = nav_coords[points - pStart]
+            cell_point_coords = nav_coords[self._coord_rows_for_points(nav_dm, points)]
             cell_centroid = cell_point_coords.mean(axis=0)
             centroids_list.append(cell_centroid)
 
@@ -4707,13 +4755,13 @@ class Mesh(Stateful, uw_object):
             cell_faces = nav_dm.getCone(cell_id)
             points = nav_dm.getTransitiveClosure(cell_id)[0][-cell_num_points:]
             # Use raw internal array for internal mesh operations (avoid unit-aware wrapping)
-            cell_point_coords = nav_coords[points - pStart]
+            cell_point_coords = nav_coords[self._coord_rows_for_points(nav_dm, points)]
 
             for face in range(cell_num_faces):
 
                 points = nav_dm.getTransitiveClosure(cell_faces[face])[0][-face_num_points:]
                 # Use raw internal array for internal mesh operations (avoid unit-aware wrapping)
-                point_coords = nav_coords[points - pStart]
+                point_coords = nav_coords[self._coord_rows_for_points(nav_dm, points)]
 
                 face_centroid = point_coords.mean(axis=0)
                 cell_centroid = cell_point_coords.mean(axis=0)
@@ -4998,7 +5046,7 @@ class Mesh(Stateful, uw_object):
         for face in boundary_faces:
             cell = nav_dm.getJoin(face)[0]
             points = nav_dm.getTransitiveClosure(face)[0][-face_num_points:]
-            point_coords = nav_coords[points - pStart]  # Use raw array for internal calculations
+            point_coords = nav_coords[self._coord_rows_for_points(nav_dm, points)]  # raw array for internal calculations
             face_centroid = point_coords.mean(axis=0)
             cell_centroid = nav_centroids[cell - cStart]
 
@@ -5019,7 +5067,7 @@ class Mesh(Stateful, uw_object):
                 # boundary edge — needs the cell's third vertex to
                 # build the cell normal.
                 cell_points = nav_dm.getTransitiveClosure(cell)[0][-cell_num_points:]
-                cell_point_coords = nav_coords[cell_points - pStart]
+                cell_point_coords = nav_coords[self._coord_rows_for_points(nav_dm, cell_points)]
                 cell_normal = numpy.cross(
                     cell_point_coords[1] - cell_point_coords[0],
                     cell_point_coords[2] - cell_point_coords[0],

--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -4546,7 +4546,7 @@ class Mesh(Stateful, uw_object):
         coord_dm = nav_dm.getCoordinateDM()
         local_coords = coord_dm.createLocalVec()
         coord_dm.globalToLocal(
-            nav_dm.getCoordinates(), local_coords, addv=PETSc.InsertMode.INSERT
+            nav_dm.getCoordinates(), local_coords, addv=PETSc.InsertMode.INSERT_VALUES
         )
         return numpy.array(local_coords.array).reshape(-1, self.cdim)
 

--- a/tests/parallel/test_0775_deform_kdtree_parallel.py
+++ b/tests/parallel/test_0775_deform_kdtree_parallel.py
@@ -1,0 +1,106 @@
+"""Parallel navigation after mesh motion / on overlapped nav DMs (issue #360).
+
+Moving-mesh workflows rebuild the cell-search kd-tree every step
+(``nuke_coords_and_rebuild`` -> ``_build_kd_tree_index``). On the 1-cell-
+overlap navigation clone used for manifold (codim-1) meshes the local
+coordinate array is laid out by the coordinate PetscSection AND
+``distributeOverlap`` leaves the ghost-vertex coordinates unscattered, so the
+old affine ``nav_coords[plex_point - pStart]`` map ran out of bounds
+(``IndexError``) on every rank in parallel. These tests reproduce the crash
+(pre-fix) and assert that navigation actually works — not merely that no
+exception is raised.
+
+Run with:
+    mpirun -n 2 python -m pytest --with-mpi tests/parallel/test_0775_deform_kdtree_parallel.py
+    mpirun -n 4 python -m pytest --with-mpi tests/parallel/test_0775_deform_kdtree_parallel.py
+"""
+
+import numpy as np
+import pytest
+
+import underworld3 as uw
+
+pytestmark = [
+    pytest.mark.level_1,
+    pytest.mark.tier_a,
+    pytest.mark.mpi(min_size=2),
+    pytest.mark.timeout(120),
+]
+
+
+@pytest.mark.mpi(min_size=2)
+def test_deform_box_navigation_parallel():
+    """A distributed box mesh must survive a deform step and still locate
+    points via the rebuilt kd-tree on every rank."""
+    mesh = uw.meshing.UnstructuredSimplexBox(
+        minCoords=(0.0, 0.0), maxCoords=(1.0, 1.0), cellSize=0.2, qdegree=2,
+    )
+
+    X = np.asarray(mesh.X.coords, dtype=float).copy()
+    bump = 0.02 * np.sin(np.pi * X[:, 0]) * np.sin(np.pi * X[:, 1])
+    new = X.copy()
+    new[:, 0] += bump
+    new[:, 1] += bump
+
+    # Pre-fix this raised IndexError inside _build_kd_tree_index on every
+    # rank the moment the overlapped/section-ordered coord array was indexed.
+    mesh.deform(new)
+
+    # Positive navigation check: evaluate the coordinate field at this rank's
+    # own (deformed) vertices; point-location must return them exactly.
+    pts = np.asarray(mesh.X.coords, dtype=float)
+    vx = np.asarray(uw.function.evaluate(mesh.X[0], pts)).reshape(-1)
+    vy = np.asarray(uw.function.evaluate(mesh.X[1], pts)).reshape(-1)
+    err = max(np.abs(vx - pts[:, 0]).max(), np.abs(vy - pts[:, 1]).max())
+    assert err < 1e-8, f"navigation broken after deform: max coord error {err}"
+
+
+@pytest.mark.mpi(min_size=2)
+def test_manifold_surface_navigation_parallel():
+    """A codim-1 surface submesh forces the 1-cell-overlap navigation clone.
+    Building it (kd-tree + face control points) must not crash in parallel,
+    and every navigation coordinate row — including the overlap ghost rows —
+    must carry the correct geometry (issue #360)."""
+    r_outer = 1.0
+    ann = uw.meshing.Annulus(
+        radiusOuter=r_outer, radiusInner=0.5, cellSize=0.1, qdegree=2,
+    )
+
+    # Pre-fix: this raised IndexError in _build_kd_tree_index at construction
+    # (the overlapped nav coord array is short by the ghost rows).
+    surf = ann.extract_surface("Upper")
+    assert surf.dm.getDimension() == 1
+
+    nav_dm = surf._nav_dm if surf._nav_dm is not None else surf.dm
+    nav_coords = surf._nav_coords
+
+    # Completeness: a navigation coordinate row for every vertex the local
+    # cell closures reference (pre-fix the array was short -> out of bounds).
+    pStart, pEnd = nav_dm.getDepthStratum(0)
+    assert nav_coords.shape[0] >= (pEnd - pStart), (
+        f"nav coords ({nav_coords.shape[0]} rows) do not cover all "
+        f"{pEnd - pStart} nav vertices"
+    )
+
+    # Correctness: the "Upper" surface loop sits at r = radiusOuter; every
+    # navigation row (owned AND overlap ghost) must lie on that circle. A
+    # zero/garbage ghost row (the pre-fix failure mode) would violate this.
+    rows = surf._coord_rows_for_points(nav_dm, np.arange(pStart, pEnd))
+    r = np.sqrt((nav_coords[rows] ** 2).sum(axis=1))
+    assert np.allclose(r, r_outer, atol=1e-9), (
+        f"nav vertex radii off the surface: [{r.min()}, {r.max()}] != {r_outer}"
+    )
+
+    # Exercise a real navigation-driven operation on the manifold.
+    h = uw.discretisation.MeshVariable("h360", surf, 1, degree=1)
+    h.data[:, 0] = 1.0
+    uw.meshing.smooth_surface_field(h, n_iters=5, alpha=0.5, taubin=True)
+    assert np.allclose(h.data[:, 0], 1.0, atol=1e-8), (
+        "surface smoother did not preserve the constant field"
+    )
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v", "--with-mpi"]))


### PR DESCRIPTION
## Root cause

Every moving-mesh / manifold workflow crashed at `np>1` the first time navigation rebuilt the cell-search kd-tree (`nuke_coords_and_rebuild → _build_kd_tree_index`), with `IndexError: index N is out of bounds` (indices ran both negative and past the end, different per rank). The kd-tree build and the two mark-faces routines mapped vertex **plex-points** to **coordinate rows** with the affine shift `nav_coords[points - pStart]`, valid only when vertex numbering is serial-contiguous. On the 1-cell-overlap **navigation clone** used for manifold (codim-1) meshes the local coordinate array is ordered by the coordinate `PetscSection`, not by `plex_point − pStart`, so ghost/halo vertices push the affine index out of bounds. Serial is unaffected (no overlap; the section offset equals the affine shift exactly).

Investigation showed the bug has **two parts** — the section-offset remap alone is necessary but *not* sufficient, because `distributeOverlap` also leaves the ghost coordinates unscattered (the local coordinate vector is short by the ghost rows, so even section offsets overrun it). Both are fixed here.

## The fix

Two small private helpers on `Mesh`, applied method-locally:

1. **`_coord_rows_for_points(nav_dm, points)`** — maps each vertex to its row via the coordinate section offset (`getOffset(p) // cdim`), the authoritative vertex→row map for the (possibly overlapped) local coordinate array. In serial this equals `(plex_point − pStart) * cdim`, so rows are **bit-identical** to the old affine indexing.
2. **`_navigation_coords_from_dm(nav_dm)`** — rebuilds the full section-consistent local coordinate array (including ghost rows) through the coordinate DM's `globalToLocal` scatter, so every ghost vertex a local cell closure references actually carries coordinates. In serial (no overlap) this equals `getCoordinatesLocal()`.

### The four call-site groups (five physical sites)
- `_build_kd_tree_index` — the crash-trace site (1)
- `_mark_faces_inside_and_out` — cell closure + face closure (2)
- `_mark_local_boundary_faces_inside_and_out` — boundary-face closure + the `dim==2, cdim==3` cell-normal branch (2)

`_nav_coords` is now built with helper 2 at construction and, for the deform/adapt refresh in `nuke_coords_and_rebuild`, via `setCoordinates(main-global) + helper 2` so the overlapped clone tracks the moved geometry (the old `setCoordinatesLocal(main-local)` was size-mismatched on the overlapped clone and left ghost rows unfilled).

## Before / after evidence

- **Repro (before):** `extract_surface` on an Annulus at np2/np4 crashed at `_build_kd_tree_index` with e.g. `IndexError: index -20 is out of bounds for axis 0 with size 19` — matching the issue signature (both negative and past-end). Serial clean.
- **After:** the new regression test and the previously-red `test_0773_surface_smoother_mpi` pass at np2 and np4; serial navigation is provably unchanged.

## Gates (run serially, single `amr-dev` env)

| Gate | Result |
|---|---|
| Serial `level_1 and tier_a` | **373 passed**, 12 skipped, 2 xfailed, 1 xpassed, 0 failed (new test is parallel-only → skipped serially; identical pre/post) |
| Serial evaluate / RBF / point-location / kdtree families | **93 passed**, 1 xfailed (pre-existing 1-manifold point-location limitation) |
| Serial bit-identical probe | helper rows == affine rows (max diff **0**); evaluate coord error **0.00e+00** (box + annulus) |
| np2 navigation batch | **25 passed**, 1 skipped, 1 pre-existing failure (`test_0765` `_deform_mesh` guard — #331/#326, documented `TODO(BUG)` in the test) |
| np4 navigation batch | **25 passed**, 2 pre-existing failures (same `test_0765` guard; `test_0700` `test_nodal_swarm_advection_basic` = stale `SemiLagrangian.__init__` test API) |
| New `test_0775` | FAILS pre-fix (IndexError at `_build_kd_tree_index`, np2+np4); PASSES post-fix (np2+np4) |
| Dependencies / lockfile | unchanged |

The two pre-existing failures are unrelated to this change (one is the coordinate-mutation guard rejecting a direct `_deform_mesh` call — #331; the other a test using an outdated `SemiLagrangian` signature).

## Coordination

Wave D mesh PR #344 (open) refactors this same file (`discretisation_mesh.py`). This diff is small and method-local (five one-line call swaps + two new helpers + two `_nav_coords` assignment sites); #344 will need a trivial rebase over these sites (or vice versa) — please sequence them at merge.

Closes #360

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)
