### PR TITLE
3D node redistribution: the MMPDE mover drives tetrahedral meshes (capstone round 2)

### DIFF
--- a/docs/developer/design/ADAPTIVITY_3D_SPHERICAL_2026-07.md
+++ b/docs/developer/design/ADAPTIVITY_3D_SPHERICAL_2026-07.md
@@ -573,6 +573,29 @@ out of scope here, as in 2D.
   metric-variation term is 2·d analytic metric evaluations per iteration —
   measure, and if hot, evaluate the Shepard-baked metric's gradient instead.
 
+**Round-2a status: DONE (2026-07-23, worktree `mmpde-3d`).** The rim
+locks fell as predicted (`_tet_cells` / new `_signed_volumes` /
+`fact = d!`; guards flipped; `mesh_metric_mismatch` and the
+`follow_metric` polish gained their tet forms). The one REAL blocker
+was not on the list: `_pinned_mask` stopped its label closure at
+edges, and 3D gmsh labels tag *faces only*, so on any 3D mesh **no
+boundary vertex was classified at all** — nothing pinned, nothing
+slipped, the whole boundary drifted freely into the interior. Every
+tagged non-vertex point now closes down to its vertices (bit-identical
+in 2D, where an edge's closure is exactly its endpoints). With that
+fixed, first light on the dipping-fault-plane box: monotone energy
+descent, zero folds, boundary nodes held **exactly** on their faces
+under slip, and h-grading ratio 1.12 vs 1.30 for the identical 2D
+problem — same family, compressed by the dimension exponent (the
+ideal equidistribution ratio for this metric is 4× in 2D but only
+2.5× in 3D, h ∝ ρ^(−1/d)); repeated calls hold a stable equilibrium,
+matching the 2D "maintains, does not compound" behaviour.
+`follow_metric` runs end-to-end on 3D. Full mover/adapt family sweep:
+215 green serially; the negative 3D-raises contract tests flipped to
+capability tests (`test_0764`, `test_0850_mesh_smoothing`). Spherical
+slip validation deferred to round 3b with the rest of the curved-
+boundary work.
+
 ### Round 2b — 3D MMPDE, parallel (same worktree, gated separately)
 
 The mover's parallel machinery (coordinate-DM `localToGlobal(ADD_VALUES)`
@@ -582,6 +605,15 @@ np2/np4 parity tests mirroring the 2D contract (velocity assembly
 bit-identical; the known ~1e-4%-level step-cap partition drift documented in
 `mmpde.py:487-495` applies unchanged). Any 3D-specific divergence is a bug to
 fix, not a new mechanism to build.
+
+**Round-2b status: DONE (2026-07-23).** Gates, not code, exactly as
+predicted — zero 3D-specific changes were needed. The dipping-plane
+box gate at np=1/2/4: runs clean at every rank count (exercising the
+post-#379 collective sync machinery in 3D), zero folds everywhere,
+boundary nodes held exactly on their faces, and the graded
+near/far h medians agree across partitions to ≤2.5% each (grading
+ratio 1.121 / 1.088 / 1.077) — the same few-percent equilibrium
+drift the rank-local step cap produces in the 2D combination gate.
 
 ### Round 3a — unified adapt + redistribute workflow
 

--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -3119,11 +3119,8 @@ class Mesh(Stateful, uw_object):
 
         all_labels = (tuple(boundary_labels) if boundary_labels is not None
                       else _auto_pinned_labels(self))
-        # TODO(follow-up): _pinned_mask expands labels through vertices/edges
-        # only, so a 3D boundary label that tags FACES alone (a mesh loaded with
-        # markVertices=False) leaves its boundary vertices unmarked. This is a
-        # pre-existing limitation of the shared helper used by every mover; the
-        # fix (close faces→edges→vertices) belongs with _pinned_mask itself.
+        # _pinned_mask closes every tagged point (edge in 2D, face in 3D)
+        # down to its vertices, so face-only 3D labels classify correctly.
         is_bnd = _pinned_mask(dm, all_labels)
 
         slip_labels, free_labels = self._resolve_slip_spec(slip_spec)
@@ -6159,12 +6156,12 @@ class Mesh(Stateful, uw_object):
         mesh in place.
 
         This method is how each mesh type controls whether (and how) it
-        can be modified: the base implementation supports **2D simplex
-        (triangle) meshes**, where it drives the Huang–Kamenski
-        variational MMPDE mover (non-folding by construction,
-        parallel-safe; scalar metric → isotropic equidistribution,
-        tensor metric → anisotropic clustering and alignment).
-        Quadrilateral / hexahedral meshes, 3D meshes and constrained
+        can be modified: the base implementation supports **2D
+        (triangle) and 3D (tetrahedral) simplex meshes**, where it
+        drives the Huang–Kamenski variational MMPDE mover (non-folding
+        by construction, parallel-safe; scalar metric → isotropic
+        equidistribution, tensor metric → anisotropic clustering and
+        alignment). Quadrilateral / hexahedral meshes and constrained
         manifolds raise ``NotImplementedError`` — no mover is
         implemented for them yet.
 
@@ -6202,16 +6199,16 @@ class Mesh(Stateful, uw_object):
                 f"manifold meshes (mesh.dim={self.dim} != mesh.cdim="
                 f"{self.cdim}): every node would have to be constrained "
                 "to the surface. Implemented today: 2D simplex (triangle) "
-                "meshes, via the MMPDE mover.")
-        if not bool(self.dm.isSimplex()) or self.cdim != 2:
+                "and 3D simplex (tetrahedral) meshes, via the MMPDE mover.")
+        if not bool(self.dm.isSimplex()) or self.cdim not in (2, 3):
             kind = "simplex" if bool(self.dm.isSimplex()) else "tensor-product (quad/hex)"
             raise NotImplementedError(
                 f"node redistribution is not implemented for {self.cdim}D "
                 f"{kind} meshes. Implemented today: 2D simplex (triangle) "
-                "meshes, via the MMPDE mover (its 3D / quad discretization "
-                "does not exist yet). To add resolution instead, use "
-                "mesh.adapt(metric_field, max_levels=...) — a topology "
-                "change.")
+                "and 3D simplex (tetrahedral) meshes, via the MMPDE mover "
+                "(no quad/hex discretization exists). To add resolution "
+                "instead, use mesh.adapt(metric_field, max_levels=...) — "
+                "a topology change.")
         from underworld3.meshing.smoothing import smooth_mesh_interior
         smooth_mesh_interior(self, metric=metric, method="mmpde",
                              verbose=verbose, **kwargs)

