### PR TITLE
Empty-rank mesh construction, tensor stats, global metric moments, swarm.points label

### DIFF
--- a/src/underworld3/ckdtree.pyx
+++ b/src/underworld3/ckdtree.pyx
@@ -624,7 +624,9 @@ cdef class KDTree:
         # Note: query() returns sqr_dists=True by default, and we use the converted coords
         distance_n, closest_n = self.query(coords, k=nnn)
 
-        if np.any(closest_n > self.n):
+        # valid indices are 0..n-1; the empty-tree sentinel (0 with n=0)
+        # must trip this guard, so the comparison is >= (issue #399).
+        if np.any(closest_n >= self.n):
             raise RuntimeError(
                 "Error in rbf_interpolator_local_from_kdtree - a nearest neighbour wasn't found"
             )

--- a/src/underworld3/ckdtree.pyx
+++ b/src/underworld3/ckdtree.pyx
@@ -91,6 +91,16 @@ cdef class KDTree:
         import underworld3.function.unit_conversion as unit_conv
         self.coord_units = unit_conv.get_units(points_input) if unit_conv.has_units(points_input) else None
 
+        # A legible error beats the memoryview's "Buffer has wrong number
+        # of dimensions" — the common trigger is numpy.array([]) from an
+        # empty point list, which is 1-D (issue #399).
+        if points_input.ndim != 2:
+            raise RuntimeError(
+                f"KDTree points must be a 2-D (n_points, dim) array, "
+                f"got shape {points_input.shape}. (An empty point set must "
+                f"still be shaped (0, dim).)"
+            )
+
         # Extract raw numpy array for C++ interface
         cdef const double[:,::1] points
         if unit_conv.has_units(points_input):
@@ -101,7 +111,13 @@ cdef class KDTree:
         if points.shape[1] not in (2,3):
             raise RuntimeError(f"Provided points array dimensionality must be 2 or 3, not {points.shape[1]}.")
         self.points = points
-        self.index = new KDTree_Interface(<const double *> &points[0][0], points.shape[0], points.shape[1])
+        # An empty point cloud is legitimate — a parallel rank can own zero
+        # cells (issue #399). No C++ index is built (taking &points[0][0]
+        # would be invalid); the query methods return honest empties.
+        if points.shape[0] > 0:
+            self.index = new KDTree_Interface(<const double *> &points[0][0], points.shape[0], points.shape[1])
+        else:
+            self.index = NULL
 
         global _live_instances, _total_constructed
         _live_instances += 1
@@ -190,6 +206,8 @@ cdef class KDTree:
         """
         Build the kd-tree index.
         """
+        if self.index is NULL:
+            return
         self.index.build_index()
 
     def kdtree_points(self):
@@ -234,6 +252,14 @@ cdef class KDTree:
         indices  = np.empty(count, dtype=np.uint64,  order='C')
         dist_sqr = np.empty(count, dtype=np.float64, order='C')
         found    = np.empty(count, dtype=np.bool_,   order='C')
+
+        # Empty index (a rank owning zero points, issue #399): nothing can
+        # be found — report that honestly for every query.
+        if self.index is NULL or count == 0:
+            indices[...] = 0
+            dist_sqr[...] = np.inf
+            found[...] = False
+            return indices, dist_sqr, found
 
         cdef long unsigned int[::1]  c_indices = indices
         cdef            double[::1] c_dist_sqr = dist_sqr
@@ -280,6 +306,13 @@ cdef class KDTree:
 
         n_indices  = np.empty((coords.shape[0], nCount), dtype=np.uint64,  order='C')
         n_dist_sqr = np.empty((coords.shape[0], nCount), dtype=np.float64,  order='C')
+
+        # Empty index (a rank owning zero points, issue #399): no
+        # neighbours exist — infinite distances, sentinel indices.
+        if self.index is NULL or nInput == 0:
+            n_indices[...] = 0
+            n_dist_sqr[...] = np.inf
+            return n_indices, n_dist_sqr
 
         indices  = np.empty(nCount, dtype=np.uint64,  order='C')
         dist_sqr = np.empty(nCount, dtype=np.float64, order='C')

--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -5803,7 +5803,9 @@ class Mesh(Stateful, uw_object):
 
         if len(model_coords) > 0:
             dist, closest_points = self._index.query(model_coords, k=1, sqr_dists=False)
