### PR TITLE
Callback-array parallel safety: central view/copy guard, honest exceptions, no dead snapshots (#379 items 3+4b)

### DIFF
--- a/docs/developer/UW3_Developers_NDArrays.md
+++ b/docs/developer/UW3_Developers_NDArrays.md
@@ -438,21 +438,13 @@ The NDArray_With_Callback system intercepts NumPy operations:
 ```python
 
 def __setitem__(self, key, value):
-    # Capture old value for callback info
-    old_value = self[key].copy() if self._track_changes else None
-    
     # Perform the actual assignment
     super().__setitem__(key, value)
-    
-    # Trigger callbacks with operation info
-    if self._callbacks_enabled:
-        change_info = {
-            'operation': 'setitem',
-            'indices': key,
-            'old_value': old_value,
-            'new_value': self[key],
-        }
-        self._trigger_callback(change_info)
+
+    # Notify callbacks. old_value is always None: no registered callback
+    # ever read prior values, and snapshotting them cost a full-array
+    # copy per write (the key is retained for dict-shape compatibility).
+    self._trigger_callback("setitem", indices=key, new_value=value)
 ```
 
 ## PETSc Synchronization Details

--- a/docs/developer/UW3_Style_and_Patterns_Guide.md
+++ b/docs/developer/UW3_Style_and_Patterns_Guide.md
@@ -159,8 +159,14 @@ arr = NDArray_With_Callback(data, owner=self, callback=func)  # With callback
 
 # Callback signature
 def callback(array: NDArray_With_Callback, change_info: dict) -> None:
-    # change_info contains: operation, indices, old_value, new_value, array_shape, array_dtype
+    # change_info contains: operation, indices, old_value (always None,
+    # retained for compatibility), new_value, array_shape, array_dtype
     pass
+
+# For callbacks that synchronise a variable's CANONICAL storage, register
+# with add_canonical_callback(func): it guards against firing on derived
+# views/copies (rank-asymmetric collectives, #376) and hands the callback
+# the canonical array every time.
 ```
 
 ## Array vs Data Property Shapes

--- a/docs/developer/subsystems/data-access.md
+++ b/docs/developer/subsystems/data-access.md
@@ -181,7 +181,8 @@ Key implementation locations:
 - **MeshVariable**: `discretisation_mesh_variables.py`
   - `array` property (lines 700-720)
   - `data` property for compatibility (lines 680-700)
-  - Callback registration in `_create_variable_array()`
+  - Callback registration in `_create_canonical_data_array()` via
+    `NDArray_With_Callback.add_canonical_callback()` (central view/copy guard)
 
 - **SwarmVariable**: `swarm.py`
   - `array` property with caching (lines 857-871)

--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -244,7 +244,18 @@ def _mesh_coords_update_callback(array, change_context):
         uw.pprint(f"Mesh update callback - mesh deform")
 
     coords = array.reshape(-1, mesh.cdim)
-    mesh._deform_mesh(coords, verbose=verbose)
+    try:
+        mesh._deform_mesh(coords, verbose=verbose)
+    except Exception:
+        # The user's write landed in the canonical array BEFORE this
+        # callback ran. A rejected/failed deform must not leave
+        # mesh.X.coords disagreeing with the DM — the guard's message
+        # says the write "is rejected", so make that true by restoring
+        # the canonical from the DM, then let the error surface.
+        # (np.copyto bypasses callbacks; this restore must not re-fire.)
+        dm_coords = mesh.dm.getCoordinatesLocal().array.reshape(-1, mesh.cdim)
+        numpy.copyto(numpy.asarray(mesh._coords).reshape(-1, mesh.cdim), dm_coords)
+        raise
 
     # Increment mesh version to notify registered swarms of coordinate changes
     with mesh._mesh_update_lock:

--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -254,7 +254,12 @@ def _mesh_coords_update_callback(array, change_context):
         # the canonical from the DM, then let the error surface.
         # (np.copyto bypasses callbacks; this restore must not re-fire.)
         dm_coords = mesh.dm.getCoordinatesLocal().array.reshape(-1, mesh.cdim)
-        numpy.copyto(numpy.asarray(mesh._coords).reshape(-1, mesh.cdim), dm_coords)
+        cached = numpy.asarray(mesh._coords).reshape(-1, mesh.cdim)
+        if cached.shape == dm_coords.shape:
+            numpy.copyto(cached, dm_coords)
+        # else: the failure replaced the coordinate Vec at a different size
+        # (mid-rebuild) — restoring is impossible and a broadcast error here
+        # would mask the original exception (round-2 review).
         raise
 
     # Increment mesh version to notify registered swarms of coordinate changes

--- a/src/underworld3/discretisation/discretisation_mesh_variables.py
+++ b/src/underworld3/discretisation/discretisation_mesh_variables.py
@@ -527,143 +527,6 @@ class _BaseMeshVariable(Stateful, uw_object):
         else:
             self._remesh_policy = RemeshPolicy(value)
 
-    def _create_variable_array(self, initial_data=None):
-        """
-        Factory function to create NDArray_With_Callback for variable data.
-        Follows the same pattern as mesh.points implementation.
-
-        Parameters
-        ----------
-        initial_data : numpy.ndarray, optional
-            Initial data for the array. If None, fetches current data from PETSc.
-
-        Returns
-        -------
-        NDArray_With_Callback
-            Array object with callback for automatic PETSc synchronization
-        """
-        if initial_data is None:
-            initial_data = self.unpack_uw_data_from_petsc(squeeze=False, sync=True)
-
-        # Create NDArray_With_Callback (following mesh._points pattern)
-        array_obj = uw.utilities.NDArray_With_Callback(
-            initial_data,
-            owner=self,
-            disable_inplace_operators=False,  # Allow operations like existing arrays
-        )
-
-        # Single callback function (following mesh_update_callback pattern)
-        def variable_update_callback(array, change_context):
-            """Callback to sync variable changes back to PETSc (like mesh.points)"""
-            var = array.owner
-            if var is None:
-                # This guard handles cases where the array is accessed during
-                # object teardown (e.g. at application exit or mesh rebuilds),
-                # where the owning Python variable has already been garbage
-                # collected but the NDArray proxy still exists.
-                return
-
-            # Only act on data-changing operations (following mesh.points pattern)
-            data_changed = change_context.get("data_has_changed", True)
-            if not data_changed:
-                return
-
-            # Prevent recursion by checking if we're already in a callback
-            if hasattr(var, "_in_callback") and var._in_callback:
-                return
-
-            # Set recursion guard
-            var._in_callback = True
-
-            try:
-                # Skip updates during mesh coordinate changes to prevent corruption
-                # Check if mesh is currently being updated
-                if hasattr(var.mesh, "_mesh_update_lock"):
-                    # Try to acquire lock without blocking - if we can't, skip update
-                    if not var.mesh._mesh_update_lock.acquire(blocking=False):
-                        return
-                    try:
-                        # Persist changes to PETSc (like mesh callback updates coordinates)
-                        var.pack_uw_data_to_petsc(array, sync=True)
-                    finally:
-                        var.mesh._mesh_update_lock.release()
-                else:
-                    # Fallback if no lock exists
-                    var.pack_uw_data_to_petsc(array, sync=True)
-            finally:
-                # Clear recursion guard
-                var._in_callback = False
-
-        # Register the callback (following mesh.points pattern)
-        array_obj.add_callback(variable_update_callback)
-        return array_obj
-
-    def _create_flat_data_array(self, initial_data=None):
-        """
-        Factory function to create NDArray_With_Callback for backward-compatible flat data.
-        Returns data in shape (-1, num_components) using pack_raw/unpack_raw methods.
-
-        Parameters
-        ----------
-        initial_data : numpy.ndarray, optional
-            Initial data for the array. If None, fetches current data from PETSc.
-
-        Returns
-        -------
-        NDArray_With_Callback
-            Array object with callback for automatic PETSc synchronization
-        """
-        if initial_data is None:
-            # Use unpack_raw to get flat format (-1, num_components)
-            initial_data = self.unpack_raw_data_from_petsc(squeeze=False, sync=True)
-
-        # Create NDArray_With_Callback for flat data
-        array_obj = uw.utilities.NDArray_With_Callback(
-            initial_data,
-            owner=self,
-            disable_inplace_operators=False,  # Allow operations like existing arrays
-        )
-
-        # Callback for flat data format
-        def flat_data_update_callback(array, change_context):
-            """Callback to sync flat data changes back to PETSc"""
-            var = array.owner
-            if var is None:
-                return
-
-            # Only act on data-changing operations
-            data_changed = change_context.get("data_has_changed", True)
-            if not data_changed:
-                return
-
-            # Prevent recursion by checking if we're already in a callback
-            if hasattr(var, "_in_flat_callback") and var._in_flat_callback:
-                return
-
-            # Set recursion guard
-            var._in_flat_callback = True
-
-            try:
-                # Skip updates during mesh coordinate changes to prevent corruption
-                if hasattr(var.mesh, "_mesh_update_lock"):
-                    if not var.mesh._mesh_update_lock.acquire(blocking=False):
-                        return
-                    try:
-                        # Use pack_raw for flat data format
-                        var.pack_raw_data_to_petsc(array, sync=True)
-                    finally:
-                        var.mesh._mesh_update_lock.release()
-                else:
-                    # Fallback if no lock exists
-                    var.pack_raw_data_to_petsc(array, sync=True)
-            finally:
-                # Clear recursion guard
-                var._in_flat_callback = False
-
-        # Register the callback
-        array_obj.add_callback(flat_data_update_callback)
-        return array_obj
-
     def _object_viewer(self):
         """This will substitute specific information about this object"""
         from IPython.display import Latex, Markdown, display
@@ -2767,85 +2630,54 @@ class _BaseMeshVariable(Stateful, uw_object):
         from underworld3.utilities import NDArray_With_Callback
         array_obj = NDArray_With_Callback(flat_petsc_data, owner=self)
 
-        # Single canonical callback for PETSc synchronization
-
+        # Single canonical callback for PETSc synchronization. The
+        # add_canonical_callback dispatch guarantees `array` IS the canonical
+        # storage (views resolved to it, fancy-index copies skipped), so the
+        # pack below always covers the full local vector — never a
+        # partition-dependent subset whose collectives would run on some
+        # ranks only (#376).
         def canonical_data_callback(array, change_context):
             """ONLY callback that handles PETSc synchronization - prevents conflicts"""
             var = array.owner
             if var is None:
+                # Array outlived its variable (teardown / mesh rebuild)
                 return
 
-            # Only act on data-changing operations
-            data_changed = change_context.get("data_has_changed", True)
-            if not data_changed:
+            if not change_context.get("data_has_changed", True):
                 return
 
-            # Check for None array to prevent copy errors
-            if array is None:
-                return
+            var._flush_canonical_to_petsc(array)
 
-            import numpy as np
-
-            # Only the canonical storage may be packed to PETSc. Derived
-            # arrays inherit this callback via __array_finalize__, so an
-            # in-place op on a fancy-indexed COPY (``var.data[mask] /= s``)
-            # would try to pack the subset into the full-size vec. The mask
-            # is partition-dependent, so in parallel the failed pack skips
-            # the collective sync on some ranks only — mismatched
-            # collectives hang the run (#376). numpy writes the copy back
-            # through __setitem__ on the parent, which re-runs this
-            # callback with the canonical array, so skipping here loses
-            # nothing. A partial VIEW has already changed the canonical
-            # storage in place: sync the full canonical instead.
-            #
-            # View-vs-copy must be decided by IDENTITY in the base chain,
-            # not memory overlap: np.may_share_memory is False for any
-            # zero-size array, so a rank whose slice is locally empty
-            # would classify a view as a copy and skip the collective
-            # sync that the other ranks enter — the same rank-asymmetry
-            # again. For indexing statements (basic slice → view, fancy
-            # → copy) the classification follows the statement and is
-            # identical on every rank. Known corner (#379): reshape/
-            # ravel of a NON-contiguous derived view is a copy on
-            # non-empty ranks but a view on a zero-size rank, so that
-            # pattern is still rank-asymmetric — unresolvable here (the
-            # zero-size cases are locally indistinguishable); the
-            # dirty-flag flush planned in #379 is the real fix.
-            if array is not array_obj:
-                base = array.base
-                while base is not None and base is not array_obj:
-                    base = getattr(base, "base", None)
-                if base is None:
-                    return
-                array = np.asarray(array_obj)
-
-            # STEP 1: Ensure array has correct canonical shape before PETSc sync
-            # The callback might receive wrong-shaped arrays from array view operations
-            canonical_array = np.atleast_2d(array)
-
-            if canonical_array.shape != (canonical_array.shape[0], var.num_components):
-                # Only reshape if we actually need to
-                canonical_array = canonical_array.reshape(-1, var.num_components)
-
-            # Skip updates during mesh coordinate changes to prevent corruption
-            if hasattr(var.mesh, "_mesh_update_lock"):
-                if not var.mesh._mesh_update_lock.acquire(blocking=False):
-                    return
-                try:
-                    # STEP 1: Sync to PETSc using established method with correct shape
-                    var.pack_raw_data_to_petsc(canonical_array, sync=True)
-                finally:
-                    var.mesh._mesh_update_lock.release()
-            else:
-                # Fallback if no lock exists
-                var.pack_raw_data_to_petsc(canonical_array, sync=True)
-
-            # STEP 2: Handle variable-specific updates (extensible like SwarmVariable)
-            if hasattr(var, "_on_data_changed"):
-                var._on_data_changed()
-
-        array_obj.add_callback(canonical_data_callback)
+        array_obj.add_canonical_callback(canonical_data_callback)
         return array_obj
+
+    def _flush_canonical_to_petsc(self, array):
+        """Pack canonical-storage values into PETSc, with ghost synchronisation.
+
+        The single write-back path behind the canonical data callback. The
+        pack with ``sync=True`` performs a local-to-global / global-to-local
+        round trip, which is collective: every rank must call this for the
+        same variable.
+        """
+        canonical_array = numpy.atleast_2d(array)
+        if canonical_array.shape != (canonical_array.shape[0], self.num_components):
+            canonical_array = canonical_array.reshape(-1, self.num_components)
+
+        # A mesh-coordinate update owns the lock; packing mid-update would
+        # corrupt the coordinate change, so this write-back is skipped (the
+        # deform path re-syncs variables when it completes).
+        if hasattr(self.mesh, "_mesh_update_lock"):
+            if not self.mesh._mesh_update_lock.acquire(blocking=False):
+                return
+            try:
+                self.pack_raw_data_to_petsc(canonical_array, sync=True)
+            finally:
+                self.mesh._mesh_update_lock.release()
+        else:
+            self.pack_raw_data_to_petsc(canonical_array, sync=True)
+
+        if hasattr(self, "_on_data_changed"):
+            self._on_data_changed()
 
     @array.setter
     def array(self, array_value):

--- a/src/underworld3/swarm.py
+++ b/src/underworld3/swarm.py
@@ -380,63 +380,6 @@ class SwarmVariable(DimensionalityMixin, MathematicalMixin, Stateful, uw_object)
         """Check if this variable has units."""
         return self._units is not None
 
-    def _create_variable_array(self, initial_data=None):
-        """
-        Factory function to create NDArray_With_Callback for variable data.
-        Follows the same pattern as swarm.points implementation.
-
-        Parameters
-        ----------
-        initial_data : numpy.ndarray, optional
-            Initial data for the array. If None, fetches current data from PETSc.
-
-        Returns
-        -------
-        NDArray_With_Callback
-            Array object with callback for automatic PETSc synchronization
-        """
-        if initial_data is None:
-            initial_data = self.unpack_uw_data_from_petsc(squeeze=False)
-
-        # Create NDArray_With_Callback (following swarm._points pattern)
-        array_obj = uw.utilities.NDArray_With_Callback(
-            initial_data,
-            owner=self,
-            disable_inplace_operators=False,  # Allow operations like existing arrays
-        )
-
-        # Single callback function (following swarm_update_callback pattern)
-        def variable_update_callback(array, change_context):
-            """Callback to sync variable changes back to PETSc (like swarm.points)"""
-            var = array.owner
-            if var is None:
-                # This guard handles cases where the array is accessed during
-                # object teardown (e.g. at application exit or mesh rebuilds),
-                # where the owning Python variable has already been garbage
-                # collected but the NDArray proxy still exists.
-                return
-
-            # Only act on data-changing operations (following swarm.points pattern)
-            data_changed = change_context.get("data_has_changed", True)
-            if not data_changed:
-                return
-
-            # While migration is suppressed, DEFER the PETSc pack rather than
-            # discarding the write: the DMSwarm layout may be mid-change, so
-            # packing now could corrupt it, but the user's values must survive.
-            # They are flushed by Swarm._flush_pending_petsc_sync() when the
-            # migration-control context exits (SWARM-04).
-            if getattr(var.swarm, "_migration_disabled", False):
-                var.swarm._pending_petsc_sync.add(var.clean_name)
-                return
-
-            # Persist changes to PETSc (like swarm callback updates coordinates)
-            var.pack_uw_data_to_petsc(array)
-
-        # Register the callback (following swarm.points pattern)
-        array_obj.add_callback(variable_update_callback)
-        return array_obj
-
     def _create_canonical_data_array(self, initial_data=None):
         """
         Create the single canonical data array with PETSc synchronization.
@@ -469,7 +412,11 @@ class SwarmVariable(DimensionalityMixin, MathematicalMixin, Stateful, uw_object)
             disable_inplace_operators=False,  # Allow operations like existing arrays
         )
 
-        # Single canonical callback for PETSc synchronization
+        # Single canonical callback for PETSc synchronization. The
+        # add_canonical_callback dispatch guarantees `array` IS the canonical
+        # storage (views resolved to it, fancy-index copies skipped), so the
+        # pack below always covers every local particle — never a
+        # partition-dependent subset (#376).
         def canonical_data_callback(array, change_context):
             """ONLY callback that handles PETSc synchronization - prevents conflicts"""
             # Only act on data-changing operations
@@ -489,35 +436,7 @@ class SwarmVariable(DimensionalityMixin, MathematicalMixin, Stateful, uw_object)
                 self.swarm._pending_petsc_sync.add(self.clean_name)
                 return
 
-            # Check for None array to prevent copy errors
-            if array is None:
-                return
-
-            import numpy as np
-
-            # Only the canonical storage may be packed to PETSc (same
-            # guard as the MeshVariable callback, #376): a fancy-indexed
-            # COPY inherits this callback and would pack a wrong-sized
-            # subset — numpy's write-back via __setitem__ on the parent
-            # does the real sync. A partial VIEW has already updated the
-            # canonical storage in place, so pack the full canonical.
-            # View-vs-copy is decided by identity in the base chain
-            # (indexing statements classify the same on every rank), NOT
-            # by np.may_share_memory, which is False for any zero-size
-            # array and would re-create the rank asymmetry on ranks with
-            # no local particles. Known corner (#379): reshape/ravel of
-            # a non-contiguous derived view still classifies
-            # asymmetrically on zero-size ranks.
-            if array is not array_obj:
-                base = array.base
-                while base is not None and base is not array_obj:
-                    base = getattr(base, "base", None)
-                if base is None:
-                    return
-                array = np.asarray(array_obj)
-
             # STEP 1: Ensure array has correct canonical shape before PETSc sync
-            # The callback might receive wrong-shaped arrays from array view operations
             canonical_array = np.atleast_2d(array)
             if canonical_array.shape != (array.shape[0], self.num_components):
                 # Reshape to canonical format: (-1, num_components)
@@ -539,8 +458,8 @@ class SwarmVariable(DimensionalityMixin, MathematicalMixin, Stateful, uw_object)
             if hasattr(self, "_on_data_changed"):
                 self._on_data_changed()
 
-        # Register the single canonical callback
-        array_obj.add_callback(canonical_data_callback)
+        # Register through the central view/copy guard
+        array_obj.add_canonical_callback(canonical_data_callback)
         return array_obj
 
     def _create_array_view(self):
@@ -3253,6 +3172,11 @@ class Swarm(Stateful, uw_object):
                 disable_inplace_operators=True,
             )
 
+            # TODO(BUG): this callback calls collective migrate() per write and
+            # raises rank-locally on size mismatch — the pattern the swarm
+            # variable canonical callback was rewritten to avoid (SWARM-03).
+            # swarm.points is deprecated; the whole writable stack is removed
+            # by issue #379 item 1 (mesh.points treatment) rather than ported.
             # Define the callback function (only once)
             def swarm_update_callback(array, change_context):
                 # print(

--- a/src/underworld3/swarm.py
+++ b/src/underworld3/swarm.py
@@ -419,6 +419,15 @@ class SwarmVariable(DimensionalityMixin, MathematicalMixin, Stateful, uw_object)
         # partition-dependent subset (#376).
         def canonical_data_callback(array, change_context):
             """ONLY callback that handles PETSc synchronization - prevents conflicts"""
+            # Resolve the variable through the owner weakref (like the mesh
+            # callback) rather than closing over self: the callback list
+            # lives on the canonical array, so a strong self-capture here
+            # would be a var <-> array reference cycle.
+            var = array.owner
+            if var is None:
+                # Array outlived its variable (teardown / swarm rebuild)
+                return
+
             # Only act on data-changing operations
             data_changed = change_context.get("data_has_changed", True)
             if not data_changed:
@@ -432,18 +441,18 @@ class SwarmVariable(DimensionalityMixin, MathematicalMixin, Stateful, uw_object)
             # context exits (SWARM-04: previously these writes were silently
             # lost — nothing re-packed, and migrate()'s trailing invalidation
             # destroyed the only copy).
-            if getattr(self.swarm, "_migration_disabled", False):
-                self.swarm._pending_petsc_sync.add(self.clean_name)
+            if getattr(var.swarm, "_migration_disabled", False):
+                var.swarm._pending_petsc_sync.add(var.clean_name)
                 return
 
             # STEP 1: Ensure array has correct canonical shape before PETSc sync
             canonical_array = np.atleast_2d(array)
-            if canonical_array.shape != (array.shape[0], self.num_components):
+            if canonical_array.shape != (array.shape[0], var.num_components):
                 # Reshape to canonical format: (-1, num_components)
-                canonical_array = canonical_array.reshape(-1, self.num_components)
+                canonical_array = canonical_array.reshape(-1, var.num_components)
 
             # STEP 1: Sync to PETSc using established method with correct shape
-            self.pack_raw_data_to_petsc(canonical_array)
+            var.pack_raw_data_to_petsc(canonical_array)
 
             # Coordinate writes may strand particles on the wrong rank. Mark
             # the swarm for DEFERRED migration — migrate() itself is
@@ -451,12 +460,12 @@ class SwarmVariable(DimensionalityMixin, MathematicalMixin, Stateful, uw_object)
             # write unevenly → deadlock). The migration happens at the next
             # collective point: migration-control context exit or solve entry
             # (SWARM-03; the class docstring's automatic-migration promise).
-            if getattr(self.swarm, "_coord_var", None) is self:
-                self.swarm._needs_migration = True
+            if getattr(var.swarm, "_coord_var", None) is var:
+                var.swarm._needs_migration = True
 
             # STEP 2: Handle variable-specific updates (like IndexSwarmVariable proxy marking)
-            if hasattr(self, "_on_data_changed"):
-                self._on_data_changed()
+            if hasattr(var, "_on_data_changed"):
+                var._on_data_changed()
 
         # Register through the central view/copy guard
         array_obj.add_canonical_callback(canonical_data_callback)

--- a/src/underworld3/utilities/nd_array_callback.py
+++ b/src/underworld3/utilities/nd_array_callback.py
@@ -362,11 +362,16 @@ class NDArray_With_Callback(np.ndarray):
 
         _canonical_dispatch._is_canonical = True
         _canonical_dispatch._canonical_ref = canonical_ref
+        _canonical_dispatch._wrapped = callback
         self.add_callback(_canonical_dispatch)
 
     def remove_callback(self, callback: Callable):
         """
         Remove a specific callback function.
+
+        Accepts either the registered callable itself or the original
+        function handed to :meth:`add_canonical_callback` (the list stores
+        the guarding dispatch wrapper, not the original).
 
         Parameters
         ----------
@@ -375,6 +380,10 @@ class NDArray_With_Callback(np.ndarray):
         """
         if callback in self._callbacks:
             self._callbacks.remove(callback)
+            return
+        for registered in list(self._callbacks):
+            if getattr(registered, "_wrapped", None) is callback:
+                self._callbacks.remove(registered)
 
     def clear_callbacks(self):
         """Remove all registered callbacks."""
@@ -442,14 +451,13 @@ class NDArray_With_Callback(np.ndarray):
                     except Exception as e:
                         logger.warning(f"MPI barrier failed before delayed callback execution: {e}")
 
-                # Execute all delayed callbacks
+                # Execute all delayed callbacks. Exceptions PROPAGATE, as on
+                # the immediate path: a swallowed failure here leaves PETSc
+                # desynchronised on this rank only (#376-class).
                 for callback_item in delayed_callbacks:
-                    try:
-                        callback_item["callback"](
-                            callback_item["array"], callback_item["change_info"]
-                        )
-                    except Exception as e:
-                        logger.warning(f"Delayed callback error: {e}")
+                    callback_item["callback"](
+                        callback_item["array"], callback_item["change_info"]
+                    )
 
                 # MPI barrier to ensure all processes complete their callbacks
                 # before any process exits the context
@@ -509,14 +517,13 @@ class NDArray_With_Callback(np.ndarray):
                             f"MPI barrier failed before global delayed callback execution: {e}"
                         )
 
-                # Execute all delayed callbacks
+                # Execute all delayed callbacks. Exceptions PROPAGATE, as on
+                # the immediate path: a swallowed failure here leaves PETSc
+                # desynchronised on this rank only (#376-class).
                 for callback_item in delayed_callbacks:
-                    try:
-                        callback_item["callback"](
-                            callback_item["array"], callback_item["change_info"]
-                        )
-                    except Exception as e:
-                        logger.warning(f"Delayed callback error: {e}")
+                    callback_item["callback"](
+                        callback_item["array"], callback_item["change_info"]
+                    )
 
                 # MPI barrier to ensure all processes complete their callbacks
                 # before any process exits the context
@@ -853,8 +860,18 @@ class NDArray_With_Callback(np.ndarray):
                 disable_inplace_operators=self._disable_inplace_operators,
             )
 
-            # Copy all callbacks and settings
-            new_obj._callbacks = self._callbacks.copy()
+            # Re-home callbacks onto the new object. Canonical-guarded
+            # callbacks are bound (by weakref) to THIS array's identity —
+            # copying their wrappers verbatim would leave callbacks that
+            # never fire on the new object (every write would classify as
+            # a foreign copy). Re-register their original functions against
+            # the new canonical; plain callbacks copy across unchanged.
+            for registered in self._callbacks:
+                original = getattr(registered, "_wrapped", None)
+                if original is not None:
+                    new_obj.add_canonical_callback(original)
+                else:
+                    new_obj.add_callback(registered)
             new_obj._callback_enabled = self._callback_enabled
 
             # Trigger callback on the new object

--- a/src/underworld3/utilities/nd_array_callback.py
+++ b/src/underworld3/utilities/nd_array_callback.py
@@ -311,6 +311,56 @@ class NDArray_With_Callback(np.ndarray):
         if callback is not None and callback not in self._callbacks:
             self._callbacks.append(callback)
 
+    def add_canonical_callback(self, callback: Callable):
+        """
+        Register a callback that only ever fires for the canonical storage.
+
+        ``self`` must be the canonical array at registration time. Derived
+        arrays inherit the callback list via ``__array_finalize__``, so an
+        unguarded callback also fires on views and temporary fancy-index
+        copies. A copy's contents are partition-dependent, so a PETSc sync
+        run from inside the callback executes its collectives on some ranks
+        only — the #376 parallel hang. This wrapper applies the guard once,
+        centrally:
+
+        - write through a **view** of the canonical array: the data already
+          landed in canonical storage, so the callback fires with the FULL
+          canonical array;
+        - write to a **copy**: skipped — numpy's fancy-index write-back
+          re-fires the callback through the parent's ``__setitem__``, so
+          nothing is lost;
+        - view-vs-copy is decided by IDENTITY in numpy's base chain, never
+          ``np.may_share_memory``, which is False for any zero-size array
+          and would re-create the rank asymmetry on ranks whose local
+          slice is empty.
+
+        Parameters
+        ----------
+        callback : callable
+            Function with signature ``callback(array, change_info)``;
+            ``array`` is always the canonical storage.
+        """
+        # weakref: the callback list lives ON the array, so a strong capture
+        # of self inside the closure would be an uncollectable cycle
+        canonical_ref = weakref.ref(self)
+
+        def _canonical_dispatch(array, change_info):
+            canonical = canonical_ref()
+            if canonical is None:
+                return
+            if array is not canonical:
+                base = array.base
+                while base is not None and base is not canonical:
+                    base = getattr(base, "base", None)
+                if base is None:
+                    return
+                array = canonical
+            callback(array, change_info)
+
+        _canonical_dispatch._is_canonical = True
+        _canonical_dispatch._canonical_ref = canonical_ref
+        self.add_callback(_canonical_dispatch)
+
     def remove_callback(self, callback: Callable):
         """
         Remove a specific callback function.

--- a/src/underworld3/utilities/nd_array_callback.py
+++ b/src/underworld3/utilities/nd_array_callback.py
@@ -337,6 +337,14 @@ class NDArray_With_Callback(np.ndarray):
           and would re-create the rank asymmetry on ranks whose local
           slice is empty.
 
+        Known corner (from the #378 analysis): ``reshape``/``ravel`` of a
+        NON-contiguous derived view produces a copy on non-empty ranks but
+        a view on a zero-size rank, so that one pattern remains
+        rank-asymmetric at the per-write level — locally
+        indistinguishable. The ``uw.synchronised_array_update`` dirty-flag
+        flush (#383) is the real fix: agreement happens per variable at
+        context exit, not per write.
+
         Parameters
         ----------
         callback : callable

--- a/src/underworld3/utilities/nd_array_callback.py
+++ b/src/underworld3/utilities/nd_array_callback.py
@@ -118,7 +118,10 @@ class NDArray_With_Callback(np.ndarray):
 
     - ``operation`` (str): Operation name ('setitem', 'iadd', 'fill', etc.)
     - ``indices`` (tuple/slice/None): Location of change (for setitem operations)
-    - ``old_value`` (array-like/None): Previous values (when available)
+    - ``old_value`` (None): Always None. Internal operations no longer snapshot
+      prior values (no registered callback ever read them, and the copy was a
+      full-array allocation per write); the key is retained for dict-shape
+      compatibility.
     - ``new_value`` (array-like): New values being assigned
     - ``array_shape`` (tuple): Current shape of the array
     - ``array_dtype`` (np.dtype): Data type of the array
@@ -541,8 +544,9 @@ class NDArray_With_Callback(np.ndarray):
             Name of the operation that triggered the callback
         indices : tuple or slice, optional
             Indices that were modified
-        old_value : array-like, optional
-            Previous value(s) at the modified location
+        old_value : None
+            Always None from internal operations (see class docstring);
+            the parameter and dict key remain for compatibility
         new_value : array-like, optional
             New value(s) at the modified location
         data_has_changed : bool, optional
@@ -567,23 +571,15 @@ class NDArray_With_Callback(np.ndarray):
             for callback in self._callbacks:
                 _delayed_callback_manager.add_delayed_callback(self, callback, change_info)
         else:
-            # Execute callbacks immediately
+            # Execute callbacks immediately. Exceptions PROPAGATE: a swallowed
+            # callback failure leaves PETSc out of sync with the canonical
+            # array on this rank only — the silent desynchronisation that hid
+            # the #376 parallel hang.
             for callback in self._callbacks.copy():  # Copy in case callbacks modify the list
-                try:
-                    callback(self, change_info)
-                except Exception as e:
-                    logger.warning(f"Callback error in {callback}: {e}")
+                callback(self, change_info)
 
     def __setitem__(self, key, value):
         """Override setitem to trigger callbacks on assignment."""
-        if self._callback_enabled and self._callbacks:
-            try:
-                old_value = self[key].copy() if hasattr(self[key], "copy") else self[key]
-            except (IndexError, ValueError):
-                old_value = None
-        else:
-            old_value = None
-
         # Handle UnitAwareArray values by extracting magnitude
         # This allows: T.array[...] = uw.function.evaluate(...) where evaluate returns UnitAwareArray
         # Without this, numpy raises "only length-1 arrays can be converted to Python scalars"
@@ -596,7 +592,7 @@ class NDArray_With_Callback(np.ndarray):
         super().__setitem__(key, actual_value)
 
         # Trigger callbacks
-        self._trigger_callback("setitem", indices=key, old_value=old_value, new_value=value)
+        self._trigger_callback("setitem", indices=key, new_value=value)
 
     def __iadd__(self, other):
         """In-place addition with callback."""
@@ -606,13 +602,8 @@ class NDArray_With_Callback(np.ndarray):
                 "Use explicit assignment instead: arr = arr + other"
             )
 
-        if self._callback_enabled and self._callbacks:
-            old_value = self.copy()
-        else:
-            old_value = None
-
         result = super().__iadd__(other)
-        self._trigger_callback("iadd", old_value=old_value, new_value=other)
+        self._trigger_callback("iadd", new_value=other)
         return result
 
     def __isub__(self, other):
@@ -623,13 +614,8 @@ class NDArray_With_Callback(np.ndarray):
                 "Use explicit assignment instead: arr = arr - other"
             )
 
-        if self._callback_enabled and self._callbacks:
-            old_value = self.copy()
-        else:
-            old_value = None
-
         result = super().__isub__(other)
-        self._trigger_callback("isub", old_value=old_value, new_value=other)
+        self._trigger_callback("isub", new_value=other)
         return result
 
     def __imul__(self, other):
@@ -640,13 +626,8 @@ class NDArray_With_Callback(np.ndarray):
                 "Use explicit assignment instead: arr = arr * other"
             )
 
-        if self._callback_enabled and self._callbacks:
-            old_value = self.copy()
-        else:
-            old_value = None
-
         result = super().__imul__(other)
-        self._trigger_callback("imul", old_value=old_value, new_value=other)
+        self._trigger_callback("imul", new_value=other)
         return result
 
     def __itruediv__(self, other):
@@ -657,13 +638,8 @@ class NDArray_With_Callback(np.ndarray):
                 "Use explicit assignment instead: arr = arr / other"
             )
 
-        if self._callback_enabled and self._callbacks:
-            old_value = self.copy()
-        else:
-            old_value = None
-
         result = super().__itruediv__(other)
-        self._trigger_callback("itruediv", old_value=old_value, new_value=other)
+        self._trigger_callback("itruediv", new_value=other)
         return result
 
     def __ifloordiv__(self, other):
@@ -674,13 +650,8 @@ class NDArray_With_Callback(np.ndarray):
                 "Use explicit assignment instead: arr = arr // other"
             )
 
-        if self._callback_enabled and self._callbacks:
-            old_value = self.copy()
-        else:
-            old_value = None
-
         result = super().__ifloordiv__(other)
-        self._trigger_callback("ifloordiv", old_value=old_value, new_value=other)
+        self._trigger_callback("ifloordiv", new_value=other)
         return result
 
     def __imod__(self, other):
@@ -691,13 +662,8 @@ class NDArray_With_Callback(np.ndarray):
                 "Use explicit assignment instead: arr = arr % other"
             )
 
-        if self._callback_enabled and self._callbacks:
-            old_value = self.copy()
-        else:
-            old_value = None
-
         result = super().__imod__(other)
-        self._trigger_callback("imod", old_value=old_value, new_value=other)
+        self._trigger_callback("imod", new_value=other)
         return result
 
     def __ipow__(self, other):
@@ -708,13 +674,8 @@ class NDArray_With_Callback(np.ndarray):
                 "Use explicit assignment instead: arr = arr ** other"
             )
 
-        if self._callback_enabled and self._callbacks:
-            old_value = self.copy()
-        else:
-            old_value = None
-
         result = super().__ipow__(other)
-        self._trigger_callback("ipow", old_value=old_value, new_value=other)
+        self._trigger_callback("ipow", new_value=other)
         return result
 
     def __iand__(self, other):
@@ -725,13 +686,8 @@ class NDArray_With_Callback(np.ndarray):
                 "Use explicit assignment instead: arr = arr & other"
             )
 
-        if self._callback_enabled and self._callbacks:
-            old_value = self.copy()
-        else:
-            old_value = None
-
         result = super().__iand__(other)
-        self._trigger_callback("iand", old_value=old_value, new_value=other)
+        self._trigger_callback("iand", new_value=other)
         return result
 
     def __ior__(self, other):
@@ -742,13 +698,8 @@ class NDArray_With_Callback(np.ndarray):
                 "Use explicit assignment instead: arr = arr | other"
             )
 
-        if self._callback_enabled and self._callbacks:
-            old_value = self.copy()
-        else:
-            old_value = None
-
         result = super().__ior__(other)
-        self._trigger_callback("ior", old_value=old_value, new_value=other)
+        self._trigger_callback("ior", new_value=other)
         return result
 
     def __ixor__(self, other):
@@ -759,13 +710,8 @@ class NDArray_With_Callback(np.ndarray):
                 "Use explicit assignment instead: arr = arr ^ other"
             )
 
-        if self._callback_enabled and self._callbacks:
-            old_value = self.copy()
-        else:
-            old_value = None
-
         result = super().__ixor__(other)
-        self._trigger_callback("ixor", old_value=old_value, new_value=other)
+        self._trigger_callback("ixor", new_value=other)
         return result
 
     def __ilshift__(self, other):
@@ -776,13 +722,8 @@ class NDArray_With_Callback(np.ndarray):
                 "Use explicit assignment instead: arr = arr << other"
             )
 
-        if self._callback_enabled and self._callbacks:
-            old_value = self.copy()
-        else:
-            old_value = None
-
         result = super().__ilshift__(other)
-        self._trigger_callback("ilshift", old_value=old_value, new_value=other)
+        self._trigger_callback("ilshift", new_value=other)
         return result
 
     def __irshift__(self, other):
@@ -793,46 +734,24 @@ class NDArray_With_Callback(np.ndarray):
                 "Use explicit assignment instead: arr = arr >> other"
             )
 
-        if self._callback_enabled and self._callbacks:
-            old_value = self.copy()
-        else:
-            old_value = None
-
         result = super().__irshift__(other)
-        self._trigger_callback("irshift", old_value=old_value, new_value=other)
+        self._trigger_callback("irshift", new_value=other)
         return result
 
     def fill(self, value):
         """Fill array with scalar value, triggering callback."""
-        if self._callback_enabled and self._callbacks:
-            old_value = self.copy()
-        else:
-            old_value = None
-
         super().fill(value)
-        self._trigger_callback("fill", old_value=old_value, new_value=value)
+        self._trigger_callback("fill", new_value=value)
 
     def sort(self, axis=-1, kind=None, order=None):
         """Sort array in-place, triggering callback."""
-        if self._callback_enabled and self._callbacks:
-            old_value = self.copy()
-        else:
-            old_value = None
-
         super().sort(axis=axis, kind=kind, order=order)
-        self._trigger_callback("sort", old_value=old_value)
+        self._trigger_callback("sort")
 
     def resize(self, new_shape, refcheck=True):
         """Resize array in-place, triggering callback."""
-        if self._callback_enabled and self._callbacks:
-            old_value = self.copy()
-            old_shape = self.shape
-        else:
-            old_value = None
-            old_shape = None
-
         super().resize(new_shape, refcheck=refcheck)
-        self._trigger_callback("resize", old_value=old_value, new_value=new_shape)
+        self._trigger_callback("resize", new_value=new_shape)
 
     def copy(self, order="C"):
         """
@@ -911,12 +830,6 @@ class NDArray_With_Callback(np.ndarray):
         """
         new_array = np.asarray(new_data)
 
-        # Store old info for callback
-        if self._callback_enabled and self._callbacks:
-            old_data = self.copy()
-        else:
-            old_data = None
-
         if new_array.shape == self.shape and new_array.dtype == self.dtype:
             # Same size and dtype: ultra-efficient in-place copy
             np.copyto(self, new_array)
@@ -924,7 +837,6 @@ class NDArray_With_Callback(np.ndarray):
             # Trigger callback for the sync operation
             self._trigger_callback(
                 "sync_data",
-                old_value=old_data,
                 new_value=new_array,
                 indices=None,  # Full array update
                 data_has_changed=False,  # Sync operation doesn't represent user data change
@@ -948,7 +860,6 @@ class NDArray_With_Callback(np.ndarray):
             # Trigger callback on the new object
             new_obj._trigger_callback(
                 "sync_data",
-                old_value=old_data,
                 new_value=new_array,
                 indices=None,
                 data_has_changed=False,  # Sync operation doesn't represent user data change

--- a/tests/test_0059_canonical_callback_guard.py
+++ b/tests/test_0059_canonical_callback_guard.py
@@ -113,3 +113,56 @@ def test_no_reference_cycle_with_canonical():
     del arr
     gc.collect()
     assert ref() is None
+
+
+def test_callback_exceptions_propagate_immediately_and_delayed():
+    """A failing callback must surface — immediately, and at delay-context
+    exit. The swallowed-warning path left PETSc silently desynchronised on
+    one rank (#376-class)."""
+    import underworld3 as uw
+
+    arr = NDArray_With_Callback(np.zeros(4))
+
+    def failing(array, info):
+        raise RuntimeError("callback failure")
+
+    arr.add_canonical_callback(failing)
+
+    with pytest.raises(RuntimeError, match="callback failure"):
+        arr[0] = 1.0
+
+    with pytest.raises(RuntimeError, match="callback failure"):
+        with uw.synchronised_array_update():
+            arr[1] = 2.0
+
+
+def test_change_info_old_value_always_none():
+    """Internal operations no longer snapshot prior values; the dict key
+    remains for compatibility and is always None."""
+    arr = NDArray_With_Callback(np.zeros(4))
+    seen = []
+    arr.add_canonical_callback(lambda a, info: seen.append(info["old_value"]))
+    arr[0] = 1.0
+    arr += 1.0
+    arr.fill(3.0)
+    assert seen == [None, None, None]
+
+
+def test_sync_data_resize_rehomes_canonical_callbacks():
+    """The different-size sync_data path returns a NEW canonical object;
+    canonical callbacks must be re-registered against it, not copied as
+    wrappers bound to the old array's identity."""
+    arr, recorder = _canonical(shape=(4, 2))
+    bigger = arr.sync_data(np.ones((6, 2)))
+    assert bigger is not arr
+    recorder.calls.clear()
+    bigger[0, 0] = 5.0
+    assert len(recorder.calls) == 1
+    assert recorder.calls[0][0] is bigger
+
+
+def test_remove_canonical_callback_by_original_function():
+    arr, recorder = _canonical()
+    arr.remove_callback(recorder)
+    arr[0, 0] = 1.0
+    assert recorder.calls == []

--- a/tests/test_0059_canonical_callback_guard.py
+++ b/tests/test_0059_canonical_callback_guard.py
@@ -1,0 +1,115 @@
+"""Regression tests for ``NDArray_With_Callback.add_canonical_callback`` (#379).
+
+``__array_finalize__`` hands the callback list to every array derived by
+indexing, so a callback written for the canonical storage also fires on
+views and temporary fancy-index copies. Firing on a copy is the #376
+parallel hang: the copy's contents are partition-dependent, so a PETSc
+sync from inside the callback runs its collectives on some ranks only.
+
+``add_canonical_callback`` centralises the fix: the registered callback
+only ever receives the canonical array. View-vs-copy is decided by
+IDENTITY in numpy's base chain — ``np.may_share_memory`` is False for any
+zero-size array, which would re-create the rank asymmetry on ranks whose
+local slice is empty.
+"""
+
+import gc
+import weakref
+
+import numpy as np
+import pytest
+
+from underworld3.utilities import NDArray_With_Callback
+
+pytestmark = [pytest.mark.level_1, pytest.mark.tier_a]
+
+
+class _CallRecorder:
+    """Records every (array, change_info) pair a callback receives."""
+
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, array, change_info):
+        self.calls.append((array, change_info))
+
+
+def _canonical(shape=(6, 2)):
+    arr = NDArray_With_Callback(np.zeros(shape))
+    recorder = _CallRecorder()
+    arr.add_canonical_callback(recorder)
+    return arr, recorder
+
+
+def test_write_to_canonical_fires_with_canonical():
+    arr, recorder = _canonical()
+    arr[2, 0] = 1.0
+    assert len(recorder.calls) == 1
+    assert recorder.calls[0][0] is arr
+
+
+def test_write_through_basic_slice_view_fires_with_full_canonical():
+    """A basic slice is a view: the write already landed in canonical
+    storage, so the callback must receive the FULL canonical array."""
+    arr, recorder = _canonical()
+    view = arr[1:4]
+    view[0, 0] = 3.0
+    assert len(recorder.calls) == 1
+    assert recorder.calls[0][0] is arr
+    assert arr[1, 0] == 3.0
+
+
+def test_nested_view_chain_still_resolves_to_canonical():
+    arr, recorder = _canonical()
+    inner = arr[1:5][1:3]
+    inner[0, 0] = 7.0
+    assert len(recorder.calls) == 1
+    assert recorder.calls[0][0] is arr
+
+
+def test_zero_size_view_is_still_classified_as_view():
+    """The empty-rank case: np.may_share_memory(empty_view, arr) is False,
+    but the base-chain walk must still classify it as a view so every rank
+    takes the same branch."""
+    arr, recorder = _canonical()
+    empty_view = arr[3:3]
+    empty_view[...] = 9.0  # writes nothing, but fires __setitem__
+    assert len(recorder.calls) == 1
+    assert recorder.calls[0][0] is arr
+
+
+def test_fancy_index_write_fires_exactly_once_via_parent_writeback():
+    """``arr[mask] += delta`` creates a temporary COPY, fires the inherited
+    callback on it (skipped), then numpy writes back through the parent's
+    ``__setitem__`` (fires with canonical). Net: exactly one call, on the
+    canonical array — this is the #376 scenario."""
+    arr, recorder = _canonical()
+    mask = np.zeros(arr.shape[0], dtype=bool)
+    mask[1] = mask[4] = True
+    arr[mask] += 1.0
+    assert len(recorder.calls) == 1
+    assert recorder.calls[0][0] is arr
+    assert arr[1, 0] == 1.0 and arr[4, 0] == 1.0
+
+
+def test_detached_copy_never_fires():
+    """A standalone copy has left the canonical base chain entirely; writes
+    to it must not reach the canonical callback."""
+    arr, recorder = _canonical()
+    detached = arr[np.array([0, 2])]  # fancy index → independent copy
+    recorder.calls.clear()  # discard the write-back-free extraction call, if any
+    detached[0, 0] = 5.0
+    assert recorder.calls == []
+    assert arr[0, 0] == 0.0
+
+
+def test_no_reference_cycle_with_canonical():
+    """The dispatch closure must hold the canonical array weakly: the
+    callback list lives ON the array, so a strong capture would keep the
+    array alive forever."""
+    arr = NDArray_With_Callback(np.zeros((4, 1)))
+    arr.add_canonical_callback(lambda a, info: None)
+    ref = weakref.ref(arr)
+    del arr
+    gc.collect()
+    assert ref() is None

--- a/tests/test_0500_enhanced_array_structure.py
+++ b/tests/test_0500_enhanced_array_structure.py
@@ -17,8 +17,8 @@ def test_enhanced_array_classes_exist():
         from underworld3.swarm import SwarmVariable
 
         # Check that SwarmVariable has the unified array interface
-        assert hasattr(SwarmVariable, "_create_variable_array")
-        print("✅ _create_variable_array factory method exists")
+        assert hasattr(SwarmVariable, "_create_canonical_data_array")
+        print("✅ _create_canonical_data_array factory method exists")
 
         # Check that the direct methods exist
         required_methods = [
@@ -137,7 +137,7 @@ class TestEnhancedArrayStructure:
             from underworld3.swarm import SwarmVariable
 
             # Test that the unified interface methods exist
-            assert hasattr(SwarmVariable, "_create_variable_array")
+            assert hasattr(SwarmVariable, "_create_canonical_data_array")
             assert hasattr(SwarmVariable, "pack_uw_data_to_petsc")
             assert hasattr(SwarmVariable, "unpack_uw_data_from_petsc")
 
@@ -178,7 +178,7 @@ def test_implementation_completeness():
         features = {
             "Enhanced pack method": hasattr(SwarmVariable, "pack_uw_data_to_petsc"),
             "Enhanced unpack method": hasattr(SwarmVariable, "unpack_uw_data_from_petsc"),
-            "Unified array factory": hasattr(SwarmVariable, "_create_variable_array"),
+            "Unified array factory": hasattr(SwarmVariable, "_create_canonical_data_array"),
             "Legacy method compatibility": hasattr(SwarmVariable, "use_enhanced_array")
             and hasattr(SwarmVariable, "use_legacy_array"),
             "Sync context manager": hasattr(SwarmVariable, "sync_disabled"),

--- a/tests/test_0510_enhanced_swarm_array.py
+++ b/tests/test_0510_enhanced_swarm_array.py
@@ -55,7 +55,7 @@ class TestEnhancedSwarmArray:
         assert hasattr(scalar_var, "unpack_uw_data_from_petsc")
 
         # Check that unified array interface exists
-        assert hasattr(scalar_var, "_create_variable_array")
+        assert hasattr(scalar_var, "_create_canonical_data_array")
         print("✅ Unified NDArray_With_Callback interface exists")
 
     def test_interface_switching(self, setup_enhanced_array_test):

--- a/tests/test_0540_coordinate_change_locking.py
+++ b/tests/test_0540_coordinate_change_locking.py
@@ -163,3 +163,26 @@ if __name__ == "__main__":
     """Run tests directly"""
     success = run_locking_tests()
     exit(0 if success else 1)
+
+
+def test_rejected_coord_write_leaves_mesh_coords_clean():
+    """A rejected in-place write to mesh.X.coords must not poison the
+    coordinate cache: the guard's message says the write "is rejected",
+    so mesh.X.coords must still agree with the DM afterwards (#379
+    review round 1). Previously the values landed in the cache before
+    the rejection fired, and catch-and-continue code then used
+    coordinates the DM does not have.
+    """
+    import underworld3 as uw
+    from underworld3.meshing import UnstructuredSimplexBox
+
+    mesh = UnstructuredSimplexBox(minCoords=(0.0, 0.0), maxCoords=(1.0, 1.0), cellSize=0.25)
+    uw.discretisation.MeshVariable("t540_reject", mesh, 1, degree=1)  # live mesh
+
+    before = np.array(mesh.X.coords)
+    with pytest.raises(RuntimeError, match="rejected"):
+        mesh.X.coords[:] = before + 0.01
+
+    assert np.array_equal(np.array(mesh.X.coords), before)
+    dm_coords = mesh.dm.getCoordinatesLocal().array.reshape(-1, mesh.cdim)
+    assert np.allclose(np.array(mesh.X.coords).reshape(-1, mesh.cdim), dm_coords)


### PR DESCRIPTION
First of the #379 series (see the issue for the full map). **Draft until #378 merges** — the two canonical callbacks this PR migrates are the same closures #378 patches inline, so this PR merges second and absorbs a small, mechanical conflict (the inline guard block is deleted here because the guard moves into the class).

## What this does

**A central guard for canonical-storage callbacks.** Callbacks written for a variable's canonical storage are inherited by every array derived from it, so they also fire on views and on temporary fancy-index copies. A copy's contents differ from rank to rank, so a PETSc sync run from inside the callback executes its collective operations on some ranks only — that is the #376 parallel hang. The new `add_canonical_callback()` applies the fix once, on the class: views hand the full canonical array to the callback, copies are skipped (numpy's write-back re-fires through the parent), and view-vs-copy is decided by identity in numpy's base chain — never `np.may_share_memory`, which is false for any zero-size array and would re-create the rank asymmetry on ranks with no local data. Any future callback registered this way gets the protection for free instead of re-inheriting the trap.

The mesh-variable and swarm-variable canonical callbacks now register through it. The mesh callback body moves to `MeshVariable._flush_canonical_to_petsc()`, which becomes the single write-back path (and is reused by the planned `synchronised_array_update` rework, the next PR in the series).

**Callback exceptions now propagate.** The immediate callback path used to swallow every exception into a `logger.warning`. A swallowed failure leaves PETSc out of sync with the canonical array on one rank only — the silent desynchronisation that hid #376. Failures now surface where they happen.

**Dead weight removed.** `_create_variable_array` (mesh and swarm) and `_create_flat_data_array` had no callers and embodied the unguarded pattern — deleted. Every write also used to snapshot prior values into `change_info['old_value']` (a full-array copy per in-place operation); nothing ever read it, so the snapshot is gone and the key stays as `None` for compatibility.

**Not touched here:** the `swarm.points` legacy callback (marked `TODO(BUG)`; removed by the #379 item-1 PR) and the delayed-replay machinery (rebuilt in the item-2 PR).

## Verification

- New `tests/test_0059_canonical_callback_guard.py` (level_1 / tier_a, written first and shown to fail): view/copy classification including the zero-size-view empty-rank case, exactly-once firing for masked `+=` writes, and a no-reference-cycle check.
- Quick gate `level_1 and tier_a`: 405 passed, 1 pre-existing xfail.
- Parallel smoke at np=2: swarm write/timestep and mesh-deform kd-tree tests pass.

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)