--- a/src/underworld3/meshing/smoothing/api.py
+++ b/src/underworld3/meshing/smoothing/api.py
@@ -135,9 +135,9 @@ def smooth_mesh_interior(
         Metric-grading solver (ignored when ``metric is None``).
         ``"mmpde"`` (alias ``"variational"``) — variational
         moving-mesh (Huang–Kamenski MMPDE) with a full tensor (or
-        scalar) metric; non-folding by construction. **Currently
-        2D-only** (triangle meshes) — a 3D mesh raises
-        ``NotImplementedError``.
+        scalar) metric; non-folding by construction. Triangle (2D)
+        and tetrahedral (3D) simplex meshes; quad/hex meshes and
+        constrained manifolds raise ``NotImplementedError``.
 
         The historical spellings ``"spring"``, ``"ma"``, ``"ot"``
         and ``"anisotropic"`` name interior movers retired in
@@ -796,17 +796,33 @@ def follow_metric(
         # stays intact while sliver cells get rounded out.
         # `polish_max_iters=0` disables entirely.
         if moved and polish_max_iters > 0:
-            tris_polish = _tri_cells(mesh.dm)
+            if mesh.cdim == 2:
+                cells_polish = _tri_cells(mesh.dm)
+            else:
+                from .graph import _tet_cells, _signed_volumes
+                cells_polish = _tet_cells(mesh.dm)
             for _polish_iter in range(int(polish_max_iters)):
-                # Check current shape quality
-                p = np.asarray(mesh.X.coords)[tris_polish]
-                e0 = np.linalg.norm(p[:, 1] - p[:, 0], axis=1)
-                e1 = np.linalg.norm(p[:, 2] - p[:, 1], axis=1)
-                e2 = np.linalg.norm(p[:, 0] - p[:, 2], axis=1)
-                A = np.abs(_signed_areas(np.asarray(mesh.X.coords),
-                                           tris_polish))
-                q = (4.0 * np.sqrt(3.0) * A
-                     / (e0 * e0 + e1 * e1 + e2 * e2 + 1.0e-30))
+                # Current worst cell-shape quality, normalised so the
+                # regular simplex scores q=1 and a degenerate sliver
+                # q→0. 2D: q = 4√3·A/Σe²  (Σ over the 3 edges).
+                # 3D: q = 6√2·V/ē³ with ē = rms of the 6 edge lengths
+                # (the volume of a regular tet of edge e is e³/(6√2)).
+                X = np.asarray(mesh.X.coords)
+                p = X[cells_polish]
+                nv = p.shape[1]
+                e2sum = np.zeros(p.shape[0])
+                n_edges = 0
+                for _a in range(nv):
+                    for _b in range(_a + 1, nv):
+                        e2sum += np.sum((p[:, _b] - p[:, _a]) ** 2, axis=1)
+                        n_edges += 1
+                if mesh.cdim == 2:
+                    A = np.abs(_signed_areas(X, cells_polish))
+                    q = 4.0 * np.sqrt(3.0) * A / (e2sum + 1.0e-30)
+                else:
+                    V = np.abs(_signed_volumes(X, cells_polish))
+                    ebar = np.sqrt(e2sum / n_edges)
+                    q = 6.0 * np.sqrt(2.0) * V / (ebar ** 3 + 1.0e-30)
                 q_min = _global_min(q.min())
                 if verbose:
                     uw.pprint(
@@ -831,9 +847,10 @@ def node_redistribution(mesh, metric, *, verbose=False, **kwargs):
     partition preserved. This is a thin dispatch to
     ``mesh.redistribute_nodes(metric, ...)`` — the mesh type controls
     whether (and how) it can be modified. The base implementation
-    supports 2D simplex (triangle) meshes via the Huang–Kamenski
-    variational MMPDE mover; unsupported mesh types (quad/hex, 3D,
-    manifolds) raise ``NotImplementedError`` stating what exists.
+    supports 2D (triangle) and 3D (tetrahedral) simplex meshes via the
+    Huang–Kamenski variational MMPDE mover; unsupported mesh types
+    (quad/hex, manifolds) raise ``NotImplementedError`` stating what
+    exists.
 
     Parameters
     ----------

--- a/src/underworld3/meshing/smoothing/graph.py
+++ b/src/underworld3/meshing/smoothing/graph.py
@@ -101,7 +101,6 @@ def _pinned_mask(dm, pinned_labels):
     ``Centre`` pressure-pin marker on an Annulus, whose underlying
     ``DMLabel`` has no strata and hard-crashes any query)."""
     pStart, pEnd = dm.getDepthStratum(0)
-    eStart, eEnd = dm.getDepthStratum(1)
     n_verts = pEnd - pStart
     is_pinned = np.zeros(n_verts, dtype=bool)
     for lname in pinned_labels:
@@ -127,10 +126,15 @@ def _pinned_mask(dm, pinned_labels):
                 if pStart <= idx < pEnd:
                     # Tagged vertex — pin directly.
                     is_pinned[idx - pStart] = True
-                elif eStart <= idx < eEnd:
-                    # Tagged edge — pin both endpoint vertices.
-                    cone = dm.getCone(idx)
-                    for c in cone:
+                else:
+                    # Tagged edge (2D labels) or face (3D labels tag
+                    # faces ONLY, so stopping at edges left every 3D
+                    # boundary vertex unmarked — no pin, no slip, the
+                    # boundary drifted freely): close the point down to
+                    # its vertices. For an edge the closure is exactly
+                    # its endpoints, so the 2D mask is bit-identical.
+                    closure = dm.getTransitiveClosure(idx)[0]
+                    for c in closure:
                         if pStart <= c < pEnd:
                             is_pinned[c - pStart] = True
     return is_pinned
@@ -235,6 +239,20 @@ def _signed_areas(coords, tris):
     c = coords[tris[:, 2]]
     return 0.5 * ((b[:, 0] - a[:, 0]) * (c[:, 1] - a[:, 1])
                   - (b[:, 1] - a[:, 1]) * (c[:, 0] - a[:, 0]))
+
+
+def _signed_volumes(coords, tets):
+    """Signed volume of each tetrahedron (sign = orientation) — the 3D
+    analogue of :func:`_signed_areas`, indexed the same way. Note the
+    DMPlex reference tet is det-NEGATIVE, so a healthy all-DMPlex-ordered
+    tet mesh yields uniformly negative values; callers (the MMPDE mover's
+    fold guard) already orientation-normalise with the global median
+    sign, exactly as they do for 2D."""
+    a = coords[tets[:, 0]]
+    e = np.stack([coords[tets[:, 1]] - a,
+                  coords[tets[:, 2]] - a,
+                  coords[tets[:, 3]] - a], axis=1)
+    return np.linalg.det(e) / 6.0
 
 
 
@@ -441,8 +459,8 @@ def smooth_surface_field(
 def _tet_cells(dm):
     """Tetrahedron vertex-index quadruples (local-chart), or ``None`` if the
     mesh is not all-tet. The 3D analogue of :func:`_tri_cells` — used by the
-    3D boundary-face extraction in :func:`_boundary_facets` (the MMPDE
-    mover itself is currently 2D-only)."""
+    3D boundary-face extraction in :func:`_boundary_facets` and by the
+    MMPDE mover's 3D discretization."""
     cStart, cEnd = dm.getHeightStratum(0)
     pStart, pEnd = dm.getDepthStratum(0)
     tets = []

--- a/src/underworld3/meshing/smoothing/metrics.py
+++ b/src/underworld3/meshing/smoothing/metrics.py
@@ -98,7 +98,8 @@ def mesh_metric_mismatch(mesh, metric, resolution_ratio=None):
     Parameters
     ----------
     mesh : underworld3.discretisation.Mesh
-        Triangle mesh (only 2-D for now).
+        Triangle (2D) or tetrahedral (3D) mesh; "area" throughout
+        this docstring reads as the cell measure (volume in 3D).
     metric : sympy / UW expression
         The target *density* ρ (larger ⇒ finer cells) — same
         object you would pass to ``smooth_mesh_interior``.
@@ -134,11 +135,19 @@ def mesh_metric_mismatch(mesh, metric, resolution_ratio=None):
     import underworld3 as _uw
 
     coords = np.asarray(mesh.X.coords)
-    tris = _tri_cells(mesh.dm)
+    if mesh.cdim == 2:
+        tris = _tri_cells(mesh.dm)
+        A_actual = None if tris is None else np.abs(
+            _signed_areas(coords, tris))
+    else:
+        from .graph import _tet_cells, _signed_volumes
+        tris = _tet_cells(mesh.dm)
+        A_actual = None if tris is None else np.abs(
+            _signed_volumes(coords, tris))
     if tris is None:
         raise NotImplementedError(
-            "mesh_metric_mismatch: triangle mesh required")
-    A_actual = np.abs(_signed_areas(coords, tris))
+            "mesh_metric_mismatch: simplex (triangle/tetrahedral) mesh "
+            "required")
     centroids = coords[tris].mean(axis=1)
     rho = np.asarray(_uw.function.evaluate(
         metric, centroids)).reshape(-1)

