### PR TITLE
fix(checkpoint): read_timestep uses one coordinate frame across sessions — DG0 fields no longer collapse (#269)

### DIFF
--- a/src/underworld3/discretisation/discretisation_mesh_variables.py
+++ b/src/underworld3/discretisation/discretisation_mesh_variables.py
@@ -1066,7 +1066,14 @@ class _BaseMeshVariable(Stateful, uw_object):
         lvec = dmnew.getLocalVec()
         gvec = dmnew.getGlobalVec()
 
-        lvec.array[...] = self.coords.reshape(-1)[...]
+        # Frame contract (#269): the remap dataset stores MODEL-frame
+        # (non-dimensional) coordinates — the same frame as the mesh-file
+        # geometry and as a reading session's ``coords_nd``, independent of
+        # the units state of either session. ``.coords`` is frame-dependent
+        # (dimensional under an active units model) and baked a
+        # session-dependent frame into the file, which made
+        # ``read_timestep`` silently mis-match in any other session.
+        lvec.array[...] = numpy.asarray(self.coords_nd).reshape(-1)[...]
         dmnew.localToGlobal(lvec, gvec, addv=False)
         gvec.setName("coordinates")
 
@@ -1244,10 +1251,53 @@ class _BaseMeshVariable(Stateful, uw_object):
         landed_D = saved.array[:, 0, :]
 
         # ---- Phase 2: query swarm round-trips live DOFs to source rank ----
-        query_coords = self.coords
-        if hasattr(query_coords, "magnitude"):
-            query_coords = query_coords.magnitude
+        # Model-frame query to match the file's model-frame coordinates —
+        # the frame contract stated on ``write`` (#269). ``.coords`` is
+        # frame-dependent (dimensional under an active units model) and
+        # silently mis-matched whenever the writing and reading sessions
+        # differed in units state.
+        query_coords = np.asarray(self.coords_nd)
         n_query_local = query_coords.shape[0]
+
+        # Frame guard (#269): a checkpoint from the older writer under an
+        # active units model stores DIMENSIONAL coordinates instead of the
+        # model frame; nearest-neighbour matching across that scale
+        # mismatch returns a silently wrong, near-constant field. Compare
+        # the two clouds' extents and refuse loudly instead. (Collective:
+        # extents are reduced on every rank, so all ranks raise together.)
+        from mpi4py import MPI
+
+        file_diag = 0.0
+        if uw.mpi.rank == 0 and X_src.shape[0] > 0:
+            file_diag = float(np.linalg.norm(X_src.max(axis=0) - X_src.min(axis=0)))
+        file_diag = uw.mpi.comm.bcast(file_diag, root=0)
+
+        if n_query_local > 0:
+            local_min = np.ascontiguousarray(query_coords.min(axis=0), dtype=np.float64)
+            local_max = np.ascontiguousarray(query_coords.max(axis=0), dtype=np.float64)
+        else:
+            local_min = np.full(dim, np.inf)
+            local_max = np.full(dim, -np.inf)
+        q_min = np.empty(dim, dtype=np.float64)
+        q_max = np.empty(dim, dtype=np.float64)
+        uw.mpi.comm.Allreduce(local_min, q_min, op=MPI.MIN)
+        uw.mpi.comm.Allreduce(local_max, q_max, op=MPI.MAX)
+        query_diag = float(np.linalg.norm(q_max - q_min))
+
+        if file_diag > 0.0 and query_diag > 0.0:
+            scale_ratio = file_diag / query_diag
+            if scale_ratio > 10.0 or scale_ratio < 0.1:
+                raise RuntimeError(
+                    f"read_timestep: the saved coordinate cloud extent "
+                    f"({file_diag:.4g}) and the live DOF extent ({query_diag:.4g}) "
+                    f"differ by x{scale_ratio:.3g} — the coordinate frames do not "
+                    "match, and a nearest-neighbour remap would return silently "
+                    "wrong values. This usually means the checkpoint was written "
+                    "by an older writer with an active units model (dimensional "
+                    "coordinates in 'fields/coordinates'; issue #269). Re-write "
+                    "the checkpoint with current code, or read the raw dataset "
+                    "directly from the HDF5 file ('fields/<name>')."
+                )
         original_index = np.arange(n_query_local).reshape(-1, 1, 1)
 
         query_swarm = uw.swarm.Swarm(self.mesh)

--- a/tests/test_0003_save_load.py
+++ b/tests/test_0003_save_load.py
@@ -282,3 +282,93 @@ def test_write_timestep_missing_directory_raises(tmp_path):
 
     with pytest.raises(RuntimeError, match="does not exist"):
         mesh.write_timestep("chk", index=0, outputPath=str(missing_dir / "run"))
+
+
+def test_dg0_read_timestep_across_units_sessions(tmp_path):
+    """#269 regression: a DG0 field written under an active units model must
+    read back correctly in a session WITHOUT that model.
+
+    The remap contract stores model-frame coordinates (see
+    ``MeshVariable.write``). The old writer stored ``.coords`` — dimensional
+    under an active units model — so a units-free reading session queried in
+    the model frame against a dimensionally-scaled file cloud and got a
+    silently wrong, near-constant field (the Spiegelman ``edot`` symptom).
+    """
+    import underworld3 as uw
+
+    tmp_path = _shared_tmp_path(tmp_path, uw)
+
+    uw.reset_default_model()
+    orchestration_model = uw.get_default_model()
+    orchestration_model.set_reference_quantities(
+        length=uw.quantity(30, "km"),
+        velocity=uw.quantity(2.5, "cm/year"),
+        viscosity=uw.quantity(1e21, "Pa*s"),
+    )
+    try:
+        mesh = uw.meshing.StructuredQuadBox(
+            elementRes=(8, 8), minCoords=(0.0, 0.0), maxCoords=(1.0, 1.0),
+            units="metre")
+        v = uw.discretisation.MeshVariable("edot", mesh, 1, degree=0, continuous=False)
+        c_nd = np.asarray(v.coords_nd)
+        v.data[:, 0] = np.sin(3.0 * c_nd[:, 0]) + c_nd[:, 1]
+        wrote = np.asarray(v.data)[:, 0].copy()
+
+        mesh.write_timestep("chk269", index=0, outputPath=tmp_path, meshVars=[v])
+    finally:
+        # The reading "session" has no units model — the failing benchmark
+        # context (post-processing without set_reference_quantities).
+        uw.reset_default_model()
+
+    mesh2 = uw.discretisation.Mesh(f"{tmp_path}/chk269.mesh.00000.h5")
+    w = uw.discretisation.MeshVariable("edot", mesh2, 1, degree=0, continuous=False)
+    w.read_timestep("chk269", "edot", 0, outputPath=tmp_path)
+    got = np.asarray(w.data)[:, 0]
+
+    # The two meshes partition differently, so compare GLOBAL statistics of
+    # the per-cell value multiset (identical cells, exact nearest match).
+    def _global_stats(a):
+        from mpi4py import MPI
+
+        n = uw.mpi.comm.allreduce(int(a.size), op=MPI.SUM)
+        s = uw.mpi.comm.allreduce(float(a.sum()), op=MPI.SUM)
+        ss = uw.mpi.comm.allreduce(float((a * a).sum()), op=MPI.SUM)
+        mn = uw.mpi.comm.allreduce(float(a.min()) if a.size else np.inf, op=MPI.MIN)
+        mx = uw.mpi.comm.allreduce(float(a.max()) if a.size else -np.inf, op=MPI.MAX)
+        return n, s, ss, mn, mx
+
+    n_w, s_w, ss_w, mn_w, mx_w = _global_stats(wrote)
+    n_g, s_g, ss_g, mn_g, mx_g = _global_stats(got)
+
+    assert n_g == n_w
+    assert np.isclose(s_g, s_w, rtol=1e-10) and np.isclose(ss_g, ss_w, rtol=1e-10), (
+        f"DG0 field corrupted on cross-session read: global (sum, sum-sq) "
+        f"wrote ({s_w}, {ss_w}) vs read ({s_g}, {ss_g})"
+    )
+    assert np.isclose(mn_g, mn_w) and np.isclose(mx_g, mx_w)
+
+
+def test_read_timestep_refuses_frame_mismatched_file(tmp_path):
+    """#269 guard: a file whose saved coordinate cloud is on a wildly
+    different scale from the live DOFs (a legacy dimensional-frame
+    checkpoint) must raise, not silently return nearest-garbage."""
+    import underworld3 as uw
+
+    tmp_path = _shared_tmp_path(tmp_path, uw)
+
+    mesh = uw.meshing.StructuredQuadBox(
+        elementRes=(4, 4), minCoords=(0.0, 0.0), maxCoords=(1.0, 1.0))
+    v = uw.discretisation.MeshVariable("phi269", mesh, 1, degree=0, continuous=False)
+    v.data[:, 0] = np.asarray(v.coords_nd)[:, 0]
+    mesh.write_timestep("chk269g", index=0, outputPath=tmp_path, meshVars=[v])
+
+    # Emulate the legacy writer: scale the stored remap coordinates the way
+    # an active units model did (metres for a km-scaled domain).
+    if uw.mpi.rank == 0:
+        with h5py.File(f"{tmp_path}/chk269g.mesh.phi269.00000.h5", "r+") as f:
+            f["fields/coordinates"][...] = f["fields/coordinates"][...] * 30000.0
+    uw.mpi.barrier()
+
+    w = uw.discretisation.MeshVariable("phi269b", mesh, 1, degree=0, continuous=False)
+    with pytest.raises(RuntimeError, match="coordinate frames do not match"):
+        w.read_timestep("chk269g", "phi269", 0, outputPath=tmp_path)


### PR DESCRIPTION
Closes #269.

## The bug, finally isolated

`MeshVariable.read_timestep()` returned a silently wrong, near-constant field for the Spiegelman benchmark's DG0 variables (`edot`, viscosity, stress), while the HDF5 file held correct data. The issue could not isolate the trigger among its three suspects — multi-variable checkpoint, gmsh mesh, units model. A factor-matrix reproducer showed why: **all eight combinations round-trip correctly within one session.** The real trigger is a **units-state change between the writing and the reading session**:

- `MeshVariable.write()` stored `fields/coordinates` from `.coords`, which is **dimensional** when a units model is active (the benchmark's file: coordinate extent ±1.8e6 — km-frame gmsh numbers multiplied by the 30 km scale in metres — against a mesh file storing ±60);
- `read_timestep()` queried with the **reading** session's `.coords`. The failing context was post-processing/rendering — a session that never calls `set_reference_quantities`, so it queried in the model frame against a dimensionally-scaled cloud, and the nearest-neighbour match returned garbage. In-session reads re-applied the same scale, which is why the bug hid from every single-session reproducer.

DG0 was simply where this was visible (nearest-neighbour with no smoothing); the frame dependence affected every variable in such checkpoints.

## The fix

1. **One frame, by contract.** Both sides of the remap now use the **model frame** (`coords_nd`) — the same frame as the mesh-file geometry, identical in every session regardless of units state. Files written without an active units model are unchanged (the frames coincide), so existing healthy checkpoints keep reading.
2. **A loud guard for legacy corrupt files.** `read_timestep` now compares the saved coordinate-cloud extent with the live DOF extent (collectively, so all ranks act together) and raises a `RuntimeError` naming the cause and the workarounds when they differ by more than 10x. Verified against the actual corrupt Spiegelman artifact: extent ratio 3e4, now refused with a clear message instead of returning a constant.

## Verification

- Factor matrix (multi-var × units × gmsh, 8 combinations): all round-trip, before and after.
- The km-frame benchmark shape (gmsh coordinates in km numbers, 30 km reference length), written under units and read in a units-free session: **wrong values before** (std 8.52 written vs 0.61 read), **exact after**.
- New regression tests in `tests/test_0003_save_load.py`: cross-session DG0 round-trip (global-statistics comparison, partition-independent) and the frame-mismatch refusal — pass at serial, np2 and np4.
- `test_0003` mesh-variable tests pass at np2; the swarm-test failure/hang in that file is the pre-existing, already-tracked #330 (Swarm.save metadata race), unrelated to this diff.
- Full level_1 + tier_a gate: **438 passed**, 11 skipped, 1 xfail (pre-existing), 0 failures.

## Found on the way

- #397 filed: `mesh.write()` crashes for a mesh loaded directly from a `.msh` file (`CoordinateSystemType` is None).
- The double-scaling that produced the ±1.8e6 coordinates (km-frame numbers × SI length scale) is the same units-mislabel class as #386; with the model-frame contract it no longer reaches these files.

Reminder for the merge: manual issue close needed (#269) — PRs target development, so GitHub auto-close does not fire.

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)