### PR TITLE
Cut ~115 seconds from the new 3D adaptivity test gates

### DIFF
--- a/tests/test_0764_node_redistribution.py
+++ b/tests/test_0764_node_redistribution.py
@@ -80,28 +80,6 @@ class TestNodeRedistribution:
         assert "node_redistribution" in uw.meshing.__all__
         assert callable(uw.meshing.node_redistribution)
 
-    def test_no_swallowed_callback_errors(self, caplog):
-        """Masked in-place updates (``data[mask] /= s``) must not fire the
-        canonical PETSc-sync callback on the fancy-indexed COPY. In serial
-        that surfaced as swallowed 'Callback error ... could not broadcast'
-        log warnings; in parallel the partition-dependent mask made the
-        collective sync rank-asymmetric and hung the MMPDE mover (#376).
-        The refinement=1 box exercises the trigger (`Gamma_P1` has one
-        zero-magnitude corner normal, so the mask drops one node)."""
-        import logging
-
-        mesh = uw.meshing.UnstructuredSimplexBox(
-            minCoords=(0.0, 0.0), maxCoords=(1.0, 1.0),
-            cellSize=0.4, refinement=1, qdegree=2)
-        x, y = mesh.X
-        d = sympy.Abs((x - 0.35) * 0.866 + (y - 1.0) * 0.5)
-        h = sympy.sqrt(0.08**2 + (1.6 * d) ** 2)
-        with caplog.at_level(logging.WARNING,
-                             logger="underworld3.utilities.nd_array_callback"):
-            mesh.redistribute_nodes(1.0 / h**2, slip_surfaces=True)
-        bad = [r.message for r in caplog.records
-               if "allback error" in r.message]
-        assert not bad, f"swallowed canonical-callback errors: {bad[:3]}"
 
 
 class TestEngineLessAdapt:
@@ -147,11 +125,22 @@ class TestEngineLessAdapt:
         bs, be = base3d.dm.getHeightStratum(0)
         assert ce - cs > be - bs
 
-    def test_redistribute_then_adapt_composition(self):
+    def test_redistribute_then_adapt_composition(self, caplog):
         """adapt() after redistribute_nodes refines the MOVED geometry and
         must not touch the parent's static hierarchy: DMClone shares the
         coordinates Vec by reference, so the moved-coordinate carry has to
-        install a duplicate (review finding, 2026-07 capstone close-out)."""
+        install a duplicate (review finding, 2026-07 capstone close-out).
+
+        The same mover run also guards #376: masked in-place updates
+        (``data[mask] /= s``) must not fire the canonical PETSc-sync
+        callback on the fancy-indexed COPY — in serial that surfaced as
+        swallowed 'Callback error ... could not broadcast' log warnings;
+        in parallel the partition-dependent mask made the collective sync
+        rank-asymmetric and hung the mover. The refinement=1 box is the
+        trigger (`Gamma_P1` has one zero-magnitude corner normal, so the
+        mask drops one node)."""
+        import logging
+
         mesh = uw.meshing.UnstructuredSimplexBox(
             minCoords=(0.0, 0.0), maxCoords=(1.0, 1.0),
             cellSize=0.4, refinement=1, qdegree=2)
@@ -160,7 +149,12 @@ class TestEngineLessAdapt:
         x, y = mesh.X
         d = sympy.Abs((x - 0.35) * 0.866 + (y - 1.0) * 0.5)
         h = sympy.sqrt(0.08**2 + (1.6 * d) ** 2)
-        mesh.redistribute_nodes(1.0 / h**2, slip_surfaces=True)
+        with caplog.at_level(logging.WARNING,
+                             logger="underworld3.utilities.nd_array_callback"):
+            mesh.redistribute_nodes(1.0 / h**2, slip_surfaces=True)
+        bad = [r.message for r in caplog.records
+               if "allback error" in r.message]
+        assert not bad, f"swallowed canonical-callback errors: {bad[:3]}"
         moved = mesh.dm.getCoordinatesLocal().array.copy()
         assert not np.array_equal(moved, hier_before)   # mover moved nodes
 

--- a/tests/test_0840_nvb_3d_serial_adapt.py
+++ b/tests/test_0840_nvb_3d_serial_adapt.py
@@ -96,11 +96,19 @@ def test_bounded_closure_single_cell_is_local():
 
 
 def test_shape_regularity_bounded_similarity_classes():
-    base = _base3(cellSize=0.6)
+    # The full-depth version of this bound (2.87M cells, 9 passes) was
+    # proven by the stage-1a oracle; the CI gate only needs the plateau
+    # SIGNATURE — the class count stops growing once every base cell has
+    # cycled its bisection edges (within two isotropic levels), and 36 is
+    # the theoretical ceiling it must plateau under.
+    base = _base3(cellSize=0.75)
     eng = TaggedBisectionMesh.from_dm(base.dm_hierarchy[-1])
-    for _ in range(9):                      # three full isotropic levels
+    for _ in range(5):
         eng.refine(list(eng.cells))
-    assert eng.similarity_classes() <= 36   # dim!·dim·2^(dim-2), dim=3
+    plateau = eng.similarity_classes()
+    eng.refine(list(eng.cells))             # sixth pass: two full levels
+    assert eng.similarity_classes() == plateau   # count has saturated
+    assert plateau <= 36                    # dim!·dim·2^(dim-2), dim=3
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
A test-cost trim that was pushed to the #378 branch a few minutes after the squash-merge, so it missed the window — re-applied cleanly on current development (with the #381-#385 callback series in) and verified: the four 3D adaptivity test files pass in 45s instead of ~160s.

Two changes, no loss of coverage:

- The similarity-class gate ran nine full uniform refinement passes in the pure-Python engine (512x cell growth, 117 seconds) to check a bound the design-stage oracle already proved at 2.87 million cells. The gate now checks the sharp part cheaply and more strictly: the class count must **saturate** between passes five and six (two full isotropic levels) and plateau under the theoretical ceiling of 36. Nine seconds.

- The #376 warning-free guard and the redistribute-then-adapt composition test each ran an identical node-redistribution pass on an identical mesh; one mover run now carries both sets of assertions.

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)