--- a/src/underworld3/meshing/smoothing/mmpde.py
+++ b/src/underworld3/meshing/smoothing/mmpde.py
@@ -236,6 +236,11 @@ def _mmpde_mover(mesh, metric, pinned_labels, verbose,
     cells_all = _tri_cells(dm) if cdim == 2 else _tet_cells(dm)
     signed_vol = _signed_areas if cdim == 2 else _signed_volumes
     if cells_all is None:
+        # TODO(BUG): rank-LOCAL early return — under MPI a rank with zero
+        # local cells (or a non-simplex local patch) returns here while the
+        # other ranks enter the collective energy/line-search reductions
+        # below, hanging the job. Pre-existing 2D posture, inherited by 3D
+        # (2026-07 review note); the fix is a collective emptiness check.
         return
     fact = float(math.factorial(cdim))         # d! → |K| = |detE|/d!
     owned_cell = _owned_cell_mask(dm)

--- a/src/underworld3/meshing/smoothing/mmpde.py
+++ b/src/underworld3/meshing/smoothing/mmpde.py
@@ -1,15 +1,17 @@
 """The Huang–Kamenski variational MMPDE mover (recommended for
-production adaptive meshing; 2D-only). See the package docstring for
-the module map.
+production adaptive meshing; triangle and tetrahedral meshes). See the
+package docstring for the module map.
 """
 
+import math
 import warnings
 
 import numpy as np
 
 import underworld3 as uw
 
-from .graph import (_tri_cells, _signed_areas, _owned_cell_mask,
+from .graph import (_tri_cells, _tet_cells, _signed_areas, _signed_volumes,
+                    _owned_cell_mask,
                     _owned_vertex_mask, _min_incident_edge_nd,
                     _global_sum, _global_min, _global_max, _global_mean)
 
@@ -94,10 +96,10 @@ def _mmpde_mover(mesh, metric, pinned_labels, verbose,
                    **_unknown_kwargs):
     r"""Anisotropic variational moving-mesh adaptation (Huang–Kamenski
     MMPDE; the direct simplex discretization of JCP 301 (2015) 322,
-    arXiv:1410.7872). **2D (triangle meshes) only** and parallel-safe.
-    The underlying method is dimension-general, but the 3D (tetrahedral)
-    discretization has not been implemented — a 3D mesh raises
-    ``NotImplementedError`` immediately.
+    arXiv:1410.7872). Triangle (2D) and tetrahedral (3D) meshes,
+    parallel-safe. The per-element algebra is written over ``cdim``
+    throughout — the two dimensions differ only in the cell list, the
+    signed-measure primitive and the ``d!`` volume factor.
 
     Generates the physical mesh as the image of a **fixed computational
     (reference) mesh** under the inverse coordinate map, minimizing
@@ -160,14 +162,12 @@ def _mmpde_mover(mesh, metric, pinned_labels, verbose,
             stacklevel=2)
     pinned_labels = tuple(pinned_labels)
     cdim = mesh.cdim
-    if cdim != 2:
-        # Guard here, before any metric parsing or DM work, so a 3D caller
-        # gets an honest message rather than a NameError from the (never
-        # implemented) 3D discretization deeper in the mover (READ-01).
+    if cdim not in (2, 3):
+        # Guard here, before any metric parsing or DM work, so the caller
+        # gets an honest message rather than a failure deeper in the mover.
         raise NotImplementedError(
-            "MMPDE mesh movement is currently 2D-only (triangle meshes): "
-            "the 3D tetrahedral discretization of the mover has not been "
-            f"implemented. Got a mesh with cdim={cdim}.")
+            "MMPDE mesh movement supports 2D (triangle) and 3D "
+            f"(tetrahedral) simplex meshes. Got a mesh with cdim={cdim}.")
     p = float(p); theta = float(theta); tau = float(tau)
     q = cdim * p / 2.0
     dq = float(cdim) ** q
@@ -230,14 +230,14 @@ def _mmpde_mover(mesh, metric, pinned_labels, verbose,
     dm = mesh.dm
     pStart, pEnd = dm.getDepthStratum(0)
     n_verts = pEnd - pStart
-    # cdim == 2 is guaranteed by the guard at the top of this function.
-    # (The former 3D branch here referenced `_signed_volumes`, which was
-    # never implemented — READ-01.)
-    cells_all = _tri_cells(dm)
-    signed_vol = _signed_areas
+    # cdim in (2, 3) is guaranteed by the guard at the top; the rest of
+    # the mover is written over cdim and needs only the right cell list,
+    # signed-measure primitive and d! volume factor.
+    cells_all = _tri_cells(dm) if cdim == 2 else _tet_cells(dm)
+    signed_vol = _signed_areas if cdim == 2 else _signed_volumes
     if cells_all is None:
         return
-    fact = 2.0                                 # d! → |K| = |detE|/d!
+    fact = float(math.factorial(cdim))         # d! → |K| = |detE|/d!
     owned_cell = _owned_cell_mask(dm)
     cells_own = cells_all[owned_cell]
     is_owned_v = _owned_vertex_mask(dm)

--- a/src/underworld3/meshing/surfaces.py
+++ b/src/underworld3/meshing/surfaces.py
@@ -2747,7 +2747,10 @@ def fault_metric_tensor(mesh, faults, refinement=3.0, width="auto", base=1.0):
     Parameters
     ----------
     mesh : Mesh
-        2D mesh (the anisotropic mover is 2D-only).
+        2D mesh. (The metric CONSTRUCTION here is 2D — polyline
+        normals and in-plane bumps; the MMPDE mover itself now
+        handles 3D, so a 3D generalisation of this builder is a
+        geometry exercise, not a mover limitation.)
     faults : Surface | array | list
         The fault geometry, in **mesh coordinate space**: a :class:`Surface`
         (uses its control-point polyline), an ``(N>=2, 2|3)`` polyline array,
@@ -2778,7 +2781,10 @@ def fault_metric_tensor(mesh, faults, refinement=3.0, width="auto", base=1.0):
     cdim = mesh.cdim
     if cdim != 2:
         raise NotImplementedError(
-            "fault_metric_tensor is 2D only (matches the anisotropic mover)")
+            "fault_metric_tensor is 2D only: the polyline-normal band\n"
+            "construction is planar. The MMPDE mover itself handles 3D —\n"
+            "build a 3D metric directly (e.g. from a plane/surface\n"
+            "distance) and pass it to redistribute_nodes.")
     R = float(refinement)
     if isinstance(width, str):
         if width.strip().lower() != "auto":
@@ -2870,9 +2876,10 @@ def fault_comb_metric(mesh, faults, cell_size, n_across=4, amplitude=6.0,
     Parameters
     ----------
     mesh : Mesh
-        2D mesh. (The MMPDE mover is 2D-only; 3D would need a 3D
-        discretization of the mover, which does not yet exist, so this
-        builder is 2D-only.)
+        2D mesh. (The comb construction — teeth along a polyline,
+        rows across it — is planar geometry; the MMPDE mover itself
+        now handles 3D, so a 3D comb would be a geometry exercise,
+        not a mover limitation.)
     faults : Surface | array | list
         Fault geometry in mesh coordinate space — a :class:`Surface`, an
         ``(N>=2, 2|3)`` polyline array, or a list mixing those. Each fault's
@@ -2905,8 +2912,9 @@ def fault_comb_metric(mesh, faults, cell_size, n_across=4, amplitude=6.0,
     cdim = mesh.cdim
     if cdim != 2:
         raise NotImplementedError(
-            "fault_comb_metric is 2D only (the MMPDE mover is 2D; 3D needs "
-            "a 3D discretization of the mover)")
+            "fault_comb_metric is 2D only: the comb construction is\n"
+            "planar. The MMPDE mover itself handles 3D — build a 3D\n"
+            "metric directly and pass it to redistribute_nodes.")
     dx = float(cell_size)
     if not (dx > 0.0):
         raise ValueError(f"cell_size must be positive; got {cell_size}")

--- a/tests/test_0762_fault_metric_tensor.py
+++ b/tests/test_0762_fault_metric_tensor.py
@@ -10,7 +10,8 @@ refining a thin band ACROSS one or more faults. These tests pin:
   metric=M) centres TWO close faults on their lines (|offset| < one refined
   cell) with the topology preserved (r-adapt, not h-adapt);
 * the builder accepts Surface objects equivalently to raw segments;
-* 3D raises NotImplementedError (the mover is 2D-only).
+* 3D raises NotImplementedError (the BUILDER's polyline-band
+  construction is planar; the MMPDE mover itself handles 3D).
 """
 import numpy as np
 import sympy

--- a/tests/test_0764_node_redistribution.py
+++ b/tests/test_0764_node_redistribution.py
@@ -69,16 +69,15 @@ class TestNodeRedistribution:
                            match="2D simplex"):
             uw.meshing.node_redistribution(mesh, sympy.sympify(1))
 
-    def test_3d_simplex_moves_no_fold_boundary_held(self, caplog):
+    def test_3d_simplex_moves_no_fold_boundary_held(self):
         """3D node redistribution landed with the adaptivity capstone
         (round 2): the same MMPDE mover drives tetrahedral meshes. One
         compact run walks the ladder — nodes move, nothing folds (every
-        tet keeps its orientation sign), slip keeps boundary nodes
+        tet keeps its orientation sign), and slip keeps boundary nodes
         EXACTLY on their box faces (the face-only 3D labels close down
-        to vertices now), and no swallowed callback errors (#376's
-        trigger exists identically in 3D)."""
-        import logging
-
+        to vertices now). Callback-sync failures (#376's trigger exists
+        identically in 3D) RAISE since the #379 rework, so a clean run
+        is itself the guard — no log capture needed."""
         from underworld3.meshing.smoothing.graph import (
             _tet_cells, _signed_volumes)
 
@@ -93,14 +92,9 @@ class TestNodeRedistribution:
         tets = _tet_cells(mesh.dm)
         sign0 = np.sign(_signed_volumes(before, tets))
 
-        with caplog.at_level(logging.WARNING,
-                             logger="underworld3.utilities.nd_array_callback"):
-            uw.meshing.node_redistribution(
-                mesh, rho, slip_surfaces=True,
-                method_kwargs=dict(n_outer=15))
-        bad = [r.message for r in caplog.records
-               if "allback error" in r.message]
-        assert not bad, f"swallowed callback errors: {bad[:3]}"
+        uw.meshing.node_redistribution(
+            mesh, rho, slip_surfaces=True,
+            method_kwargs=dict(n_outer=15))
 
         after = np.asarray(mesh.X.coords)
         assert after.shape == before.shape            # topology preserved

--- a/tests/test_0764_node_redistribution.py
+++ b/tests/test_0764_node_redistribution.py
@@ -7,9 +7,10 @@ algorithm names (NVB, MMPDE) live in internals and docs. Locked here:
   fixed-topology node redistribution — dispatches through the
   mesh-controlled ``Mesh.redistribute_nodes`` method (mesh types control
   how they can be modified);
-* supported: 2D simplex (triangle) meshes, warning-free;
-* unsupported mesh types (quad/hex, 3D simplex, manifolds) raise an
-  honest ``NotImplementedError`` stating what exists;
+* supported: 2D (triangle) and 3D (tetrahedral) simplex meshes,
+  warning-free;
+* unsupported mesh types (quad/hex, manifolds) raise an honest
+  ``NotImplementedError`` stating what exists;
 * ``mesh.adapt(metric, max_levels=...)`` needs no ``engine=`` and
   defaults to the graded NVB engine on 2D meshes.
 """