-            if np.any(closest_points > self._index.n):
+            # >= : valid indices are 0..n-1, and the empty-tree sentinel
+            # (0 with n=0) must trip this guard, not index _indexMap (#399).
+            if np.any(closest_points >= self._index.n):
                 raise RuntimeError(
                     "An error was encountered attempting to find the closest cells to the provided coordinates."
                 )
@@ -5876,7 +5878,9 @@ class Mesh(Stateful, uw_object):
 
         if len(coords) > 0:
             dist, closest_points = self._index.query(coords, k=1, sqr_dists=False)
-            if np.any(closest_points > self._index.n):
+            # >= : valid indices are 0..n-1, and the empty-tree sentinel
+            # (0 with n=0) must trip this guard, not index _indexMap (#399).
+            if np.any(closest_points >= self._index.n):
                 raise RuntimeError(
                     "An error was encountered attempting to find the closest cells to the provided coordinates."
                 )
@@ -6279,7 +6283,18 @@ class Mesh(Stateful, uw_object):
         import numpy as np
         from underworld3.utilities import gather_data
 
-        domain_centroid = self._centroids.mean(axis=0)
+        # A rank owning zero cells has no centroid; mean() of the empty
+        # array is NaN, and gather_data silently STRIPS NaN rows — the
+        # gathered table's row index then no longer equals rank, and
+        # _route_by_nearest_centroid mis-routes particles to the wrong
+        # rank (issue #399 review). A huge FINITE sentinel keeps the row
+        # (row == rank) while a nearest-centroid search can never select
+        # it, so starved ranks correctly receive no particles. (Finite,
+        # not inf: infinities poison the kd-tree's bounding boxes.)
+        if self._centroids.shape[0] > 0:
+            domain_centroid = self._centroids.mean(axis=0)
+        else:
+            domain_centroid = np.full(self.cdim, 1.0e30)
         all_centroids = gather_data(domain_centroid, bcast=True).reshape(-1, self.cdim)
         return all_centroids
 

--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -5171,7 +5171,12 @@ class Mesh(Stateful, uw_object):
             control_points_list.append(cell_centroid)
             control_points_cell_list.append(cell_id)
 
-        self._indexCoords = numpy.array(control_points_list)
+        # A rank can own zero cells (small mesh / imbalanced partition):
+        # shape the point arrays explicitly so an empty list becomes a
+        # well-formed (0, cdim) array rather than a 1-D numpy.array([]),
+        # which crashed the KDTree construction (issue #399).
+        self._indexCoords = numpy.array(
+            control_points_list, dtype=numpy.float64).reshape(-1, self.cdim)
         self._index = uw.kdtree.KDTree(self._indexCoords)
         # self._index.build_index()
         self._indexMap = numpy.array(control_points_cell_list, dtype=numpy.int64)
@@ -5182,7 +5187,8 @@ class Mesh(Stateful, uw_object):
         # We keep _nav_centroids separate from _centroids (which is
         # the main-DM cell centroids set in __init__) so the FE-side
         # ``_centroids`` semantics are unchanged on manifold meshes.
-        self._nav_centroids = numpy.array(centroids_list)
+        self._nav_centroids = numpy.array(
+            centroids_list, dtype=numpy.float64).reshape(-1, self.cdim)
         self._centroid_index = uw.kdtree.KDTree(self._nav_centroids)
 
         return

--- a/src/underworld3/discretisation/discretisation_mesh_variables.py
+++ b/src/underworld3/discretisation/discretisation_mesh_variables.py
@@ -3199,15 +3199,20 @@ class _BaseMeshVariable(Stateful, uw_object):
         )
 
         try:
-            # Compute Frobenius norm: ||A||_F = sqrt(sum(A_ij^2))
-            # Components are read through the FLAT layout: a tensor's
-            # .array is structured (N, d, d), so indexing it with the flat
-            # component count d*d walked off the axis (issue #400).
+            # Compute Frobenius norm: ||A||_F = sqrt(sum_ij(A_ij^2))
+            # Structured (N, d, d) reads (issue #400): correct for full
+            # tensors AND for symmetric storage — the .array view mirrors
+            # the Voigt components, so off-diagonals are counted twice as
+            # the Frobenius sum requires. (Flat component reads counted
+            # each Voigt entry once and under-measured SYM_TENSOR norms;
+            # the original structured read with the FLAT component count
+            # walked off the axis.)
             with uw.synchronised_array_update():
