### PR TITLE
Intercept out= ufunc writes: close the silent callback bypass (#379 item 4a)

### DIFF
--- a/src/underworld3/utilities/nd_array_callback.py
+++ b/src/underworld3/utilities/nd_array_callback.py
@@ -727,6 +727,17 @@ class NDArray_With_Callback(np.ndarray):
         Remaining bypasses this cannot intercept: ``np.copyto`` and
         ``ufunc.at`` (neither passes ``out=``).
         """
+        if out is not None:
+            for target in out:
+                if getattr(target, "_disable_inplace_operators", False):
+                    # The out= spelling must honour the same contract as the
+                    # in-place operators — bypassing it would re-arm the
+                    # per-write hazard the flag exists to prevent.
+                    raise RuntimeError(
+                        "In-place ufunc output (out=) is disabled for parallel "
+                        "safety on this array. Use explicit assignment instead."
+                    )
+
         plain_inputs = tuple(
             np.asarray(x) if isinstance(x, NDArray_With_Callback) else x for x in inputs
         )

--- a/src/underworld3/utilities/nd_array_callback.py
+++ b/src/underworld3/utilities/nd_array_callback.py
@@ -706,6 +706,52 @@ class NDArray_With_Callback(np.ndarray):
             for callback in self._callbacks.copy():  # Copy in case callbacks modify the list
                 callback(self, change_info)
 
+    def __array_ufunc__(self, ufunc, method, *inputs, out=None, **kwargs):
+        """Compute on plain-ndarray views, then notify ``out=`` targets.
+
+        ``np.add(x, 1, out=x)`` (and every in-place operator, which numpy
+        routes through the same machinery) writes straight into the buffer
+        with no ``__setitem__`` — previously a silent bypass: values landed
+        but ghost sync and the state increment did not happen.
+
+        The standard override recipe applies: operands are unwrapped to
+        base-class views (``ndarray.__array_ufunc__`` refuses mixed
+        overriding operands), and each requested ``out`` is returned AS THE
+        ORIGINAL OBJECT so ``x += 1`` keeps its subclass and callbacks. The
+        notification goes to each ``out=`` target rather than ``self``,
+        because numpy invokes this method on the first operand, which need
+        not be the array being written. Results without ``out`` come back
+        as plain ndarrays (matching the prior ``__array_wrap__`` policy of
+        not propagating callbacks to derived results).
+
+        Remaining bypasses this cannot intercept: ``np.copyto`` and
+        ``ufunc.at`` (neither passes ``out=``).
+        """
+        plain_inputs = tuple(
+            np.asarray(x) if isinstance(x, NDArray_With_Callback) else x for x in inputs
+        )
+        if out is not None:
+            kwargs["out"] = tuple(
+                np.asarray(x) if isinstance(x, NDArray_With_Callback) else x for x in out
+            )
+
+        results = getattr(ufunc, method)(*plain_inputs, **kwargs)
+
+        if out is not None:
+            for target in out:
+                if isinstance(target, NDArray_With_Callback):
+                    target._trigger_callback("ufunc_out")
+
+        if method == "at":
+            return None
+        if ufunc.nout == 1:
+            results = (results,)
+        wrapped = tuple(
+            out[i] if out is not None and i < len(out) and out[i] is not None else r
+            for i, r in enumerate(results)
+        )
+        return wrapped[0] if len(wrapped) == 1 else wrapped
+
     def __setitem__(self, key, value):
         """Override setitem to trigger callbacks on assignment."""
         # Handle UnitAwareArray values by extracting magnitude
@@ -730,9 +776,9 @@ class NDArray_With_Callback(np.ndarray):
                 "Use explicit assignment instead: arr = arr + other"
             )
 
-        result = super().__iadd__(other)
-        self._trigger_callback("iadd", new_value=other)
-        return result
+        # Callback fires via __array_ufunc__ (out= detection) — an
+        # explicit trigger here would notify twice per operation.
+        return super().__iadd__(other)
 
     def __isub__(self, other):
         """In-place subtraction with callback."""
@@ -742,9 +788,9 @@ class NDArray_With_Callback(np.ndarray):
                 "Use explicit assignment instead: arr = arr - other"
             )
 
-        result = super().__isub__(other)
-        self._trigger_callback("isub", new_value=other)
-        return result
+        # Callback fires via __array_ufunc__ (out= detection) — an
+        # explicit trigger here would notify twice per operation.
+        return super().__isub__(other)
 
     def __imul__(self, other):
         """In-place multiplication with callback."""
@@ -754,9 +800,9 @@ class NDArray_With_Callback(np.ndarray):
                 "Use explicit assignment instead: arr = arr * other"
             )
 
-        result = super().__imul__(other)
-        self._trigger_callback("imul", new_value=other)
-        return result
+        # Callback fires via __array_ufunc__ (out= detection) — an
+        # explicit trigger here would notify twice per operation.
+        return super().__imul__(other)
 
     def __itruediv__(self, other):
         """In-place true division with callback."""
@@ -766,9 +812,9 @@ class NDArray_With_Callback(np.ndarray):
                 "Use explicit assignment instead: arr = arr / other"
             )
 
-        result = super().__itruediv__(other)
-        self._trigger_callback("itruediv", new_value=other)
-        return result
+        # Callback fires via __array_ufunc__ (out= detection) — an
+        # explicit trigger here would notify twice per operation.
+        return super().__itruediv__(other)
 
     def __ifloordiv__(self, other):
         """In-place floor division with callback."""
@@ -778,9 +824,9 @@ class NDArray_With_Callback(np.ndarray):
                 "Use explicit assignment instead: arr = arr // other"
             )
 
-        result = super().__ifloordiv__(other)
-        self._trigger_callback("ifloordiv", new_value=other)
-        return result
+        # Callback fires via __array_ufunc__ (out= detection) — an
+        # explicit trigger here would notify twice per operation.
+        return super().__ifloordiv__(other)
 
     def __imod__(self, other):
         """In-place modulo with callback."""
@@ -790,9 +836,9 @@ class NDArray_With_Callback(np.ndarray):
                 "Use explicit assignment instead: arr = arr % other"
             )
 
-        result = super().__imod__(other)
-        self._trigger_callback("imod", new_value=other)
-        return result
+        # Callback fires via __array_ufunc__ (out= detection) — an
+        # explicit trigger here would notify twice per operation.
+        return super().__imod__(other)
 
     def __ipow__(self, other):
         """In-place power with callback."""
@@ -802,9 +848,9 @@ class NDArray_With_Callback(np.ndarray):
                 "Use explicit assignment instead: arr = arr ** other"
             )
 
-        result = super().__ipow__(other)
-        self._trigger_callback("ipow", new_value=other)
-        return result
+        # Callback fires via __array_ufunc__ (out= detection) — an
+        # explicit trigger here would notify twice per operation.
+        return super().__ipow__(other)
 
     def __iand__(self, other):
         """In-place bitwise and with callback."""
@@ -814,9 +860,9 @@ class NDArray_With_Callback(np.ndarray):
                 "Use explicit assignment instead: arr = arr & other"
             )
 
-        result = super().__iand__(other)
-        self._trigger_callback("iand", new_value=other)
-        return result
+        # Callback fires via __array_ufunc__ (out= detection) — an
+        # explicit trigger here would notify twice per operation.
+        return super().__iand__(other)
 
     def __ior__(self, other):
         """In-place bitwise or with callback."""
@@ -826,9 +872,9 @@ class NDArray_With_Callback(np.ndarray):
                 "Use explicit assignment instead: arr = arr | other"
             )
 
-        result = super().__ior__(other)
-        self._trigger_callback("ior", new_value=other)
-        return result
+        # Callback fires via __array_ufunc__ (out= detection) — an
+        # explicit trigger here would notify twice per operation.
+        return super().__ior__(other)
 
     def __ixor__(self, other):
         """In-place bitwise xor with callback."""
@@ -838,9 +884,9 @@ class NDArray_With_Callback(np.ndarray):
                 "Use explicit assignment instead: arr = arr ^ other"
             )
 
-        result = super().__ixor__(other)
-        self._trigger_callback("ixor", new_value=other)
-        return result
+        # Callback fires via __array_ufunc__ (out= detection) — an
+        # explicit trigger here would notify twice per operation.
+        return super().__ixor__(other)
 
     def __ilshift__(self, other):
         """In-place left shift with callback."""
@@ -850,9 +896,9 @@ class NDArray_With_Callback(np.ndarray):
                 "Use explicit assignment instead: arr = arr << other"
             )
 
-        result = super().__ilshift__(other)
-        self._trigger_callback("ilshift", new_value=other)
-        return result
+        # Callback fires via __array_ufunc__ (out= detection) — an
+        # explicit trigger here would notify twice per operation.
+        return super().__ilshift__(other)
 
     def __irshift__(self, other):
         """In-place right shift with callback."""
@@ -862,9 +908,9 @@ class NDArray_With_Callback(np.ndarray):
                 "Use explicit assignment instead: arr = arr >> other"
             )
 
-        result = super().__irshift__(other)
-        self._trigger_callback("irshift", new_value=other)
-        return result
+        # Callback fires via __array_ufunc__ (out= detection) — an
+        # explicit trigger here would notify twice per operation.
+        return super().__irshift__(other)
 
     def fill(self, value):
         """Fill array with scalar value, triggering callback."""

--- a/tests/test_0061_ufunc_out_callback.py
+++ b/tests/test_0061_ufunc_out_callback.py
@@ -1,0 +1,113 @@
+"""Regression tests for the ``out=`` ufunc callback bypass (#379 item 4a).
+
+``np.add(x, 1, out=x)`` writes straight into the buffer through numpy's
+ufunc machinery — no ``__setitem__``, no in-place operator wrapper — so
+before this fix no callback fired: values landed (the canonical array
+wraps the PETSc vec memory) but ghost synchronisation and the state
+increment silently did not happen.
+
+``__array_ufunc__`` now delegates to numpy unchanged and then notifies
+each ``out=`` target that is an ``NDArray_With_Callback``. The canonical
+guard composes: an ``out=`` view resolves to the canonical array, an
+``out=`` detached copy is skipped, and inside
+``uw.synchronised_array_update`` the write dirty-marks for the single
+deferred flush.
+
+Known remaining bypasses (documented, not intercepted): ``np.copyto``
+and ``ufunc.at`` — neither routes through ``__array_ufunc__``'s ``out=``.
+"""
+
+import numpy as np
+import pytest
+
+import underworld3 as uw
+from underworld3.utilities import NDArray_With_Callback
+
+pytestmark = [pytest.mark.level_1, pytest.mark.tier_a]
+
+
+class _CallRecorder:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, array, change_info):
+        self.calls.append(change_info["operation"])
+
+
+def _canonical(shape=(6, 2)):
+    arr = NDArray_With_Callback(np.zeros(shape))
+    recorder = _CallRecorder()
+    arr.add_canonical_callback(recorder)
+    return arr, recorder
+
+
+def test_ufunc_out_on_canonical_fires():
+    arr, recorder = _canonical()
+    np.add(arr, 1.0, out=arr)
+    assert recorder.calls == ["ufunc_out"]
+    assert np.allclose(np.asarray(arr), 1.0)
+
+
+def test_ufunc_out_on_view_resolves_to_canonical():
+    arr, recorder = _canonical()
+    view = arr[1:4]
+    np.multiply(view, 0.0, out=view)
+    assert recorder.calls == ["ufunc_out"]
+
+
+def test_ufunc_out_on_detached_copy_is_skipped():
+    arr, recorder = _canonical()
+    detached = arr[np.array([0, 2])]  # fancy index → independent copy
+    recorder.calls.clear()
+    np.add(detached, 5.0, out=detached)
+    assert recorder.calls == []
+    assert np.allclose(np.asarray(arr), 0.0)
+
+
+def test_plain_ufunc_without_out_stays_silent():
+    arr, recorder = _canonical()
+    result = arr + 1.0
+    assert recorder.calls == []
+    assert not isinstance(result, NDArray_With_Callback)
+    assert np.allclose(result, 1.0)
+
+
+def test_inplace_operator_fires_exactly_once():
+    """+= routes through the ufunc machinery with out=self; the explicit
+    per-operator triggers are gone, so exactly ONE notification arrives."""
+    arr, recorder = _canonical()
+    arr += 2.0
+    assert recorder.calls == ["ufunc_out"]
+    assert np.allclose(np.asarray(arr), 2.0)
+
+
+def test_masked_inplace_still_fires_exactly_once():
+    """arr[mask] += 1: the temporary copy's ufunc_out is skipped (copy),
+    the parent write-back fires — net one canonical notification."""
+    arr, recorder = _canonical()
+    mask = np.zeros(arr.shape[0], dtype=bool)
+    mask[1] = True
+    arr[mask] += 1.0
+    assert recorder.calls == ["setitem"]
+    assert arr[1, 0] == 1.0
+
+
+def test_ufunc_out_defers_inside_synchronised_update():
+    arr, recorder = _canonical()
+    with uw.synchronised_array_update("ufunc out"):
+        np.add(arr, 1.0, out=arr)
+        np.add(arr, 1.0, out=arr)
+        assert recorder.calls == []
+    assert recorder.calls == ["deferred_flush"]
+    assert np.allclose(np.asarray(arr), 2.0)
+
+
+def test_mesh_variable_ufunc_out_reaches_petsc():
+    mesh = uw.meshing.StructuredQuadBox(
+        elementRes=(4, 4), minCoords=(0.0, 0.0), maxCoords=(1.0, 1.0)
+    )
+    t = uw.discretisation.MeshVariable("t61", mesh, 1, vtype=uw.VarType.SCALAR, degree=1)
+    t.data[...] = 2.0
+    np.multiply(t.data, 3.0, out=t.data)
+    assert np.allclose(np.asarray(t.data), 6.0)
+    assert np.allclose(t.vec.array, 6.0)

--- a/tests/test_0061_ufunc_out_callback.py
+++ b/tests/test_0061_ufunc_out_callback.py
@@ -111,3 +111,15 @@ def test_mesh_variable_ufunc_out_reaches_petsc():
     np.multiply(t.data, 3.0, out=t.data)
     assert np.allclose(np.asarray(t.data), 6.0)
     assert np.allclose(t.vec.array, 6.0)
+
+
+def test_out_honours_disable_inplace_operators():
+    """np.add(x, 1, out=x) must respect the same contract as x += 1 —
+    bypassing the flag re-armed the per-write hazard it exists to prevent
+    (#379 review round 1)."""
+    arr = NDArray_With_Callback(np.zeros(4), disable_inplace_operators=True)
+    with pytest.raises(RuntimeError, match="parallel safety"):
+        np.add(arr, 1.0, out=arr)
+    with pytest.raises(RuntimeError, match="parallel safety"):
+        arr += 1.0
+    assert np.allclose(np.asarray(arr), 0.0)


### PR DESCRIPTION
Last of the #379 series, **stacked on #383** (base is `bugfix/synchronised-update-collective-flush`; retarget as the stack merges). Deliberately a single, independently revertable commit.

## What this does

`np.add(x, 1, out=x)` — and every in-place operator, which numpy routes through the same ufunc machinery — wrote straight into the buffer with no `__setitem__` and no callback. Values landed, because the canonical array wraps the PETSc vec memory, but the ghost synchronisation and the state increment silently did not happen: stale ghosts and stale caches rather than hangs.

`NDArray_With_Callback` now implements `__array_ufunc__` using the standard numpy override recipe:

- operands are unwrapped to base-class views for the computation (numpy's default implementation refuses to operate when another overriding operand is present);
- each requested `out=` is returned **as the original object**, so `x += 1` keeps its subclass and callbacks — this is the recipe's load-bearing detail;
- each `out=` target of ours is notified after the write. The notification composes with the #381 canonical guard (an `out=` view resolves to the canonical array; an `out=` detached copy is skipped) and with the #383 flush (inside `uw.synchronised_array_update` it dirty-marks for the single deferred flush).

The twelve in-place operators drop their explicit triggers — with the hook in place they would notify twice per operation.

**Remaining documented bypasses**: `np.copyto` and `ufunc.at` do not pass `out=` and are not intercepted; they are recorded in the class docstring and the test module.

## Verification

- New `tests/test_0061_ufunc_out_callback.py` (level_1 / tier_a, written first and shown to fail): `out=` on canonical / view / detached copy, plain arithmetic stays silent and returns plain ndarrays, `+=` fires exactly once, masked `+=` still nets one notification via the parent write-back, deferral inside `synchronised_array_update`, and an end-to-end mesh-variable `out=` write reaching the PETSc vec.
- Units suite (0700/0710/0730/0800/0814/0850): 240 passed, pre-existing skips/xfails only.
- Quick gate `level_1 and tier_a`: 419 passed, 1 pre-existing xfail.
- Matplotlib quiver + contourf + masked-array smoke: clean.
- Ufunc dispatch overhead: a fixed ~2-3 microseconds per call (vs ~1.5 for plain ndarray) — noise against any PETSc pack. If real-model profiling ever disagrees, revert this one commit and the bypass reverts to a documented limitation.

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)