@@ -68,13 +69,50 @@ class TestNodeRedistribution:
                            match="2D simplex"):
             uw.meshing.node_redistribution(mesh, sympy.sympify(1))
 
-    def test_3d_simplex_raises_not_implemented(self):
+    def test_3d_simplex_moves_no_fold_boundary_held(self, caplog):
+        """3D node redistribution landed with the adaptivity capstone
+        (round 2): the same MMPDE mover drives tetrahedral meshes. One
+        compact run walks the ladder — nodes move, nothing folds (every
+        tet keeps its orientation sign), slip keeps boundary nodes
+        EXACTLY on their box faces (the face-only 3D labels close down
+        to vertices now), and no swallowed callback errors (#376's
+        trigger exists identically in 3D)."""
+        import logging
+
+        from underworld3.meshing.smoothing.graph import (
+            _tet_cells, _signed_volumes)
+
         mesh = uw.meshing.UnstructuredSimplexBox(
             minCoords=(0.0, 0.0, 0.0), maxCoords=(1.0, 1.0, 1.0),
-            cellSize=0.5)
-        with pytest.raises(NotImplementedError,
-                           match="2D simplex"):
-            uw.meshing.node_redistribution(mesh, sympy.sympify(1))
+            cellSize=0.3)
+        x, y, z = mesh.X
+        d = sympy.Abs((x - 0.35) * 0.866 + (z - 1.0) * 0.5)
+        rho = 1.0 + 15.0 * sympy.exp(-((d / 0.15) ** 2))
+
+        before = np.asarray(mesh.X.coords).copy()
+        tets = _tet_cells(mesh.dm)
+        sign0 = np.sign(_signed_volumes(before, tets))
+
+        with caplog.at_level(logging.WARNING,
+                             logger="underworld3.utilities.nd_array_callback"):
+            uw.meshing.node_redistribution(
+                mesh, rho, slip_surfaces=True,
+                method_kwargs=dict(n_outer=15))
+        bad = [r.message for r in caplog.records
+               if "allback error" in r.message]
+        assert not bad, f"swallowed callback errors: {bad[:3]}"
+
+        after = np.asarray(mesh.X.coords)
+        assert after.shape == before.shape            # topology preserved
+        assert np.all(np.isfinite(after))
+        assert not np.allclose(before, after)         # nodes actually moved
+        # no fold: every tet keeps its original orientation sign
+        assert np.array_equal(np.sign(_signed_volumes(after, tets)), sign0)
+        # slip holds boundary nodes exactly on their planes
+        for k in range(3):
+            for v in (0.0, 1.0):
+                onf = np.isclose(before[:, k], v, atol=1.0e-9)
+                assert np.allclose(after[onf, k], v, atol=1.0e-9)
 
     def test_exported_from_meshing_namespace(self):
         assert "node_redistribution" in uw.meshing.__all__