+                arr = np.asarray(self.array)
                 sum_squares = 0.0
-                for i in range(self.num_components):
-                    component = np.asarray(self.data[:, i]).flatten()
-                    sum_squares += component**2
+                for i in range(self.shape[0]):
+                    for j in range(self.shape[1]):
+                        sum_squares = sum_squares + arr[:, i, j] ** 2
                 frobenius_var.array[:, 0, 0] = np.sqrt(sum_squares)
 
             # Get scalar stats on Frobenius norm

--- a/src/underworld3/discretisation/discretisation_mesh_variables.py
+++ b/src/underworld3/discretisation/discretisation_mesh_variables.py
@@ -3190,16 +3190,23 @@ class _BaseMeshVariable(Stateful, uw_object):
                 f"Cannot compute tensor stats: a variable named '{temp_name}' "
                 "already exists on this mesh (reserved as a stats temporary)."
             )
-        frobenius_var = uw.discretisation.MeshVariable(
+        # _BaseMeshVariable, matching _vector_stats: the enhanced wrapper's
+        # __getattr__ refuses underscore-name delegation, so the
+        # _scalar_stats call below would raise AttributeError through it
+        # (second latent defect under issue #400).
+        frobenius_var = _BaseMeshVariable(
             temp_name, self.mesh, 1, degree=self.degree
         )
 
         try:
             # Compute Frobenius norm: ||A||_F = sqrt(sum(A_ij^2))
+            # Components are read through the FLAT layout: a tensor's
+            # .array is structured (N, d, d), so indexing it with the flat
+            # component count d*d walked off the axis (issue #400).
             with uw.synchronised_array_update():
                 sum_squares = 0.0
                 for i in range(self.num_components):
-                    component = self.array[:, 0, i].flatten()
+                    component = np.asarray(self.data[:, i]).flatten()
                     sum_squares += component**2
                 frobenius_var.array[:, 0, 0] = np.sqrt(sum_squares)
 

--- a/src/underworld3/meshing/smoothing/metrics.py
+++ b/src/underworld3/meshing/smoothing/metrics.py
@@ -9,7 +9,7 @@ import numpy as np
 
 import underworld3 as uw
 
-from .graph import _tri_cells, _signed_areas, _global_sum
+from .graph import _tri_cells, _signed_areas, _global_sum, _global_max
 
 
 # Named adaptation strategies (off / vlow / low / med / high /
@@ -135,44 +135,48 @@ def mesh_metric_mismatch(mesh, metric, resolution_ratio=None):
     import underworld3 as _uw
 
     coords = np.asarray(mesh.X.coords)
-    if mesh.cdim == 2:
-        tris = _tri_cells(mesh.dm)
-        A_actual = None if tris is None else np.abs(
-            _signed_areas(coords, tris))
+    cStart, cEnd = mesh.dm.getHeightStratum(0)
+    if cEnd > cStart:
+        if mesh.cdim == 2:
+            tris = _tri_cells(mesh.dm)
+            A_actual = None if tris is None else np.abs(
+                _signed_areas(coords, tris))
+        else:
+            from .graph import _tet_cells, _signed_volumes
+            tris = _tet_cells(mesh.dm)
+            A_actual = None if tris is None else np.abs(
+                _signed_volumes(coords, tris))
+        if tris is None:
+            raise NotImplementedError(
+                "mesh_metric_mismatch: simplex (triangle/tetrahedral) mesh "
+                "required")
+        centroids = coords[tris].mean(axis=1)
+        rho = np.asarray(_uw.function.evaluate(
+            metric, centroids)).reshape(-1)
+        rho = np.maximum(rho, 1.0e-12)   # guard
     else:
-        from .graph import _tet_cells, _signed_volumes
-        tris = _tet_cells(mesh.dm)
-        A_actual = None if tris is None else np.abs(
-            _signed_volumes(coords, tris))
-    if tris is None:
-        raise NotImplementedError(
-            "mesh_metric_mismatch: simplex (triangle/tetrahedral) mesh "
-            "required")
-    centroids = coords[tris].mean(axis=1)
-    rho = np.asarray(_uw.function.evaluate(
-        metric, centroids)).reshape(-1)
-    rho = np.maximum(rho, 1.0e-12)   # guard
-    inv_rho = 1.0 / rho
-    # TODO(BUG): A_target (and A_mean below) are built from rank-LOCAL
-    # sums, so under MPI the delta moments returned here (rms / max /
-    # median_abs) are partition-dependent diagnostics measured against a
-    # per-rank equidistribution target, not the global one the docstring
-    # describes. The skip signal consumed by smooth_mesh_interior
-    # (alignment / misalignment) is NOT affected — it is computed from
-    # globally reduced moment sums further down. Fix: reduce
-    # A_actual.sum(), inv_rho.sum() and the cell count globally before
-    # forming A_target / A_mean (delta stays a local array; its moments
-    # then need global reductions too).
-    A_target = A_actual.sum() * inv_rho / inv_rho.sum()
+        # A rank owning zero cells still participates in every global
+        # reduction below with empty contributions — raising or returning
+        # early here would desynchronise the collectives.
+        A_actual = np.empty(0)
+        rho = np.empty(0)
+    inv_rho = 1.0 / rho if rho.size else np.empty(0)
+    # Global equidistribution target (issue #351): the sums and the cell
+    # count are reduced across ranks — rank-local sums measured each
+    # rank's cells against a per-rank target, so the returned moments
+    # were partition-dependent and inconsistent with the docstring.
+    sum_A = _global_sum(A_actual.sum())
+    sum_inv_rho = _global_sum(inv_rho.sum())
+    A_target = sum_A * inv_rho / sum_inv_rho
     if resolution_ratio is not None:
         R = float(resolution_ratio)
-        A_mean = A_actual.sum() / len(A_actual)
+        A_mean = sum_A / _global_sum(A_actual.size)
         # Clip target areas to the mover's achievable band
         # [A_mean/R², A_mean·R²] (h in [h0/R, h0·R] ⇒
         # A in [h0²/R², h0²·R²] = [A_mean/R², A_mean·R²]).
         A_target = np.clip(A_target, A_mean / R ** 2,
                            A_mean * R ** 2)
-    delta = 0.5 * np.log(A_actual / A_target)
+    delta = 0.5 * np.log(A_actual / A_target) if A_actual.size else np.empty(0)
     abs_delta = np.abs(delta)
 
     # Alignment — Pearson r of log(1/A_c) with log(ρ_c).
@@ -210,9 +214,24 @@ def mesh_metric_mismatch(mesh, metric, resolution_ratio=None):
     misalignment = float(
         np.sqrt(max(0.0, 1.0 - max(0.0, alignment) ** 2)))
 
-    return dict(rms=float(np.sqrt(np.mean(delta ** 2))),
-                max=float(abs_delta.max()),
-                median_abs=float(np.median(abs_delta)),
+    # Global moments of |δ| (issue #351): every rank reports the same
+    # diagnostics. The exact median needs the values in one place — this
+    # is a diagnostic at adapt cadence, so gather |δ| to rank 0 and
+    # broadcast the scalar.
+    n_cells = _global_sum(delta.size)
+    rms = float(np.sqrt(_global_sum((delta ** 2).sum()) / n_cells))
+    delta_max = _global_max(abs_delta.max() if abs_delta.size else 0.0)
+    if _uw.mpi.size > 1:
+        gathered = _uw.mpi.comm.gather(abs_delta, root=0)
+        median_abs = (float(np.median(np.concatenate(gathered)))
+                      if _uw.mpi.rank == 0 else None)
+        median_abs = _uw.mpi.comm.bcast(median_abs, root=0)
+    else:
+        median_abs = float(np.median(abs_delta))
+
+    return dict(rms=rms,
+                max=float(delta_max),
+                median_abs=median_abs,
                 alignment=alignment,
                 misalignment=misalignment)
 

--- a/src/underworld3/meshing/smoothing/metrics.py
+++ b/src/underworld3/meshing/smoothing/metrics.py
@@ -134,6 +134,16 @@ def mesh_metric_mismatch(mesh, metric, resolution_ratio=None):
     """
     import underworld3 as _uw
 
+    # Rank-SYMMETRIC refusal for non-simplex meshes: mesh.isSimplex is a
+    # rank-uniform property, so every rank raises together. (The per-rank
+    # tris-is-None check below cannot serve — a starved rank has no cells
+    # to inspect and would sail into the collective reductions while the
+    # populated ranks raise; issue #351 review.)
+    if not mesh.isSimplex:
+        raise NotImplementedError(
+            "mesh_metric_mismatch: simplex (triangle/tetrahedral) mesh "
+            "required")
+
     coords = np.asarray(mesh.X.coords)
     cStart, cEnd = mesh.dm.getHeightStratum(0)
     if cEnd > cStart:
@@ -155,9 +165,17 @@ def mesh_metric_mismatch(mesh, metric, resolution_ratio=None):
             metric, centroids)).reshape(-1)
         rho = np.maximum(rho, 1.0e-12)   # guard
     else:
-        # A rank owning zero cells still participates in every global
-        # reduction below with empty contributions — raising or returning
-        # early here would desynchronise the collectives.
+        # A rank owning zero cells participates in the global reductions
+        # below with empty contributions — raising or returning early here
+        # would desynchronise the collectives.
+        #
+        # KNOWN LIMIT: this skips uw.function.evaluate, which is itself
+        # collective for metrics containing MESH-VARIABLE data — a starved
+        # rank then deadlocks the populated ranks inside evaluate. Full
+        # starved-rank support for field-valued metrics needs the
+        # evaluate/points_in_domain layer to be empty-rank safe first
+        # (tracked with the #399 follow-up issue). Analytic (pure-sympy)
+        # metrics are fine: their evaluation is rank-local.
         A_actual = np.empty(0)
         rho = np.empty(0)
     inv_rho = 1.0 / rho if rho.size else np.empty(0)

--- a/src/underworld3/swarm.py
+++ b/src/underworld3/swarm.py
@@ -3247,8 +3247,10 @@ class Swarm(Stateful, uw_object):
         # Scale model coordinates to physical coordinates
         if hasattr(self.mesh.CoordinateSystem, "_scaled") and self.mesh.CoordinateSystem._scaled:
             coords = model_coords * self.mesh.CoordinateSystem._length_scale
+            scaled_to_si = True
         else:
             coords = model_coords
+            scaled_to_si = False
 
         coords.flags.writeable = False
         coords = coords.view(_ReadOnlyCoordinateSnapshot)
@@ -3256,7 +3258,13 @@ class Swarm(Stateful, uw_object):
         if hasattr(self.mesh, "units") and self.mesh.units is not None:
             from underworld3.utilities.unit_aware_array import UnitAwareArray
 
-            return UnitAwareArray(coords, units=self.mesh.units)
+            # The _length_scale factor converts model coordinates to SI
+            # metres, so scaled values are labelled "meter" — the same
+            # convention as mesh.X.coords. Labelling metre magnitudes with
+            # mesh.units (e.g. kilometres) was a 1000x label/value
+            # mismatch (issue #386).
+            return UnitAwareArray(
+                coords, units="meter" if scaled_to_si else self.mesh.units)
 
         return coords
 

--- a/tests/parallel/test_0700_basic_parallel_operations.py
+++ b/tests/parallel/test_0700_basic_parallel_operations.py
@@ -328,3 +328,18 @@ if __name__ == "__main__":
     import sys
 
     sys.exit(pytest.main([__file__, "-v", "--with-mpi"]))
+
+
+@pytest.mark.mpi(min_size=4)
+def test_empty_rank_mesh_construction():
+    """#399: mesh construction must survive ranks that own zero cells.
+
+    A 2x2 quad box at np4 starves at least one rank; the navigation
+    kd-tree build then received a 1-D empty array and crashed (with the
+    other ranks dying on the resulting collective divergence).
+    """
+    mesh = uw.meshing.StructuredQuadBox(elementRes=(2, 2))
+    uw.discretisation.MeshVariable("T399", mesh, 1, degree=1)
+
+    area = float(uw.maths.Integral(mesh, 1.0).evaluate())
+    assert np.isclose(area, 1.0, rtol=1e-10), f"domain area = {area}"

--- a/tests/parallel/test_0750_global_statistics.py
+++ b/tests/parallel/test_0750_global_statistics.py
@@ -389,3 +389,25 @@ if __name__ == "__main__":
     import sys
 
     sys.exit(pytest.main([__file__, "-v", "--with-mpi"]))
+
+
+@pytest.mark.mpi(min_size=2)
+def test_metric_mismatch_moments_partition_independent():
+    """#351: mesh_metric_mismatch must return the SAME delta moments on
+    every rank — the sums feeding A_target/A_mean and the moments
+    themselves are globally reduced (rank-local sums made the diagnostics
+    partition-dependent)."""
+    import sympy
+    from underworld3.meshing.smoothing.metrics import mesh_metric_mismatch
+
+    mesh = uw.meshing.UnstructuredSimplexBox(
+        minCoords=(0.0, 0.0), maxCoords=(1.0, 1.0), cellSize=0.1)
+    x, y = mesh.X
+
+    result = mesh_metric_mismatch(mesh, 1.0 + 10.0 * x)
+
+    for key in ("rms", "max", "median_abs", "alignment", "misalignment"):
+        gathered = uw.mpi.comm.allgather(result[key])
+        assert max(gathered) - min(gathered) < 1e-14, (
+            f"{key} differs across ranks: {gathered}"
+        )

--- a/tests/test_0101_kdtree.py
+++ b/tests/test_0101_kdtree.py
@@ -137,3 +137,26 @@ def test_mesh_centroid(res, dim, fill_param):
     assert np.any(kdpt > index.n) == False, "Some point weren't found. Error"
     # `find_closest_point` should return index of pts.
     assert np.allclose(cellid, kdpt), "Point indices weren't as expected."
+
+
+def test_empty_point_cloud():
+    """#399: a KDTree over zero points is legitimate — a parallel rank can
+    own no cells. Construction succeeds and queries report not-found."""
+    kd = uw.kdtree.KDTree(np.empty((0, 2)))
+    assert kd.n == 0
+
+    query = np.array([[0.5, 0.5]])
+    indices, dist_sqr, found = kd.find_closest_point(query)
+    assert not found[0]
+    assert np.isinf(dist_sqr[0])
+
+    n_idx, n_dist = kd.find_closest_n_points(3, query)
+    assert n_idx.shape == (1, 3)
+    assert np.isinf(n_dist).all()
+
+
+def test_one_dimensional_input_rejected():
+    """#399: numpy.array([]) is 1-D — the constructor must say so legibly
+    instead of failing in the memoryview cast."""
+    with pytest.raises(RuntimeError, match="2-D"):
+        uw.kdtree.KDTree(np.empty(0))

--- a/tests/test_0102_meshvariable_stats.py
+++ b/tests/test_0102_meshvariable_stats.py
@@ -25,16 +25,37 @@ def mesh():
 def test_tensor_stats_computes_frobenius(mesh):
     T = uw.discretisation.MeshVariable(
         "T400", mesh, (mesh.dim, mesh.dim), vtype=uw.VarType.TENSOR, degree=1)
-    # Identity everywhere: ||I||_F = sqrt(d)
+    # Non-symmetric, spatially varying — compare against numpy directly.
     with uw.synchronised_array_update():
-        T.array[:, :, :] = np.eye(mesh.dim)
+        x = np.asarray(T.coords)[:, 0]
+        T.array[:, 0, 0] = 1.0 + x
+        T.array[:, 0, 1] = 2.0
+        T.array[:, 1, 0] = -3.0 * x
+        T.array[:, 1, 1] = 0.5
 
+    expected = np.sqrt((np.asarray(T.array) ** 2).sum(axis=(1, 2)))
     result = T.stats()
     assert result["type"] == "tensor"
-    expected = np.sqrt(mesh.dim)
+    assert np.isclose(result["mean"], expected.mean(), rtol=1e-12)
+    assert np.isclose(result["max"], expected.max(), rtol=1e-12)
+    assert np.isclose(result["min"], expected.min(), rtol=1e-12)
+
+
+def test_sym_tensor_stats_counts_off_diagonals_twice(mesh):
+    # SYM_TENSOR stores Voigt components; the Frobenius norm must count
+    # the mirrored off-diagonals twice (adversarial-review finding: a flat
+    # single-count read under-measured ||A||_F silently).
+    S = uw.discretisation.MeshVariable(
+        "S400", mesh, (mesh.dim, mesh.dim), vtype=uw.VarType.SYM_TENSOR, degree=1)
+    with uw.synchronised_array_update():
+        S.data[:, 0] = 1.0   # xx
+        S.data[:, 1] = 2.0   # yy
+        S.data[:, 2] = 3.0   # xy (mirrored)
+
+    expected = np.sqrt(1.0 + 4.0 + 2.0 * 9.0)
+    result = S.stats()
     assert np.isclose(result["mean"], expected, rtol=1e-12)
     assert np.isclose(result["max"], expected, rtol=1e-12)
-    assert np.isclose(result["min"], expected, rtol=1e-12)
 
 
 def test_vector_stats_repeat_and_cleanup(mesh):

--- a/tests/test_0102_meshvariable_stats.py
+++ b/tests/test_0102_meshvariable_stats.py
@@ -1,0 +1,51 @@
+"""MeshVariable.stats() over the variable types.
+
+Regression coverage for:
+
+- issue #400: ``_tensor_stats`` indexed the flat component count (d*d)
+  against the structured ``.array`` axis of size d — ``stats()`` on any
+  genuine TENSOR variable raised IndexError;
+- issue #384 lifecycle: the stats temporaries are created and cleaned up
+  by name — repeated calls must work and leave no variable behind.
+"""
+
+import numpy as np
+import pytest
+import underworld3 as uw
+
+pytestmark = [pytest.mark.level_1, pytest.mark.tier_b]
+
+
+@pytest.fixture(scope="module")
+def mesh():
+    return uw.meshing.UnstructuredSimplexBox(
+        minCoords=(0.0, 0.0), maxCoords=(1.0, 1.0), cellSize=0.25)
+
+
+def test_tensor_stats_computes_frobenius(mesh):
+    T = uw.discretisation.MeshVariable(
+        "T400", mesh, (mesh.dim, mesh.dim), vtype=uw.VarType.TENSOR, degree=1)
+    # Identity everywhere: ||I||_F = sqrt(d)
+    with uw.synchronised_array_update():
+        T.array[:, :, :] = np.eye(mesh.dim)
+
+    result = T.stats()
+    assert result["type"] == "tensor"
+    expected = np.sqrt(mesh.dim)
+    assert np.isclose(result["mean"], expected, rtol=1e-12)
+    assert np.isclose(result["max"], expected, rtol=1e-12)
+    assert np.isclose(result["min"], expected, rtol=1e-12)
+
+
+def test_vector_stats_repeat_and_cleanup(mesh):
+    V = uw.discretisation.MeshVariable("V400", mesh, mesh.dim, degree=1)
+    with uw.synchronised_array_update():
+        V.array[:, 0, 0] = 3.0
+        V.array[:, 0, 1] = 4.0
+
+    for _ in range(2):  # repeated calls: temp is recreated by name each time
+        result = V.stats()
+        assert np.isclose(result["magnitude_mean"], 5.0, rtol=1e-12)
+
+    leftovers = [name for name in mesh.vars if name.startswith("_temp_")]
+    assert leftovers == [], f"stats temporaries left behind: {leftovers}"

--- a/tests/test_0114_swarm_save_coordinate_units.py
+++ b/tests/test_0114_swarm_save_coordinate_units.py
@@ -109,16 +109,18 @@ def test_points_label_matches_magnitudes(scaled_model):
     by the SI length scale (metres) — the unit label must be 'meter', not
     mesh.units (kilometres here: a 1000x label/value mismatch)."""
     mesh = uw.meshing.StructuredQuadBox(
-        elementRes=(4, 4), minCoords=(0.0, 0.0), maxCoords=(1.0, 1.0),
-        units="km")
+        elementRes=(4, 4), minCoords=(0.0, 0.0), maxCoords=(1.0, 1.0))
     swarm = uw.swarm.Swarm(mesh)
     swarm.populate(fill_param=2)
 
     with pytest.warns(DeprecationWarning):
         pts = swarm.points
 
-    if getattr(mesh.CoordinateSystem, "_scaled", False):
-        assert str(pts.units) in ("meter", "metre"), f"label = {pts.units}"
-        model_coords = np.asarray(swarm._particle_coordinates.data)
-        scale = mesh.CoordinateSystem._length_scale
-        assert np.allclose(np.asarray(pts), model_coords * scale)
+    # The scaled_model fixture activates coordinate scaling — assert it,
+    # so a fixture change cannot silently vacuate this test.
+    assert mesh.CoordinateSystem._scaled
+
+    assert str(pts.units) in ("meter", "metre"), f"label = {pts.units}"
+    model_coords = np.asarray(swarm._particle_coordinates.data)
+    scale = mesh.CoordinateSystem._length_scale
+    assert np.allclose(np.asarray(pts), model_coords * scale)

--- a/tests/test_0114_swarm_save_coordinate_units.py
+++ b/tests/test_0114_swarm_save_coordinate_units.py
@@ -102,3 +102,23 @@ def test_save_read_roundtrip_with_scaling(scaled_model, tmp_path):
         "unit system (physically scaled, outside the model-unit mesh domain)"
     )
     np.testing.assert_allclose(restored, original, rtol=1e-12)
