### PR TITLE
Swarm-notification version bump belongs in deform(), not the internal primitive

### DIFF
--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -3456,6 +3456,15 @@ class Mesh(Stateful, uw_object):
         result = remesh_with_field_transfer(
             self, _do_move, dt=dt, extra_zero=zero, verbose=verbose)
 
+        # Notify registered swarms: solve-entry sync compares this version
+        # and marks them for deferred migration (#379 item 1 retired the
+        # read-trigger that consumed this channel). The bump lives HERE,
+        # not in _deform_mesh: the internal primitive also runs on
+        # snapshot restore, whose integrity check treats a moved version
+        # as invalidation and would refuse its own recovery.
+        if result:
+            self._mesh_version += 1
+
         # Refresh deformation-tracking per-boundary normals so Nitsche/penalty
         # BCs that captured ``boundary_normal(...).sym`` at setup read the new
         # geometry (the JIT reads the variable's .data, which would otherwise
@@ -3559,13 +3568,6 @@ class Mesh(Stateful, uw_object):
             for solver in self._equation_systems_register:
                 if solver is not None and hasattr(solver, "is_setup"):
                     solver.is_setup = False
-
-            # Notify registered swarms: solve-entry sync compares this
-            # version and marks them for deferred migration (#379 item 1
-            # retired the read-trigger that used to consume this channel).
-            # The mesh.X.coords callback path bumps again after this
-            # returns — harmless, the consumer checks inequality.
-            self._mesh_version += 1
 
             # Invalidate caches whose contents become stale when mesh
             # coordinates change. Matches the cache hygiene already


### PR DESCRIPTION
Follow-up defect from composing the #379 stack (#381-#385) on development — a consumer the per-branch gates could not see: the snapshot system treats `_mesh_version` as its integrity key, and the #382 bump inside `_deform_mesh` also fired on the snapshot RESTORE path, so recovery refused its own snapshot (`test_0007_snapshot_inmemory`).

The bump moves to the public `deform()` — what users call, and the path that strands swarms — so internal primitive callers (snapshot restore, remesh transactions, movers) no longer perturb the version. The coords-callback path keeps its own bump for direct `mesh.X.coords` writes. Both consumers (swarm solve-entry re-bin; snapshot validity) verified: gate 435 passed including test_0007, and the #382 deform-notification regression test still passes through the public path.

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)