--- a/tests/test_0850_mesh_smoothing.py
+++ b/tests/test_0850_mesh_smoothing.py
@@ -189,37 +189,25 @@ class TestPinningAPI:
 
 
 class TestMMPDEDimensionGuard:
-    """The MMPDE mover is 2D-only (READ-01/BF-09, 2026-07 audit): the 3D
-    branch used to reference `_signed_volumes`, which was never implemented,
-    so any 3D invocation died with a NameError deep in the mover. The
-    contract is now an immediate, honest NotImplementedError for cdim != 2,
-    while 2D invocation keeps working."""
+    """The MMPDE mover supports 2D (triangle) and 3D (tetrahedral)
+    simplex meshes (the 3D discretization landed with the adaptivity
+    capstone, round 2 — the mover core was dimension-general all along).
+    The guard now rejects only dimensions with no discretization, before
+    any metric parsing or DM work. The 3D capability itself is locked in
+    test_0764 (moves, no fold, boundary held)."""
 
-    def test_mmpde_3d_raises_not_implemented(self):
-        import sympy
-        mesh = uw.meshing.UnstructuredSimplexBox(
-            minCoords=(0.0, 0.0, 0.0),
-            maxCoords=(1.0, 1.0, 1.0),
-            cellSize=0.5,
-        )
-        with pytest.raises(NotImplementedError,
-                           match="MMPDE mesh movement is currently 2D-only"):
-            smooth_mesh_interior(
-                mesh, metric=sympy.sympify(1), method="mmpde",
-                method_kwargs=dict(n_outer=1))
-
-    def test_mmpde_3d_guard_fires_before_any_mesh_work(self):
+    def test_mmpde_unsupported_dim_guard_fires_before_any_mesh_work(self):
         """The guard reads only mesh.cdim, before metric parsing or DM
         access, so a minimal cdim stand-in locks the contract
         deterministically (same pattern as test_0762's non2d tests)."""
         from underworld3.meshing.smoothing import _mmpde_mover
 