+
+
+def test_points_label_matches_magnitudes(scaled_model):
+    """#386: the deprecated swarm.points snapshot scales model coordinates
+    by the SI length scale (metres) — the unit label must be 'meter', not
+    mesh.units (kilometres here: a 1000x label/value mismatch)."""
+    mesh = uw.meshing.StructuredQuadBox(
+        elementRes=(4, 4), minCoords=(0.0, 0.0), maxCoords=(1.0, 1.0),
+        units="km")
+    swarm = uw.swarm.Swarm(mesh)
+    swarm.populate(fill_param=2)
+
+    with pytest.warns(DeprecationWarning):
+        pts = swarm.points
+
+    if getattr(mesh.CoordinateSystem, "_scaled", False):
+        assert str(pts.units) in ("meter", "metre"), f"label = {pts.units}"
+        model_coords = np.asarray(swarm._particle_coordinates.data)
+        scale = mesh.CoordinateSystem._length_scale
+        assert np.allclose(np.asarray(pts), model_coords * scale)


### PR DESCRIPTION
Four fixes from the triage backlog plus the public adversarial-review round and its responses. Closes #399, closes #400, closes #351, closes #386.

## The fixes

**#399 — mesh construction crashed on ranks owning zero cells.** Two layers: the navigation kd-tree build passed a 1-D `numpy.array([])` into the KDTree memoryview, and the KDTree constructor itself could not represent an empty cloud (`&points[0][0]`). Empty point sets are now first-class: `(0, dim)` clouds build no C++ index and answer queries honestly (found=False, infinite distances); 1-D input gets a legible error. `StructuredQuadBox(elementRes=(2,2))` now constructs, integrates and **solves** at np3/np4 (PETSc itself is fine with empty ranks). Follow-ups from the review, also in this PR: the three sentinel sanity guards were off-by-one (`>` vs `>=` — the empty-tree sentinel masqueraded as valid index 0), and `_get_domain_centroids` produced NaN for starved ranks, which `gather_data` silently stripped — de-aligning the rank/row table and making `_route_by_nearest_centroid` **silently migrate particles to a rank owning zero cells** (demonstrated live in the review; now a huge-finite sentinel keeps the table aligned and the starved rank unreachable).

