### PR TITLE
fix(mmpde): per-cell collapse floor — mover was a silent no-op on graded meshes (#419)

### DIFF
--- a/src/underworld3/meshing/smoothing/mmpde.py
+++ b/src/underworld3/meshing/smoothing/mmpde.py
@@ -323,9 +323,21 @@ def _mmpde_mover(mesh, metric, pinned_labels, verbose,
 
     a0 = signed_vol(coords, cells_all)
     orient = np.sign(np.median(a0)) or 1.0
-    a0_own_med = float(np.median(np.abs(signed_vol(coords, cells_own))))
-    a0_own_med = _global_mean(a0_own_med)
-    a_min_floor = float(area_floor_frac) * a0_own_med
+    # Collapse guard reference: EACH cell's own starting volume. The floor
+    # is then "no cell may shrink below area_floor_frac of what it started
+    # as" -- scale-free and grading-free.
+    #
+    # It used to be one absolute floor, area_floor_frac x the median cell
+    # volume, which is only meaningful on a near-uniform mesh. On a graded
+    # mesh (anything out of mesh.adapt) the finest cells are orders of
+    # magnitude below the median and so start *already under* the floor:
+    # every trial step is rejected, the line search backtracks to scale=0
+    # and the mover silently does nothing. Worse, the median was a
+    # _global_mean of per-rank medians, so which cells fell foul of it
+    # depended on the partition -- the same mesh moved in serial and stood
+    # still on 2 ranks. See #419.
+    a0_own = np.abs(signed_vol(coords, cells_own))
+    a0_own = np.maximum(a0_own, 1.0e-300)
     # Representative background cell size h0 (mean reference edge length over
     # owned cells), used to make the convergence test SCALE-RELATIVE: a move
     # of dmax < tol·h0 is negligible vs the cell size, so the adapt has
@@ -361,8 +373,11 @@ def _mmpde_mover(mesh, metric, pinned_labels, verbose,
         K = np.abs(detE) / fact
         return _global_sum(np.sum(K * G))
 
-    def _min_area(X):
-        return _global_min((signed_vol(X, cells_own) * orient).min())
+    def _min_area_frac(X):
+        """Smallest cell volume as a FRACTION of that cell's starting
+        volume (global). > 0 also certifies no cell has folded."""
+        return _global_min(
+            (signed_vol(X, cells_own) * orient / a0_own).min(initial=np.inf))
 
     prevI = _energy(coords)
     _Iwin = [prevI]   # accepted-energy history for the stol stagnation test
@@ -538,7 +553,8 @@ def _mmpde_mover(mesh, metric, pinned_labels, verbose,
             trial = _halo_sync(trial)
             # reject any non-finite trial (defense-in-depth: projection/halo
             # could still introduce inf/NaN) so `_energy` never queries NaN.
-            if np.all(np.isfinite(trial)) and _min_area(trial) > a_min_floor:
+            if (np.all(np.isfinite(trial))
+                    and _min_area_frac(trial) > float(area_floor_frac)):
                 Itr = _energy(trial)
                 if Itr < prevI:
                     accepted = trial; Inew = Itr; break

--- a/tests/test_0751_mmpde_graded_area_floor.py
+++ b/tests/test_0751_mmpde_graded_area_floor.py
@@ -1,0 +1,102 @@
+"""Regression for #419: the MMPDE mover must actually move on a GRADED mesh.
+
+The line-search collapse guard used to be one absolute floor,
+``area_floor_frac x median cell volume``. On a graded mesh the finest cells
+start orders of magnitude below that floor, so every trial step was
+rejected, the line search backtracked to ``scale=0``, and the mover
+returned having moved nothing -- silently. The floor is now per-cell
+relative (no cell may shrink below a fraction of its OWN starting volume).
+"""
+import numpy as np
+import pytest
+import sympy
+import underworld3 as uw
+
+pytestmark = [pytest.mark.level_1, pytest.mark.tier_a]
+
+CENTRE, H_NEAR, H_FAR, WIDTH = 0.5, 0.01, 0.25, 0.08
+
+
+def _metric(centroids):
+    d = np.abs(np.asarray(centroids)[:, 1] - CENTRE)
+    slope = np.sqrt(H_FAR**2 - H_NEAR**2) / WIDTH
+    return 1.0 / np.minimum(np.sqrt(H_NEAR**2 + (slope * d) ** 2), H_FAR) ** 2
+
+
+def _density(mesh):
+    x, y = mesh.X
+    slope = np.sqrt(H_FAR**2 - H_NEAR**2) / WIDTH
+    d = sympy.Abs(y - CENTRE)
+    return 1.0 / sympy.Min(
+        sympy.sqrt(H_NEAR**2 + (slope * d) ** 2), H_FAR) ** 2
+
+
+def _graded_child(max_levels):
+    base = uw.meshing.UnstructuredSimplexBox(
+        minCoords=(0.0, 0.0), maxCoords=(1.0, 1.0), cellSize=0.2,
+        refinement=1, qdegree=2)
+    return base.adapt(_metric, max_levels=max_levels)
+
+
+def _coords(mesh):
+    return mesh.dm.getCoordinatesLocal().array.reshape(-1, mesh.cdim).copy()
+
+
+def _volume_spread(mesh):
+    """max/min cell volume -- how graded the mesh actually is."""
+    dm = mesh.dm
+    vS, vE = dm.getDepthStratum(0)
+    cS, cE = dm.getHeightStratum(0)
+    p = _coords(mesh)
+    t = np.asarray([[q - vS for q in dm.getTransitiveClosure(c)[0]
+                     if vS <= q < vE] for c in range(cS, cE)])
+    a, b, c = p[t[:, 0]], p[t[:, 1]], p[t[:, 2]]
+    ar = np.abs(0.5 * ((b[:, 0] - a[:, 0]) * (c[:, 1] - a[:, 1])
+                       - (c[:, 0] - a[:, 0]) * (b[:, 1] - a[:, 1])))
+    return float(ar.max() / ar.min())
+
+
+def test_mover_moves_on_a_graded_mesh():
+    """The bug: on a strongly graded mesh the mover moved nothing at all."""
+    child = _graded_child(max_levels=4)
+    # Guard the guard: if this mesh were not strongly graded the test could
+    # pass without exercising the floor at all. The spread saturates once
+    # the metric is satisfied, so it is capped by H_FAR/H_NEAR (~200 here),
+    # not by max_levels -- do not raise this without widening the metric.
+    assert _volume_spread(child) > 150.0
+
+    before = _coords(child)
+    child.redistribute_nodes(_density(child),
+                             method_kwargs=dict(n_outer=8))
+    moved = float(np.abs(_coords(child) - before).max())
+
+    h_fine = H_NEAR
+    assert moved > 1.0e-3 * h_fine, (
+        f"mover did not move a graded mesh (max|dx|={moved:.3e}); the "
+        f"collapse floor is rejecting every trial step (#419)")
+
+
+def test_collapse_guard_still_rejects_folding():
+    """The floor must still do its job: no cell may collapse or invert."""
+    child = _graded_child(max_levels=3)
+
+    dm = child.dm
+    vS, vE = dm.getDepthStratum(0)
+    cS, cE = dm.getHeightStratum(0)
+    tris = np.asarray([[q - vS for q in dm.getTransitiveClosure(c)[0]
+                        if vS <= q < vE] for c in range(cS, cE)])
+
+    def signed(p):
+        a, b, c = p[tris[:, 0]], p[tris[:, 1]], p[tris[:, 2]]
+        return 0.5 * ((b[:, 0] - a[:, 0]) * (c[:, 1] - a[:, 1])
+                      - (c[:, 0] - a[:, 0]) * (b[:, 1] - a[:, 1]))
+
+    s0 = signed(_coords(child))
+    child.redistribute_nodes(_density(child),
+                             method_kwargs=dict(n_outer=25))
+    s1 = signed(_coords(child))
+
+    sign = np.sign(np.median(s0))
+    assert np.all(sign * s1 > 0.0), "a cell folded during redistribution"
+    # and none collapsed below the documented fraction of its own start
+    assert float((s1 / s0).min()) > 0.01


### PR DESCRIPTION
Closes #419.

## The bug

The MMPDE line-search accept test used a single **absolute** collapse floor derived from the median cell volume:

```python
a0_own_med = _global_mean(float(np.median(np.abs(signed_vol(coords, cells_own)))))
a_min_floor = float(area_floor_frac) * a0_own_med
...
if np.all(np.isfinite(trial)) and _min_area(trial) > a_min_floor:
```

**1. It disabled the mover on any graded mesh.** The floor is 1% of the median cell volume. Anything out of `mesh.adapt` has finest cells orders of magnitude below the median, so they start *already under the floor*. Every trial step was rejected, the line search backtracked to `scale=0`, and the mover returned having moved nothing — silently:

```
mmpde outer 1/8: I=1.991126e+00 dI=+0.00e+00 scale=0.000 max|dx|=0.00e+00
```

**2. It was partition-dependent.** A `_global_mean` of per-rank medians is not the global median, so which cells fell foul of the floor depended on how cells were spread across ranks. The same mesh moved at np=1 and stood completely still at np=2.

This affected `redistribute_nodes` / `node_redistribution` generally, not just new code.

## The fix

Floor each cell against **its own** starting volume: no cell may shrink below `area_floor_frac` of what it started as. Scale-free, grading-free, partition-independent, and still a strict no-fold certificate — a positive ratio certifies positive volume. `area_floor_frac` keeps its name and default; only its reference changes.

## Tests

New `tests/test_0751_mmpde_graded_area_floor.py` (level_1, tier_a):
- `test_mover_moves_on_a_graded_mesh` — asserts the mesh is genuinely graded first, so the test cannot pass without exercising the floor, then asserts the mover actually moves.
- `test_collapse_guard_still_rejects_folding` — the guard must still do its job: no cell folds, and none collapses below the documented fraction of its own start.

54 existing tests pass across the mover, `follow_metric`, graded adapt and mesh smoothing.

## Reviewer notes

- The `min(initial=np.inf)` in `_min_area_frac` is deliberate: a rank owning no cells must contribute the identity for the global MIN rather than raising on an empty reduction.
- Worth checking: `area_floor_frac=0.01` now means something stricter in the fine region than it used to (1% of a small cell, not 1% of the median), so a previously-accepted step that shrank a fine cell hard will now be backtracked. That is the intended reading, but it is a behaviour change for well-graded meshes that were already moving.
- Not addressed here: the mover still reports no warning when the line search backtracks to `scale=0` for any other reason. A silent no-op is hard to diagnose — probably worth a follow-up warning.

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)