-        class _Mesh3D:
-            cdim = 3
+        class _Mesh1D:
+            cdim = 1
 
         with pytest.raises(NotImplementedError,
-                           match="MMPDE mesh movement is currently 2D-only"):
-            _mmpde_mover(_Mesh3D(), metric=1, pinned_labels=(),
+                           match="2D .triangle. and 3D"):
+            _mmpde_mover(_Mesh1D(), metric=1, pinned_labels=(),
                            verbose=False)
 
     def test_mmpde_2d_smoke_still_works(self):


### PR DESCRIPTION
## What this adds

`mesh.redistribute_nodes()` — moving a mesh's nodes so cell sizes follow a metric, with the topology fixed — now works on 3D tetrahedral meshes, serial and parallel. This removes the second of the two issues the adaptivity "capstone" set out to retire (the first, 3D refinement, landed in #378). The user API does not change: the same call, the same metric forms (scalar density or full tensor), the same slip-surface options.

## Why changes are considered minor

The mover's mathematics (the Huang–Kamenski variational method, reference [1]) was implemented dimension-generally from the start — the per-element algebra never assumed two dimensions. What kept 3D from working sat at the rim: the cell list, the signed cell measure, and the factorial volume factor were hard-wired for triangles, and the entry points refused anything else. Those now dispatch on dimension (a ten-line signed-volume routine is the only new numerics), and the guards state what is genuinely unsupported (quad/hex meshes, constrained manifolds).