**#400 — `stats()` crashed for every genuine tensor variable.** Two stacked defects: the Frobenius loop indexed the flat component count against the structured array axis, and the temp variable was built through the enhanced factory whose `__getattr__` blocks underscore delegation. The review then caught my first fix under-measuring SYM_TENSOR norms (off-diagonals must count twice) — the final form reads the structured `(N, d, d)` view, correct for both tensor kinds, validated against numpy.

**#351 — `mesh_metric_mismatch` moments were partition-dependent.** The equidistribution target and the returned moments are now globally reduced (median via gather-to-root); starved ranks participate in the reductions with empty contributions; non-simplex refusal is rank-symmetric via `mesh.isSimplex`. Known limit, documented in place: a metric containing MeshVariable data still cannot run with a starved rank — that needs the evaluate layer (#405).

**#386 — deprecated `swarm.points` labelled metre magnitudes with `mesh.units`.** Scaled values are now labelled `meter`, the `mesh.X.coords` convention; verified all three coordinate views agree physically under a km-scale model.

## Adversarial review (public, round 1)

Posted in full below. All four primary fixes held their core claims; the review found and demonstrated live: the SYM_TENSOR under-measurement, the silent particle mis-route, the sentinel off-by-ones, a deadlock in #351's empty path with field metrics, and — most valuable — the honest map of where empty-rank support *ends*: construction, solve, integrals, swarm populate and stats all work; the first `evaluate`/`estimate_dt` still fails (rank-asymmetric raise in `get_min/max_radius`). Everything in that next layer is scoped in **#405** (which also ties in #314).

## Verification

- Serial battery (kdtree, stats, swarm-units, follow-metric, smoothing): 56 passed.
- np4: test_0700 (incl. new starved-rank construction test) + test_0750_global_statistics (incl. new #351 partition-independence test): 27 passed; np2: 13 passed.
- Direct repro: `StructuredQuadBox(elementRes=(2,2))` constructs at np3 and np4 (crashed on development).
- Level_1 + tier_a gate after the response commit: **443 passed**, 0 failures.

Reminder for the merge: manual close needed for #399, #400, #351, #386.

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)