## Measured behaviour

- Serial, on a box with a dipping-fault-plane metric: monotone energy descent, zero folded cells, boundary nodes held **exactly** on their faces under slip.
- The grading reaches a ratio of 1.12 between far-field and on-fault cell size, against 1.30 for the identical problem in 2D. That compression is expected, not a defect: cell size follows the metric as its d-th root, so the same metric contrast that ideally gives 4x in 2D can only ever give 2.5x in 3D. Repeated calls hold a stable equilibrium rather than compounding — the same character as 2D, and the useful regime for the intended composition (mild base-grading with bisection refinement on top, the round-3 experiment).
- Parallel at 1, 2, and 4 ranks: runs clean (exercising the reworked collective sync machinery from #381-#385 in 3D), zero folds, boundary exact, and the near/far cell-size medians agree across partitions to within 2.5 percent — the documented few-percent equilibrium drift from the rank-local step cap, unchanged from 2D.
- `follow_metric` runs end-to-end on 3D meshes (its shape-quality polish gained the tetrahedral formula).

## Review

An independent adversarial review of the branch found no correctness defects (it verified the orientation-sign conventions of the fold guard against DMPlex's det-negative reference tets, the bit-identity of the 2D boundary mask, and the parallel consistency of the label closure). Its findings — stale "the mover is 2D-only" rationale in two metric-builder error messages, and an incorrect log-capture guard in the new test — are fixed in the final commit; a pre-existing empty-rank hazard shared with the 2D path is marked at the site.

## Evidence

Full mover/adapt serial family: 215 tests green. New/flipped contract tests in test_0764 (3D capability: moves, no fold, boundary held exactly) and test_0850_mesh_smoothing (the dimension guard now rejects only dimensions with no discretization). Style gate clean, no allowlist additions.

Design note with the round-2 status and measurements: `docs/developer/design/ADAPTIVITY_3D_SPHERICAL_2026-07.md`.

[1] Huang & Kamenski, J. Comput. Phys. 301 (2015) 322 (arXiv:1410.7872).

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)