### PR TITLE
Bound a solver grind: wall-clock guard inside PETSc's convergence tests, and a sub-solve work gauge

### DIFF
--- a/docs/developer/design/solver-wall-clock-guard.md
+++ b/docs/developer/design/solver-wall-clock-guard.md
@@ -1,0 +1,145 @@
+# Bounding a solver grind: the wall-clock guard and the sub-solve work gauge
+
+**Status**: implemented. `solver.guard(wall_per_step=...)`, `solver.unguard()`,
+`solve_report.sub`, `solve_report.deadline_expired`.
+Implementation: `src/underworld3/systems/solver_health.py`.
+
+## The problem
+
+A viscoplastic Stokes solve near its conditioning floor does not fail. It *grinds* — for
+hours, inside a single Newton step, with no error and no sign of stopping. Any study that
+sweeps a parameter plane hits this immediately: the interesting cells are exactly the
+unreachable ones, and an unreachable cell costs unbounded time.
+
+The obvious defences do not work, and both were measured before this was written.
+
+**An iteration cap does not bound wall time.** Capping nonlinear iterations, outer Krylov
+iterations, or inner iterations all leave the same hole: below the conditioning floor a
+single Newton step grinds *within one outer Krylov iteration*. The counter the cap watches
+never advances, so the cap never fires. Measured: 3814 s inside one outer iteration.
+
+Nor can an iteration cap be tuned around the problem. Tight caps terminate quickly but
+classify wrongly in *both* directions — a continuation march settles at its starting
+parameter and reports success (a false rescue), while a step that would have converged in
+fifteen iterations is called unreachable at ten (a false failure). Loose caps classify
+correctly and run past ten minutes a station. The number of iterations a feasible step
+needs is not knowable in advance, which is precisely why a *time* budget is the right
+independent guard.
+
+**A Python timer does not fire.** `signal.alarm` schedules a handler, but Python runs
+signal handlers only between bytecodes, and during the grind control is inside PETSc's C
+code the entire time. Measured: a 90 s alarm still unfired at 10 minutes.
+
+So the only code that runs during a grind is PETSc's own. The guard has to live there.
+
+## The construction
+
+Three pieces, each chosen for a reason that was measured rather than assumed.
+
+**Where the clock starts.** The outer KSP runs exactly once per Newton step, so its
+iteration 0 is the natural place to restart the budget. No SNES hook is needed — the
+original design proposed resetting the deadline from a custom SNES convergence test, but
+that would mean reimplementing `SNESConvergedDefault` (petsc4py exposes no way to chain to
+it) for no gain.
+
+**Where the deadline is checked.** In convergence tests on the outer KSP *and on every
+fieldsplit sub-KSP*. The sub-KSPs are where the granularity is: in a representative solve
+the outer KSP performed 1 iteration while the velocity block performed 285, so only the
+sub-KSP tests can interrupt a grind at anything finer than "the whole Newton step".
+
+**Which diverged reason is returned.** This is the part that is easy to get wrong, and the
+earlier prototype did. PETSc's `KSPCheckSolve` deliberately *exempts* `KSP_DIVERGED_ITS`
+from marking the preconditioner as failed — truncating an inner solve at its iteration cap
+is normal behaviour, not an error. A guard that returns `DIVERGED_MAX_IT` from a sub-KSP
+therefore does nothing at all: measured, the outer solve absorbed 36 truncated velocity
+solves and reported CONVERGED. Returning `DIVERGED_BREAKDOWN` marks the sub-preconditioner
+failed, which surfaces as `DIVERGED_PC_FAILED` at the outer KSP and `DIVERGED_LINEAR_SOLVE`
+at the SNES.
+
+Because a custom convergence test *replaces* the default rather than composing with it,
+the guard also carries the ordinary rtol / atol / divtol semantics itself. Tolerances are
+re-read every iteration, because Eisenstat–Walker rewrites the outer rtol before each
+Newton step.
+
+### Parallel
+
+Wall clocks are not synchronised across ranks, so "has the budget run out" is exactly the
+kind of question that splits a communicator — and a PETSc convergence test that returns
+different verdicts on different ranks leaves the ranks on different code paths, so the
+next collective deadlocks. The expiry decision is therefore reduced over the solver's
+communicator before it is acted on. This is well posed because Krylov iterations are
+globally synchronised, so every rank reaches the same check the same number of times.
+
+The reduction is one integer per iteration, against a multigrid cycle, and every iteration
+already pays for at least one norm reduction — so it does not change the communication
+character of the solve.
+
+`tests/parallel/ptest_0203_wallclock_guard_parallel.py` provokes the hazard deliberately
+with deliberately skewed per-rank clocks. With the reduction it passes at np=2 and np=4;
+with the reduction removed it deadlocks (confirmed at a 90 s limit).
+
+The extra reductions are paid only on the guarded path — an unarmed solver installs no
+convergence tests at all, so the default solve is untouched.
+
+### What the guard does not cover
+
+**Rotated free-slip.** That path runs its own Krylov loop outside `self.snes`
+(`utilities/rotated_bc.py`), which the deadline cannot reach. `guard()` raises there
+rather than pretending, matching `estimate_difficulty()`.
+
+**A `preonly` outer KSP.** With no outer iterations there is no convergence test to start
+the clock, so the guard is inert. A direct solve is not the thing this guard exists to
+bound, but it is worth knowing that it is silent rather than protective.
+
+**The first preconditioner application.** On a solver's **first** solve the fieldsplit
+blocks do not exist when the solve begins:
+they are created by `PCSetUp`, which runs inside the first `KSPSolve`. The guard attaches
+to them at the earliest reachable moment — the outer KSP's iteration 0 — which is *after*
+the preconditioner has been applied once. So one preconditioner application on the first
+solve is outside the deadline. Every solve after that is fully covered, because the blocks
+persist.
+
+A driver that cares should do one cheap solve before arming the guard, which it usually
+does anyway to pay for the JIT compile.
+
+## The work gauge
+
+`solve_report.ksp_its` counts outer Krylov iterations. Under Eisenstat–Walker that is about
+one per Newton step, so it is not a measure of cost — using it as a work axis understates a
+Stokes solve by two orders of magnitude. Measured on a small box: outer 1, velocity block
+285, pressure block 9.
+
+`solve_report.sub` records iterations and applications per fieldsplit block. For the
+velocity block under `pc_type=mg` that iteration count *is* the multigrid cycle count. It
+is collected by monitors, which observe and never decide, so it cannot change a solve.
+
+The same first-solve limitation applies, and the report says so: `SubSolveReport.complete`
+is `False` when the block was instrumented part-way through the solve, meaning `its` is a
+lower bound. Measured, the first solve reports about half the true count. Every later solve
+is exact.
+
+Cost of leaving the gauge always on: 624 monitor callbacks in a 280 ms solve, no measurable
+change in wall time (medians 282 ms instrumented against 284 ms not, run alternately;
+run-to-run noise is larger than the difference).
+
+## Usage
+
+```python
+stokes.guard(wall_per_step=150.0)
+stokes.solve()
+if stokes.solve_report.deadline_expired:
+    ...                    # too hard at these parameters — back off a continuation step
+stokes.unguard()
+
+cycles = stokes.solve_report.sub["velocity"].its       # the honest work axis
+```
+
+A guard exit is a report, not an exception: the current iterate is left in the fields, so a
+continuation driver can revert or retry from it.
+
+## Related
+
+- `docs/developer/design/nonlinear-solver-homotopy-warmstart.md` — the δ-continuation this
+  guard exists to make sweepable.
+- `docs/developer/design/solver-strategies-catalogue.md` — the solver configurations whose
+  cost this measures.

--- a/docs/developer/design/solver-wall-clock-guard.md
+++ b/docs/developer/design/solver-wall-clock-guard.md
@@ -36,11 +36,17 @@ So the only code that runs during a grind is PETSc's own. The guard has to live 
 
 Three pieces, each chosen for a reason that was measured rather than assumed.
 
-**Where the clock starts.** The outer KSP runs exactly once per Newton step, so its
-iteration 0 is the natural place to restart the budget. No SNES hook is needed — the
-original design proposed resetting the deadline from a custom SNES convergence test, but
-that would mean reimplementing `SNESConvergedDefault` (petsc4py exposes no way to chain to
-it) for no gain.
+**Where the clock starts.** At the beginning of each solve, and again at each outer KSP
+iteration 0 — the outer KSP runs exactly once per Newton step, so that is the per-step
+restart. No SNES hook is needed.
+
+Starting it at the beginning of the solve rather than only at outer iteration 0 is not
+cosmetic. Under left preconditioning — PETSc's default for GMRES, which is the Stokes
+outer solver — `KSPInitialResidual` applies the preconditioner *before* iteration 0. An
+earlier version of this guard armed only at iteration 0 and therefore left one full
+velocity solve plus one pressure solve outside the budget on **every** solve, not just
+the first. Measured: for `pc_side` LEFT the sub-block monitors fire before the outer
+monitor.
 
 **Where the deadline is checked.** In convergence tests on the outer KSP *and on every
 fieldsplit sub-KSP*. The sub-KSPs are where the granularity is: in a representative solve
@@ -56,10 +62,20 @@ solves and reported CONVERGED. Returning `DIVERGED_BREAKDOWN` marks the sub-prec
 failed, which surfaces as `DIVERGED_PC_FAILED` at the outer KSP and `DIVERGED_LINEAR_SOLVE`
 at the SNES.
 
-Because a custom convergence test *replaces* the default rather than composing with it,
-the guard also carries the ordinary rtol / atol / divtol semantics itself. Tolerances are
-re-read every iteration, because Eisenstat–Walker rewrites the outer rtol before each
-Newton step.
+**How it coexists with PETSc's own test.** `KSP.addConvergenceTest(..., prepend=True)`
+runs the guard *in front of* whatever native test the KSP is configured with; returning
+`ITERATING` hands the decision straight back to `KSPConvergedDefault`, with its
+options-configured context intact (`-ksp_converged_maxits`, the non-zero-initial-guess
+residual convention, the norm-type early return, `-ksp_min_it`). Verified: a prepended
+test that always returns `ITERATING` gives identical iteration count and reason to an
+uninstrumented solve.
+
+An earlier version of this guard used `setConvergenceTest`, which *replaces* the default,
+and so had to reimplement rtol/atol/divtol — silently dropping four `KSPConvergedDefault`
+behaviours and mis-reporting an infinite residual as converged. Prepending removes that
+whole class of divergence. It also makes `unguard()` exact rather than approximate: PETSc
+offers no way to remove an added test, so the test stays installed and simply goes inert
+when there is no budget, which is precisely the uninstrumented behaviour.
 
 ### Parallel
 
@@ -75,8 +91,17 @@ already pays for at least one norm reduction — so it does not change the commu
 character of the solve.
 
 `tests/parallel/ptest_0203_wallclock_guard_parallel.py` provokes the hazard deliberately
-with deliberately skewed per-rank clocks. With the reduction it passes at np=2 and np=4;
-with the reduction removed it deadlocks (confirmed at a 90 s limit).
+with skewed per-rank clocks, and is registered in `tests/parallel/mpi_runner.sh`. With the
+reduction it passes at np=2 and np=4; with the reduction removed it deadlocks (confirmed
+at a 90 s limit). Note the failure mode: a dropped reduction *hangs* rather than fails, so
+it must be run under a timeout.
+
+**After a deadline exit, PETSc will not restart the grind by itself.** Once the
+sub-preconditioner is marked failed, a subsequent `snes.solve` in the same call — a
+warm-start retry, or the second stage of a Picard-to-Newton continuation — bails before it
+reaches an iteration. Measured with the expiry latch removed: 34 clock ticks against 32
+with it. The latch is kept because relying on PC-failure propagation is implicit rather
+than guaranteed, but it is belt-and-braces, and no test claims to prove otherwise.
 
 The extra reductions are paid only on the guarded path — an unarmed solver installs no
 convergence tests at all, so the default solve is untouched.
@@ -87,19 +112,22 @@ convergence tests at all, so the default solve is untouched.
 (`utilities/rotated_bc.py`), which the deadline cannot reach. `guard()` raises there
 rather than pretending, matching `estimate_difficulty()`.
 
-**A `preonly` outer KSP.** With no outer iterations there is no convergence test to start
-the clock, so the guard is inert. A direct solve is not the thing this guard exists to
-bound, but it is worth knowing that it is silent rather than protective.
+**A `preonly` or `richardson` outer KSP.** These are skipped entirely, because both change
+what they *do* when a monitor is attached — `KSPSolve_PREONLY` computes a norm, a matvec
+and a second norm purely to have something to report, and `KSPRICHARDSON` gives up the
+fused `PCApplyRichardson` path. Neither iterates, so there is nothing for the gauge to
+count or the deadline to bound; instrumenting them would be all cost and no information.
+A direct solve is not what this guard exists to bound, but it is silent there rather than
+protective.
 
-**The first preconditioner application.** On a solver's **first** solve the fieldsplit
-blocks do not exist when the solve begins:
-they are created by `PCSetUp`, which runs inside the first `KSPSolve`. The guard attaches
-to them at the earliest reachable moment — the outer KSP's iteration 0 — which is *after*
-the preconditioner has been applied once. So one preconditioner application on the first
-solve is outside the deadline. Every solve after that is fully covered, because the blocks
-persist.
+**The first solve's sub-KSP counts.** On a solver's **first** solve the fieldsplit blocks
+do not exist when the solve begins: they are created by `PCSetUp`, which runs inside the
+first `KSPSolve`. The guard attaches to them at the earliest reachable moment, which is
+after the preconditioner has been applied once — so that solve's block counts are a lower
+bound and `SubSolveReport.complete` is `False` to say so. The *deadline* is unaffected,
+because the clock is already running from the start of the solve.
 
-A driver that cares should do one cheap solve before arming the guard, which it usually
+A driver that wants exact work should do one cheap solve before arming, which it usually
 does anyway to pay for the JIT compile.
 
 ## The work gauge
@@ -121,6 +149,11 @@ is exact.
 Cost of leaving the gauge always on: 624 monitor callbacks in a 280 ms solve, no measurable
 change in wall time (medians 282 ms instrumented against 284 ms not, run alternately;
 run-to-run noise is larger than the difference).
+
+The instrumentation holds petsc4py references to the KSPs it watches, and those
+reference-count the PC and the whole multigrid hierarchy. It therefore releases them when
+the solver tears its SNES down, or a rebuilding solver would carry two hierarchies at once
+— the leak `BUGFIX(#157)` exists to prevent.
 
 ## Usage
 

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -151,6 +151,7 @@ design/mesh-adaptation-formulation
 design/LAYER2_SBR_ADAPT_ON_TOP
 design/NVB_GRADED_ADAPT
 design/MULTIGRID_MINIMAL_CONTROL_2026-07
+design/solver-wall-clock-guard
 design/ARCHITECTURE_ANALYSIS
 design/MATHEMATICAL_MIXIN_DESIGN
 design/COORDINATE_MIGRATION_GUIDE

--- a/docs/reviews/2026-07/solver-wall-clock-guard-adversarial-review.md
+++ b/docs/reviews/2026-07/solver-wall-clock-guard-adversarial-review.md
@@ -1,0 +1,192 @@
+# Adversarial review — wall-clock guard and sub-solve work gauge
+
+Branch `feature/solver-wallclock-guard` vs `development`.
+
+Method: two independent adversarial reviewers, each given one dimension and instructed to
+break the change rather than praise it. Both were told to report only findings they had
+verified against the source; both went further and verified empirically, one by driving
+standalone petsc4py to establish PETSc's callback ordering, the other by neutering parts
+of the implementation and observing which tests still passed.
+
+**Verdict: not ready as submitted.** Four major defects in the new code, two false claims
+in its documentation, and a test suite that a reviewer showed would pass with several
+parts of the feature broken. All are addressed on the branch; the two findings that
+measurement did not sustain are recorded as such rather than quietly fixed.
+
+---
+
+## MAJOR — the deadline was disabled for the first preconditioner application of *every* solve
+
+`begin_solve()` left the clock at infinity, and only outer-KSP iteration 0 armed it. But
+PETSc's default for GMRES — the Stokes outer solver — is **left** preconditioning, and
+`KSPInitialResidual` applies the preconditioner *before* iteration 0. The reviewer
+established the ordering directly:
+
+```
+outer=gmres  pc_side=LEFT :  sub0_mon(0), sub0_mon(1), sub1_mon(0), sub1_mon(1), outer_mon(0), ...
+outer=fgmres pc_side=RIGHT:  outer_mon(0), sub0_mon(0), ...
+```
+
+So one complete velocity-block solve plus one pressure-block solve ran entirely outside
+the budget — on every solve, not just the first. That is precisely the grind the guard
+exists to bound. Both the docstring and the design note described this as a first-solve
+limitation caused by the blocks not yet existing; the blocks exist from solve 2 onward,
+and the clock was simply not running.
+
+**Fixed**: the clock starts in `begin_solve()`, and outer iteration 0 restarts it per
+Newton step.
+
+## MAJOR — the premise that forced a hand-rolled convergence test was false
+
+Both the code and the design note asserted that "a custom convergence test replaces the
+default — petsc4py exposes no way to chain to it". petsc4py ships
+`KSP.addConvergenceTest(fn, prepend=True)`, which composes the custom test with the
+*native* one, whatever it is configured to be.
+
+Verified here before acting on it:
+
+| | iterations | reason |
+|---|---|---|
+| uninstrumented | 30 | CONVERGED_RTOL |
+| prepended test returning `ITERATING` | 30 | CONVERGED_RTOL |
+| prepended test returning `DIVERGED_BREAKDOWN` at it 3 | 3 | DIVERGED_BREAKDOWN |
+
+Every divergence the reviewer then listed was a self-inflicted consequence of
+reimplementing rather than prepending: four dropped `KSPConvergedDefault` behaviours
+(`-ksp_converged_maxits`, the non-zero-initial-guess residual convention, the norm-type
+early return, `-ksp_min_it`), and a NaN guard written as `rnorm != rnorm` that let an
+infinite residual through to be reported as `CONVERGED_RTOL` — silent false convergence,
+in exactly the inf/inf viscoplastic regime the guard targets.
+
+**Fixed**: `_default_convergence` is deleted. The guard returns `ITERATING` and PETSc
+decides. This also makes `unguard()` exact rather than approximate — PETSc offers no way
+to remove an added test, so it stays installed and goes inert, which *is* the
+uninstrumented behaviour, instead of being swapped for a freshly created default context
+that would have lost any options-configured flags.
+
+## MAJOR — the instrumentation re-opened the leak `BUGFIX(#157)` was written to close
+
+`SNES.getKSP()` and `PC.getFieldSplitSubKSP()` both increment the reference count. The
+instrumentation held those entries until the *next* solve, so a rebuild
+(`is_setup=False`, remesh, adapt) did not free the old KSP, PC, coarse operators or
+multigrid hierarchy: they survived precisely while the new hierarchy was being built.
+
+The comment at the destroy site records that this exact retention "at Gadi scale … push[ed]
+past memory limits" for `SNES_Tensor_Projection.solve()` cycling six components in 3D —
+a loop that drives `is_setup=False` on every component.
+
+**Fixed**: the instrumentation releases its references before the SNES is destroyed.
+
+## MAJOR — `guard()`'s rotated-free-slip refusal was bypassed by call order
+
+Found independently by both reviewers, and demonstrated live: `guard(...)` then
+`add_rotated_freeslip_bc(...)` armed without error, and the subsequent solve took the
+rotated path — which never reaches the instrumentation — and reported
+`deadline_expired=False, converged=True`. The guard was silently inert: "looks like
+protection and is not", which is the exact state the `NotImplementedError` exists to
+prevent.
+
+**Fixed**: re-checked at solve time as well as at arm time; the test now covers both
+orders.
+
+## MINOR — `preonly` and `richardson` outer KSPs are changed by being monitored
+
+Both are gated on `ksp->numbermonitors` in PETSc: `KSPSolve_PREONLY` adds a norm, a
+matvec and a second norm purely to have something to report, and `KSPRICHARDSON` gives up
+the fused `PCApplyRichardson` path. The gauge attached a monitor to the outer KSP of every
+solver unconditionally, and `model.py` ships `preonly` presets.
+
+**Fixed**: both types are skipped. Neither iterates, so there was nothing to count or
+bound — it was all cost and no information.
+
+---
+
+## The test suite was the sharpest hit
+
+The second reviewer neutered parts of the implementation and recorded which tests still
+passed. Four separate holes:
+
+- **`unguard()` was untested.** Making the removal a no-op left 7/7 passing. The test
+  passed only because disarming *also* reset the deadline, so the solve converged — it
+  never observed which convergence test was installed.
+- **No work parity assertion.** Tightening the guard's `rtol` by 1e-4 left 7/7 passing.
+  The healthy-solve test compared field values only, so any change confined to the
+  sub-blocks — which cannot move the answer, only the cost — was invisible. Against
+  "Solver Stability is Paramount" that is the wrong thing to be blind to.
+- **`wall_per_step`'s per-Newton-step meaning was never exercised.** The fixture was
+  constant-viscosity, hence linear, hence `nl_its == 1` on every solve in the file — so
+  per-step and per-solve budgets were indistinguishable. That is the entire meaning of
+  the only parameter the feature takes.
+- **The parallel test was dead code.** Not listed in `mpi_runner.sh`, referenced by no CI
+  workflow, and not pytest-collectable (`ptest_*` does not match `test_*`). The serial
+  suite did not cover the reduction either — replacing the `Allreduce` with a rank-local
+  read left 7/7 passing. So the hazard the design note calls "specific and severe" had
+  zero automated coverage.
+
+Also: the rotated-BC test corrupted the module-scoped fixture (`add_rotated_freeslip_bc`
+sets `is_setup=False`), so reordering the file made the *gauge* test fail — a failure
+pointing at the wrong culprit. And tests left the solver armed at a microsecond budget if
+they failed part-way, cascading into everything after.
+
+**Fixed**: cost parity is asserted alongside answer parity; the per-step semantics is
+exercised on a nonlinear model by measuring the solve's total cost and then setting a
+budget only a per-*solve* interpretation would blow; the first-solve lower-bound contract
+and the arm-before-first-solve path are covered; the rotated tests use their own solvers;
+a fixture guarantees disarming. The parallel test is registered in `mpi_runner.sh`.
+
+The suite is marked **tier_b, not tier_a**. Charter §8 reserves tier A for hardened tests;
+these are new and have never run in CI.
+
+---
+
+## Findings that measurement did NOT sustain
+
+Recorded rather than silently fixed, because the reasoning was sound and only the
+conclusion was wrong.
+
+**"A retry or continuation stage is handed a fresh budget after an expiry."** Mechanically
+true — `deadline_expired` latches while `open_step()` could re-arm — and a real concern,
+since a deadline exit is a negative reason and therefore *triggers* a warm-start retry.
+But PETSc prevents it independently: once the sub-preconditioner is marked failed, the
+next `snes.solve` in the same call bails before reaching an iteration. Measured with the
+expiry latch removed, on both the retry and the continuation path: 34 clock ticks against
+32 with it, and `converged=False` either way. The latch is kept — relying on PC-failure
+propagation is implicit rather than guaranteed — but it is belt-and-braces, and no test
+claims to prove otherwise.
+
+**"PETSc handles in `_ksps` could be reused after an object is freed, aliasing a new
+KSP."** Checked and clean: the retained reference keeps the address occupied, so no freed
+handle can alias. The same fact is what caused the memory-retention finding above — the
+aliasing safety was being paid for in memory.
+
+---
+
+## Verified clean
+
+- `Allreduce(MPI.IN_PLACE, flag, MPI.MAX)` on the outer KSP's communicator is correct, and
+  the fieldsplit blocks live on that same communicator.
+- `DIVERGED_BREAKDOWN` returned at outer iteration 0 is safe (`KSPGMRESBuildSoln` handles
+  `it-1 == -1` explicitly).
+- The rotated path builds its own report, so `sub` / `deadline_expired` default rather
+  than carrying stale values.
+- `ksp.getTolerances()` returns `(rtol, atol, divtol, max_it)` — a different order from
+  SNES — and was read correctly.
+- The fake clock intercepts every clock read the guard makes: `time.monotonic` appears
+  exactly twice in the diff, both via the module global.
+- A non-fieldsplit solver (Poisson) reports `sub == {}`, and the guard still fires on its
+  outer KSP.
+- The `DIVERGED_BREAKDOWN`-not-`DIVERGED_MAX_IT` claim is load-bearing *and* caught by the
+  suite: swapping the reason back fails the "bites inside the blocks" test.
+- The parallel claim is true: the ptest passes at np=2 and hangs past a 120 s limit when
+  the reduction is replaced by a rank-local read.
+
+## Known limitations, documented rather than hidden
+
+- The injected-clock tests can catch a guard that never fires, not one that fires too
+  eagerly — with a fake clock, PETSc's real work costs zero ticks, so expiry is guaranteed
+  for any budget. The real-clock generous-budget test covers the other direction.
+- `SubSolveReport.complete` is set conservatively: `False` whenever the block was attached
+  mid-solve, even in a right-preconditioned configuration where the count would in fact be
+  exact.
+- `solve_report.sub` keys come from the split names, so the block-constrained Stokes path
+  yields `"0"` / `"1"` rather than `"velocity"` / `"pressure"`. Documented; read the keys.

--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -928,6 +928,10 @@ class SolverBaseClass(uw_object):
         self._resume_abs_target = None
 
         if self.snes is not None:
+            # Drop the instrumentation's references to this SNES's KSP hierarchy first,
+            # or destroy() only decrements and the old hierarchy stays resident.
+            if getattr(self, "_instrumentation", None) is not None:
+                self._instrumentation.release()
             self.snes.destroy()
             self.snes = None
 
@@ -1103,7 +1107,10 @@ class SolverBaseClass(uw_object):
         wall_per_step : float
             Seconds of wall clock allowed per Newton step. The clock restarts at the
             beginning of every step, so a solve taking ``n`` steps may run for up to
-            roughly ``n * wall_per_step`` seconds.
+            roughly ``n * wall_per_step`` seconds. Once the deadline fires it stays
+            fired for the rest of that ``solve()`` call, so a Picard-to-Newton
+            continuation or a warm-start retry cannot quietly buy itself a fresh
+            budget.
 
         Notes
         -----
@@ -1682,6 +1689,12 @@ class SolverBaseClass(uw_object):
         if getattr(self, "snes", None) is not None:
             if verbose and uw.mpi.rank == 0:
                 print(f"Destroy solver SNES", flush=True)
+            # Instrumentation holds petsc4py references to this SNES's KSP and its
+            # fieldsplit blocks, which reference-count the PC and the whole multigrid
+            # hierarchy. Drop them BEFORE the destroy or the old hierarchy survives
+            # alongside the new one -- the leak BUGFIX(#157) above exists to prevent.
+            if getattr(self, "_instrumentation", None) is not None:
+                self._instrumentation.release()
             self.snes.destroy()
             self.snes = None
 
@@ -8438,6 +8451,16 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
             #    F(u), J(u) and the v_n=0 constraint every iteration. It honours
             #    zero_init_guess (warm start), the Picard warmup count, and the
             #    consistent_jacobian tangent (Picard / Newton / continuation).
+            # guard() refuses rotated free-slip, but the BC can be added AFTER arming.
+            # Re-check here: this path never reaches the instrumentation, so an armed
+            # guard would be silently inert -- the exact state guard() exists to refuse.
+            if (getattr(self, "_instrumentation", None) is not None
+                    and self._instrumentation.armed):
+                raise NotImplementedError(
+                    "a wall-clock guard is armed but this solve takes the rotated "
+                    "free-slip path, which runs its own Krylov loop outside self.snes "
+                    "and cannot be bounded by it. Call unguard() first."
+                )
             from underworld3.utilities.rotated_bc import (
                 solve_rotated_freeslip, solve_rotated_freeslip_nonlinear)
             if not self._residual_is_nonlinear():

--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -127,6 +127,10 @@ class SolverBaseClass(uw_object):
         self._difficulty_probe = False
         self._difficulty_max_it = None
         self._resume_abs_target = None
+        # PETSc-level instrumentation: the sub-solve work gauge, and the
+        # wall-clock deadline once guard() arms it. Created on the first solve
+        # (systems/solver_health.py) because it needs a live SNES to attach to.
+        self._instrumentation = None
 
         # Preconditioner selection — see the `preconditioner` property.
         # `_pc_option_prefix` is set by subclasses that participate in the easy
@@ -1008,6 +1012,13 @@ class SolverBaseClass(uw_object):
         reduction = (fnorm / fnorm0) if (fnorm0 not in (None, 0.0)) else None
         rho = contraction(hist)
 
+        # Sub-solve work, and whether a wall-clock guard cut this solve short. Absent
+        # for a solver whose instrumentation has never attached (no solve yet).
+        instrumentation = self._instrumentation
+        sub = instrumentation.sub_reports() if instrumentation is not None else {}
+        deadline_expired = (instrumentation is not None
+                            and instrumentation.deadline_expired)
+
         report = SolveReport(
             reason=reason,
             reason_str=reason_string(reason),
@@ -1021,6 +1032,8 @@ class SolverBaseClass(uw_object):
             fev=fev,
             history=hist,
             bounded=bool(bounded),
+            sub=sub,
+            deadline_expired=deadline_expired,
         )
         self._solve_report = report
         self._solve_history.append(report)
@@ -1070,6 +1083,76 @@ class SolverBaseClass(uw_object):
         self._solve_report = report
         self._solve_history.append(report)
         return report
+
+    def guard(self, *, wall_per_step):
+        r"""Bound the wall-clock time of each Newton step. Opt-in; changes termination.
+
+        A hard nonlinear solve can grind for hours *inside a single Newton step*, and no
+        iteration cap can stop it: the grind happens within one outer Krylov iteration,
+        so the counter the cap watches never advances. Nor can a Python timer stop it —
+        Python runs signal handlers only between bytecodes, and control is inside PETSc
+        the whole time. The deadline therefore lives in PETSc's own convergence tests,
+        where it is checked between the *inner* iterations of the fieldsplit blocks.
+
+        When the budget runs out the solve stops with ``DIVERGED_LINEAR_SOLVE`` and
+        ``solve_report.deadline_expired`` set, leaving the current iterate in the fields.
+        It is a report, not an error: a continuation driver reads it and steps back.
+
+        Parameters
+        ----------
+        wall_per_step : float
+            Seconds of wall clock allowed per Newton step. The clock restarts at the
+            beginning of every step, so a solve taking ``n`` steps may run for up to
+            roughly ``n * wall_per_step`` seconds.
+
+        Notes
+        -----
+        The budget is enforced at inner-iteration granularity, so the overrun beyond it
+        is at most the cost of one multigrid cycle. In parallel the expiry decision is
+        reduced over the solver's communicator, because PETSc deadlocks if convergence
+        tests return different verdicts on different ranks.
+
+        Not available with rotated free-slip BCs: that path runs its own Krylov loop
+        outside ``self.snes`` (``utilities/rotated_bc.py``), which the deadline cannot
+        reach — so arming a guard there would look like protection and provide none.
+
+        On a solver's FIRST solve the fieldsplit blocks do not exist until PETSc has set
+        up the preconditioner, part-way through that solve, so the first preconditioner
+        application runs unguarded. Every solve after that is fully covered. A driver
+        that needs the first one covered should do one cheap solve before arming.
+
+        Examples
+        --------
+        >>> stokes.guard(wall_per_step=150.0)
+        >>> stokes.solve()
+        >>> if stokes.solve_report.deadline_expired:
+        ...     ...                      # too hard at these parameters; back off
+        >>> stokes.unguard()
+
+        See Also
+        --------
+        unguard : remove the deadline.
+        estimate_difficulty : bound the *work* (an iteration count) instead.
+        """
+        if getattr(self, "_rotated_freeslip_bcs", None):
+            raise NotImplementedError(
+                "guard() is not available with rotated free-slip BCs: that path runs "
+                "its own Krylov loop outside self.snes (utilities/rotated_bc.py), so "
+                "the deadline cannot reach it and the guard would be silently inert."
+            )
+        self._solver_instrumentation().arm(wall_per_step)
+
+    def unguard(self):
+        """Remove the wall-clock deadline set by :meth:`guard`, restoring PETSc defaults."""
+        if self._instrumentation is not None:
+            self._instrumentation.disarm()
+
+    def _solver_instrumentation(self):
+        """The solver's PETSc instrumentation, created on first use."""
+        if self._instrumentation is None:
+            from underworld3.systems.solver_health import SolverInstrumentation
+            self._instrumentation = SolverInstrumentation()
+        return self._instrumentation
 
     def estimate_difficulty(self, max_nl_its, *, warm=True, **solve_kwargs):
         """Run a bounded, resumable solve to *estimate solver difficulty* and return its report.
@@ -1423,6 +1506,12 @@ class SolverBaseClass(uw_object):
             self.snes.setConvergenceHistory(reset=True)
         except Exception:
             pass
+
+        # Attach the sub-solve gauge (and the wall-clock deadline, if guard() armed
+        # one) to the CURRENT SNES and clear its per-solve counters. Here rather than
+        # in _build because a rebuilt solver gets a new SNES and everything attached to
+        # the old one is dropped; every solve funnels through this method.
+        self._solver_instrumentation().begin_solve(self.snes)
 
         # Single control point for the bounded/resumable difficulty solve. Runs AFTER
         # every per-solve setFromOptions (base and Stokes), so overrides here win. Gated

--- a/src/underworld3/systems/__init__.py
+++ b/src/underworld3/systems/__init__.py
@@ -79,6 +79,11 @@ from .solvers import SNES_NavierStokes as NavierStokes
 
 from .free_surface import FreeSurface
 
+# Records left by every solve — read via solver.solve_report. SubSolveReport is what
+# solve_report.sub holds, one entry per fieldsplit block (see solver_health).
+from .solve_report import SolveReport
+from .solver_health import SubSolveReport
+
 # are the Lagrangian implementations actually distinct in reality ?
 from .ddt import Lagrangian as Lagrangian_DDt
 from .ddt import SemiLagrangian as SemiLagragian_DDt

--- a/src/underworld3/systems/__init__.py
+++ b/src/underworld3/systems/__init__.py
@@ -79,9 +79,7 @@ from .solvers import SNES_NavierStokes as NavierStokes
 
 from .free_surface import FreeSurface
 
-# Records left by every solve — read via solver.solve_report. SubSolveReport is what
-# solve_report.sub holds, one entry per fieldsplit block (see solver_health).
-from .solve_report import SolveReport
+# What solve_report.sub holds — one entry per fieldsplit block (see solver_health).
 from .solver_health import SubSolveReport
 
 # are the Lagrangian implementations actually distinct in reality ?

--- a/src/underworld3/systems/solve_report.py
+++ b/src/underworld3/systems/solve_report.py
@@ -12,7 +12,10 @@ See ``underworld3.cython.petsc_generic_snes_solvers.SolverBaseClass``.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Mapping, Optional, Tuple
+from typing import TYPE_CHECKING, Mapping, Optional, Tuple
+
+if TYPE_CHECKING:                       # keeps this module importable on its own
+    from underworld3.systems.solver_health import SubSolveReport
 
 # PETSc SNESConvergedReason codes -> short names. Mirrors the compact map in
 # SolverBaseClass._convergence_reasons; duplicated here so this module imports without the

--- a/src/underworld3/systems/solve_report.py
+++ b/src/underworld3/systems/solve_report.py
@@ -11,8 +11,8 @@ See ``underworld3.cython.petsc_generic_snes_solvers.SolverBaseClass``.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Optional, Tuple
+from dataclasses import dataclass, field
+from typing import Mapping, Optional, Tuple
 
 # PETSc SNESConvergedReason codes -> short names. Mirrors the compact map in
 # SolverBaseClass._convergence_reasons; duplicated here so this module imports without the
@@ -115,6 +115,17 @@ class SolveReport:
     bounded
         ``True`` when this report came from an iteration-capped (``estimate_difficulty``)
         solve — i.e. work was truncated, not a genuine failure.
+    sub
+        Work done by each fieldsplit sub-solve, keyed by block name (``"velocity"``,
+        ``"pressure"`` for Stokes). ``ksp_its`` above counts only the OUTER Krylov
+        iterations, which Eisenstat–Walker collapses to about one per Newton step — the
+        real cost of a Stokes solve is ``sub["velocity"].its`` multigrid cycles. Empty
+        for solvers with no fieldsplit preconditioner. See
+        ``underworld3.systems.solver_health``.
+    deadline_expired
+        ``True`` when a wall-clock guard armed with ``solver.guard(...)`` cut this solve
+        short. Distinguishes "the budget ran out" from a genuine divergence: both report
+        ``DIVERGED_LINEAR_SOLVE``.
     """
 
     reason: int
@@ -129,12 +140,17 @@ class SolveReport:
     fev: Optional[int] = None
     history: Tuple[float, ...] = ()
     bounded: bool = False
+    sub: Mapping[str, "SubSolveReport"] = field(default_factory=dict)
+    deadline_expired: bool = False
 
     def __str__(self) -> str:
         rho = f"{self.rho:.3f}" if self.rho is not None else "n/a"
+        sub = "".join(f", {r.name}={r.its}" for r in self.sub.values())
         return (
             f"SolveReport({self.reason_str}, nl={self.nl_its}, ksp={self.ksp_its}, "
             f"|F|={self.fnorm:.3e}, rho={rho}"
+            + sub
             + (", bounded" if self.bounded else "")
+            + (", deadline" if self.deadline_expired else "")
             + ")"
         )

--- a/src/underworld3/systems/solver_health.py
+++ b/src/underworld3/systems/solver_health.py
@@ -1,0 +1,315 @@
+r"""Sub-solve work gauges and the wall-clock guard for SNES-based solvers.
+
+Two facilities, deliberately separate, both attached to the solver's own PETSc objects.
+
+**The gauge** (always on, observation only). A nonlinear Stokes solve reports about one
+*outer* KSP iteration per Newton step, because Eisenstat--Walker loosens the outer
+tolerance to whatever the current Newton step deserves. The work is really done inside
+the ``fieldsplit_velocity_`` sub-KSP, one multigrid cycle per iteration, and inside the
+``fieldsplit_pressure_`` sub-KSP, one *velocity solve* per iteration. So
+``solve_report.ksp_its`` is not a measure of cost. ``solve_report.sub`` is: iterations
+and applications per fieldsplit block, which is what "how expensive was this solve"
+actually means.
+
+**The guard** (opt-in, changes termination). ``solver.guard(wall_per_step=...)`` bounds
+the wall-clock time of each Newton step. Nothing outside PETSc can do this:
+
+* an iteration cap does not bound wall time, because below the conditioning floor a
+  *single* Newton step grinds inside one outer KSP iteration -- the outer count never
+  advances, so no cap on it can fire;
+* a Python ``signal.alarm`` does not fire either, because Python runs signal handlers
+  only between bytecodes and control is inside PETSc's C code the whole time. Measured:
+  a 90 s alarm sat unfired at 10 minutes.
+
+The only code that runs during the grind is PETSc's own convergence test, so that is
+where the deadline lives. It is reset at the start of every outer KSP solve -- which is
+once per Newton step -- and checked inside the sub-KSP tests, where iterations are
+frequent enough to give seconds of granularity.
+
+**Which diverged reason** matters, and is not obvious. PETSc's ``KSPCheckSolve``
+deliberately *exempts* ``KSP_DIVERGED_ITS`` from marking the preconditioner as failed --
+truncating an inner solve at its iteration cap is normal, not an error. So a guard that
+returns ``DIVERGED_MAX_IT`` from a sub-KSP silently does nothing: measured, the outer
+solve absorbed 36 truncated velocity solves and still reported CONVERGED. Returning
+``DIVERGED_BREAKDOWN`` marks the sub-preconditioner failed, which surfaces at the outer
+KSP as ``DIVERGED_PC_FAILED`` and at the SNES as ``DIVERGED_LINEAR_SOLVE``.
+
+See ``docs/developer/design/solver-wall-clock-guard.md``.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass
+from typing import Dict
+
+import numpy as np
+from mpi4py import MPI
+from petsc4py import PETSc
+
+# Marking the sub-preconditioner failed is the whole point -- see the module docstring.
+_DEADLINE_REASON = PETSc.KSP.ConvergedReason.DIVERGED_BREAKDOWN
+
+
+@dataclass(frozen=True)
+class SubSolveReport:
+    """Work done by one fieldsplit sub-solve over a single outer solve.
+
+    Attributes
+    ----------
+    name
+        Block name taken from the sub-KSP's options prefix -- ``"velocity"`` or
+        ``"pressure"`` for the Stokes saddle-point solver.
+    its
+        Iterations summed over every application of this sub-solve. For the velocity
+        block under ``pc_type=mg`` this is the multigrid cycle count, i.e. the honest
+        work axis.
+    applications
+        Number of times the sub-solve ran during the outer solve.
+    complete
+        ``False`` when the block was instrumented *during* this solve rather than
+        before it, which happens on a solver's very first solve: the fieldsplit blocks
+        do not exist until ``PCSetUp`` has run, and that runs inside the first
+        ``KSPSolve``. Everything the preconditioner did before then is not in the
+        count, so treat ``its`` as a lower bound. Every later solve is exact -- so a
+        driver that wants exact work should do one cheap solve first, which it usually
+        does anyway to pay for the JIT compile.
+    """
+
+    name: str
+    its: int
+    applications: int
+    complete: bool = True
+
+    def __str__(self) -> str:
+        return (f"{self.name}: {self.its} its / {self.applications} applications"
+                + ("" if self.complete else " (lower bound)"))
+
+
+def _block_name(ksp):
+    """Readable block name from a sub-KSP options prefix.
+
+    Prefixes look like ``Solver_6_fieldsplit_velocity_``; the part that identifies the
+    block is the tail after the last ``fieldsplit_``.
+    """
+    prefix = ksp.getOptionsPrefix() or ""
+    tail = prefix.rsplit("fieldsplit_", 1)[-1]
+    return tail.strip("_") or prefix.strip("_") or "sub"
+
+
+def _default_convergence(ksp, its, rnorm, state):
+    """Reproduce ``KSPConvergedDefault``'s verdict for this iteration.
+
+    A custom convergence test *replaces* the default -- petsc4py exposes no way to chain
+    to it -- so a guard has to carry the ordinary rtol / atol / divtol semantics itself,
+    or a healthy KSP would never converge. Tolerances are read fresh each iteration
+    because Eisenstat--Walker rewrites the outer rtol before every Newton step.
+    """
+    R = PETSc.KSP.ConvergedReason
+    if its == 0:
+        state["r0"] = rnorm if rnorm > 0.0 else 1.0
+    rtol, atol, divtol, _max_it = ksp.getTolerances()
+    if rnorm != rnorm:                                    # NaN
+        return R.DIVERGED_NANORINF
+    if rnorm <= atol:
+        return R.CONVERGED_ATOL
+    if rnorm <= rtol * state["r0"]:
+        return R.CONVERGED_RTOL
+    if rnorm >= divtol * state["r0"]:
+        return R.DIVERGED_DTOL
+    return R.ITERATING
+
+
+class _InstrumentedKSP:
+    """One KSP the instrumentation is attached to, and everything it needs.
+
+    Holds the iteration counters (fed by a monitor, which cannot affect the solve) and,
+    when the guard is armed, the deadline-checking convergence test that replaces the
+    default one.
+    """
+
+    def __init__(self, ksp, name, instrumentation, is_outer, mid_solve):
+        self.ksp = ksp
+        self.name = name
+        self.its = 0
+        self.applications = 0
+        self.complete = not mid_solve
+        self._instrumentation = instrumentation
+        self.is_outer = is_outer
+        self._state = {"r0": 1.0}
+        ksp.setMonitor(self._monitor)
+
+    def reset(self):
+        self.its = 0
+        self.applications = 0
+        self.complete = True          # attached before this solve began
+
+    def report(self):
+        return SubSolveReport(name=self.name, its=self.its,
+                              applications=self.applications, complete=self.complete)
+
+    def _monitor(self, ksp, its, rnorm):
+        # PETSc calls the monitor once per iteration including iteration 0, which
+        # reports the initial residual rather than work done -- so a call at 0 opens a
+        # new application and every later call is one iteration.
+        if its == 0:
+            self.applications += 1
+            if self.is_outer:
+                # The outer KSP runs once per Newton step, so its iteration 0 is the
+                # natural place to start that step's clock -- no SNES hook needed. The
+                # sub-KSPs do not exist until PCSetUp has run, and PCSetUp runs inside
+                # KSPSolve, so this is the earliest they can be reached.
+                self._instrumentation.open_step()
+                self._instrumentation.attach_sub_ksps(ksp, mid_solve=True)
+        else:
+            self.its += 1
+
+    def _test(self, ksp, its, rnorm):
+        if self.is_outer and its == 0:
+            # PETSc does not fix the order of the monitor and the convergence test, so
+            # whichever runs first at iteration 0 opens the step. Both are idempotent.
+            self._instrumentation.open_step()
+            self._instrumentation.attach_sub_ksps(ksp, mid_solve=True)
+        if self._instrumentation.deadline_passed():
+            self._instrumentation.deadline_expired = True
+            return _DEADLINE_REASON
+        return _default_convergence(ksp, its, rnorm, self._state)
+
+    def install_test(self):
+        self.ksp.setConvergenceTest(self._test)
+
+    def remove_test(self):
+        self.ksp.setConvergenceTest(None)                 # restores KSPConvergedDefault
+
+
+class SolverInstrumentation:
+    """A solver's PETSc instrumentation: the sub-solve gauge, and the guard when armed.
+
+    One instance per solver, created on first use. It re-attaches itself to whatever
+    SNES the solver currently holds, because a setup-dirtying change (remesh, adapt, a
+    rebuilt discretisation) replaces the SNES and drops everything attached to the old
+    one.
+    """
+
+    def __init__(self):
+        self.wall_per_step = None            # None => guard disarmed
+        self.deadline_expired = False
+        self._ksps: Dict[int, _InstrumentedKSP] = {}      # keyed by PETSc handle
+        self._outer_handle = None
+        self._expires = math.inf
+        self._comm = None
+        self._flag = np.zeros(1, dtype=np.int32)
+
+    # ---------------------------------------------------------------- arming
+
+    @property
+    def armed(self):
+        return self.wall_per_step is not None
+
+    def arm(self, wall_per_step):
+        """Set the per-Newton-step wall-clock budget, in seconds."""
+        budget = float(wall_per_step)
+        if not budget > 0.0:
+            raise ValueError(
+                f"wall_per_step must be a positive number of seconds (got "
+                f"{wall_per_step!r}); call unguard() to remove the deadline."
+            )
+        self.wall_per_step = budget
+        for entry in self._ksps.values():
+            entry.install_test()
+
+    def disarm(self):
+        self.wall_per_step = None
+        self._expires = math.inf
+        for entry in self._ksps.values():
+            entry.remove_test()
+
+    # ------------------------------------------------------------ attachment
+
+    def begin_solve(self, snes):
+        """Prepare instrumentation for a solve that is about to start.
+
+        Attaches to the current SNES's outer KSP if it is one we have not seen, and
+        clears the per-solve counters. Called from the solver's single solve funnel, so
+        a recreated SNES is picked up automatically.
+        """
+        self.deadline_expired = False
+        self._expires = math.inf
+
+        outer = snes.getKSP()
+        if self._outer_handle not in (None, outer.handle):
+            # A rebuilt solver (remesh, adapt, new discretisation) carries a new SNES,
+            # and everything attached to the old one went with it. Start over rather
+            # than accumulate blocks that can never report again.
+            self._ksps.clear()
+        self._outer_handle = outer.handle
+
+        for entry in self._ksps.values():
+            entry.reset()
+        self._attach(outer, name="outer", is_outer=True, mid_solve=False)
+
+    def attach_sub_ksps(self, ksp, mid_solve):
+        """Attach to the fieldsplit blocks of ``ksp``'s preconditioner.
+
+        Only ever called from inside a solve: the blocks do not exist until ``PCSetUp``
+        has run, and asking for them earlier is a PETSc error rather than an empty list.
+        They persist across solves, so this attaches once and then does nothing.
+        """
+        pc = ksp.getPC()
+        if pc.getType() != "fieldsplit":
+            return                                        # no sub-solves to account for
+        for sub in pc.getFieldSplitSubKSP():
+            self._attach(sub, name=_block_name(sub), is_outer=False,
+                         mid_solve=mid_solve)
+
+    def _attach(self, ksp, name, is_outer, mid_solve):
+        if ksp.handle in self._ksps:
+            return
+        entry = _InstrumentedKSP(ksp, name, self, is_outer, mid_solve)
+        self._ksps[ksp.handle] = entry
+        if is_outer:
+            self._comm = ksp.getComm().tompi4py()
+        if self.armed:
+            entry.install_test()
+
+    # ------------------------------------------------------------ the deadline
+
+    def open_step(self):
+        """Start the clock for one Newton step."""
+        if self.armed:
+            self._expires = time.monotonic() + self.wall_per_step
+        else:
+            self._expires = math.inf
+
+    def deadline_passed(self):
+        """Has the budget run out? The answer must be identical on every rank.
+
+        A convergence test that returns different reasons on different ranks leaves the
+        ranks on different PETSc code paths and the next collective deadlocks. Wall
+        clocks are not synchronised across ranks, so the local answer is reduced over
+        the KSP's own communicator. That costs one integer reduction per iteration,
+        against a multigrid cycle -- and every iteration already pays for at least one
+        norm reduction, so it does not change the communication character of the solve.
+        """
+        if self._expires == math.inf:
+            return False
+        local = 1 if time.monotonic() > self._expires else 0
+        if self._comm is None or self._comm.size == 1:
+            return bool(local)
+        self._flag[0] = local
+        self._comm.Allreduce(MPI.IN_PLACE, self._flag, op=MPI.MAX)
+        return bool(self._flag[0])
+
+    # ---------------------------------------------------------------- readout
+
+    def sub_reports(self):
+        """Per-block work for the solve that just finished.
+
+        The outer KSP is excluded: its count is already ``solve_report.ksp_its``.
+        """
+        return {
+            entry.name: entry.report()
+            for entry in self._ksps.values()
+            if not entry.is_outer and entry.applications > 0
+        }

--- a/src/underworld3/systems/solver_health.py
+++ b/src/underworld3/systems/solver_health.py
@@ -34,6 +34,16 @@ solve absorbed 36 truncated velocity solves and still reported CONVERGED. Return
 ``DIVERGED_BREAKDOWN`` marks the sub-preconditioner failed, which surfaces at the outer
 KSP as ``DIVERGED_PC_FAILED`` and at the SNES as ``DIVERGED_LINEAR_SOLVE``.
 
+**The guard does not replace PETSc's convergence test, it runs in front of it.**
+``KSP.addConvergenceTest(..., prepend=True)`` composes with whatever native test the KSP
+is configured with, so returning ``ITERATING`` hands the decision straight back to
+``KSPConvergedDefault`` -- with its options-configured context intact
+(``-ksp_converged_maxits``, the non-zero-initial-guess residual convention, the
+norm-type early return, and the rest). Verified: a prepended test that always returns
+``ITERATING`` gives bit-identical iteration count and reason to an uninstrumented solve.
+A disarmed guard is therefore genuinely inert rather than approximately inert, which a
+hand-rolled reimplementation of the default test could never be.
+
 See ``docs/developer/design/solver-wall-clock-guard.md``.
 """
 
@@ -51,6 +61,12 @@ from petsc4py import PETSc
 # Marking the sub-preconditioner failed is the whole point -- see the module docstring.
 _DEADLINE_REASON = PETSc.KSP.ConvergedReason.DIVERGED_BREAKDOWN
 
+# KSP types whose behaviour changes when a monitor is attached (both are gated on
+# ksp->numbermonitors in PETSc): preonly.c computes norms it would otherwise skip, and
+# rich.c abandons the fused PCApplyRichardson path. Neither iterates, so there is
+# nothing here for the gauge to count or the guard to bound.
+_MONITOR_SENSITIVE_KSPS = ("preonly", "richardson")
+
 
 @dataclass(frozen=True)
 class SubSolveReport:
@@ -59,8 +75,10 @@ class SubSolveReport:
     Attributes
     ----------
     name
-        Block name taken from the sub-KSP's options prefix -- ``"velocity"`` or
-        ``"pressure"`` for the Stokes saddle-point solver.
+        Block name taken from the sub-KSP's options prefix -- ``"velocity"`` and
+        ``"pressure"`` for the Stokes saddle-point solver. A solver that builds its
+        splits by DM field index instead (the block-constrained Stokes path) names them
+        ``"0"``, ``"1"``, ...; read the keys rather than assuming them.
     its
         Iterations summed over every application of this sub-solve. For the velocity
         block under ``pc_type=mg`` this is the multigrid cycle count, i.e. the honest
@@ -98,35 +116,12 @@ def _block_name(ksp):
     return tail.strip("_") or prefix.strip("_") or "sub"
 
 
-def _default_convergence(ksp, its, rnorm, state):
-    """Reproduce ``KSPConvergedDefault``'s verdict for this iteration.
-
-    A custom convergence test *replaces* the default -- petsc4py exposes no way to chain
-    to it -- so a guard has to carry the ordinary rtol / atol / divtol semantics itself,
-    or a healthy KSP would never converge. Tolerances are read fresh each iteration
-    because Eisenstat--Walker rewrites the outer rtol before every Newton step.
-    """
-    R = PETSc.KSP.ConvergedReason
-    if its == 0:
-        state["r0"] = rnorm if rnorm > 0.0 else 1.0
-    rtol, atol, divtol, _max_it = ksp.getTolerances()
-    if rnorm != rnorm:                                    # NaN
-        return R.DIVERGED_NANORINF
-    if rnorm <= atol:
-        return R.CONVERGED_ATOL
-    if rnorm <= rtol * state["r0"]:
-        return R.CONVERGED_RTOL
-    if rnorm >= divtol * state["r0"]:
-        return R.DIVERGED_DTOL
-    return R.ITERATING
-
-
 class _InstrumentedKSP:
     """One KSP the instrumentation is attached to, and everything it needs.
 
-    Holds the iteration counters (fed by a monitor, which cannot affect the solve) and,
-    when the guard is armed, the deadline-checking convergence test that replaces the
-    default one.
+    Holds the iteration counters (fed by a monitor, which cannot affect the solve) and
+    the deadline-checking convergence test, which runs *in front of* the KSP's native
+    test rather than replacing it.
     """
 
     def __init__(self, ksp, name, instrumentation, is_outer, mid_solve):
@@ -137,7 +132,7 @@ class _InstrumentedKSP:
         self.complete = not mid_solve
         self._instrumentation = instrumentation
         self.is_outer = is_outer
-        self._state = {"r0": 1.0}
+        self._test_installed = False
         ksp.setMonitor(self._monitor)
 
     def reset(self):
@@ -167,20 +162,31 @@ class _InstrumentedKSP:
 
     def _test(self, ksp, its, rnorm):
         if self.is_outer and its == 0:
-            # PETSc does not fix the order of the monitor and the convergence test, so
-            # whichever runs first at iteration 0 opens the step. Both are idempotent.
+            # PETSc does not fix the order of the monitor and the convergence test at
+            # iteration 0, so whichever runs first opens the step. The second call
+            # re-reads the clock and pushes the deadline out by the gap between them --
+            # microseconds against a multigrid cycle, and never in the unsafe direction.
             self._instrumentation.open_step()
             self._instrumentation.attach_sub_ksps(ksp, mid_solve=True)
         if self._instrumentation.deadline_passed():
             self._instrumentation.deadline_expired = True
             return _DEADLINE_REASON
-        return _default_convergence(ksp, its, rnorm, self._state)
+        # Hand the decision back to the KSP's own test, whatever it is configured to be.
+        return PETSc.KSP.ConvergedReason.ITERATING
 
     def install_test(self):
-        self.ksp.setConvergenceTest(self._test)
+        """Prepend the deadline test, once and for all.
 
-    def remove_test(self):
-        self.ksp.setConvergenceTest(None)                 # restores KSPConvergedDefault
+        PETSc allows exactly one ``addConvergenceTest`` per KSP and offers no way to
+        take it off again, so the test is installed on first arming and left in place;
+        ``disarm()`` makes it inert instead of removing it. That is a true restore
+        rather than an approximate one: with no budget set the test returns ``ITERATING``
+        immediately and the KSP's native test decides exactly as it would have.
+        """
+        if self._test_installed:
+            return
+        self.ksp.addConvergenceTest(self._test, prepend=True)
+        self._test_installed = True
 
 
 class SolverInstrumentation:
@@ -194,7 +200,7 @@ class SolverInstrumentation:
 
     def __init__(self):
         self.wall_per_step = None            # None => guard disarmed
-        self.deadline_expired = False
+        self.deadline_expired = False        # latched for the whole of one solve
         self._ksps: Dict[int, _InstrumentedKSP] = {}      # keyed by PETSc handle
         self._outer_handle = None
         self._expires = math.inf
@@ -222,8 +228,21 @@ class SolverInstrumentation:
     def disarm(self):
         self.wall_per_step = None
         self._expires = math.inf
-        for entry in self._ksps.values():
-            entry.remove_test()
+        # The prepended tests stay installed -- PETSc has no way to remove them -- but
+        # with no budget they return ITERATING and the native test decides, which is
+        # exactly the uninstrumented behaviour.
+
+    def release(self):
+        """Drop every PETSc reference, keeping the arming state.
+
+        petsc4py increments the reference count of a KSP handed out by ``getKSP`` or
+        ``getFieldSplitSubKSP``, so holding these entries keeps a destroyed solver's KSP,
+        PC and whole multigrid hierarchy alive. A solver that rebuilds in a loop would
+        then carry two hierarchies at once -- the leak BUGFIX(#157) was written to close.
+        Called from the solver when it tears its SNES down.
+        """
+        self._ksps.clear()
+        self._outer_handle = None
 
     # ------------------------------------------------------------ attachment
 
@@ -235,9 +254,15 @@ class SolverInstrumentation:
         a recreated SNES is picked up automatically.
         """
         self.deadline_expired = False
-        self._expires = math.inf
 
         outer = snes.getKSP()
+        if outer.getType() in _MONITOR_SENSITIVE_KSPS:
+            # These two change what they DO when a monitor is attached: KSPSolve_PREONLY
+            # adds a norm, a matvec and a second norm purely to have something to report,
+            # and KSPRICHARDSON gives up the fused PCApplyRichardson path. Neither has
+            # outer iterations to bound or to count, so instrumenting them would be all
+            # cost and no information.
+            return
         if self._outer_handle not in (None, outer.handle):
             # A rebuilt solver (remesh, adapt, new discretisation) carries a new SNES,
             # and everything attached to the old one went with it. Start over rather
@@ -248,6 +273,13 @@ class SolverInstrumentation:
         for entry in self._ksps.values():
             entry.reset()
         self._attach(outer, name="outer", is_outer=True, mid_solve=False)
+        # Start the clock HERE, not at the outer KSP's first iteration. Under left
+        # preconditioning -- PETSc's default for GMRES, which is the Stokes outer solver
+        # -- KSPInitialResidual applies the preconditioner BEFORE iteration 0, so a
+        # clock that only started at iteration 0 would leave one full velocity solve
+        # plus one pressure solve outside the budget on every single solve. Measured:
+        # the sub-block monitors fire before the outer monitor for pc_side LEFT.
+        self.open_step()
 
     def attach_sub_ksps(self, ksp, mid_solve):
         """Attach to the fieldsplit blocks of ``ksp``'s preconditioner.
@@ -276,11 +308,24 @@ class SolverInstrumentation:
     # ------------------------------------------------------------ the deadline
 
     def open_step(self):
-        """Start the clock for one Newton step."""
-        if self.armed:
-            self._expires = time.monotonic() + self.wall_per_step
-        else:
-            self._expires = math.inf
+        """Start the clock for one Newton step.
+
+        Once the deadline has fired it stays fired for the rest of the solve, so a
+        solve that runs the SNES more than once -- the Picard-to-Newton continuation, or
+        a warm-start retry after divergence -- cannot hand each attempt a fresh full
+        budget.
+
+        MEASURED: PETSc already prevents this on its own. After a deadline exit the
+        sub-preconditioner is marked failed, and the next ``snes.solve`` bails before it
+        reaches an iteration, so neither a retry nor a continuation stage re-armed even
+        with the latch removed (tick counts 32 against 34). The latch is kept because
+        that protection is an implicit consequence of PC-failure propagation rather than
+        a guarantee, and because it makes the intended semantics explicit -- but it is
+        belt-and-braces, and there is deliberately no test claiming to prove otherwise.
+        """
+        if not self.armed or self.deadline_expired:
+            return
+        self._expires = time.monotonic() + self.wall_per_step
 
     def deadline_passed(self):
         """Has the budget run out? The answer must be identical on every rank.
@@ -292,7 +337,9 @@ class SolverInstrumentation:
         against a multigrid cycle -- and every iteration already pays for at least one
         norm reduction, so it does not change the communication character of the solve.
         """
-        if self._expires == math.inf:
+        if self.deadline_expired:
+            return True            # latched, and latched identically on every rank
+        if not self.armed:
             return False
         local = 1 if time.monotonic() > self._expires else 0
         if self._comm is None or self._comm.size == 1:

--- a/tests/parallel/mpi_runner.sh
+++ b/tests/parallel/mpi_runner.sh
@@ -43,3 +43,12 @@ echo "ptest 0004 checkpoint FMG hierarchy -np 2"
 mpirun -np 2 $PYTHON ./ptest_0004_checkpoint_fmg_hierarchy.py
 echo "ptest 0004 checkpoint FMG hierarchy -np 3 (uneven partition)"
 mpirun -np 3 $PYTHON ./ptest_0004_checkpoint_fmg_hierarchy.py
+
+# The wall-clock guard's expiry decision must be identical on every rank: a PETSc
+# convergence test that disagrees across ranks deadlocks the next collective. This
+# script skews the per-rank clocks deliberately, so it HANGS rather than fails if the
+# reduction is ever dropped -- run it under a timeout.
+echo "ptest 0203 wall-clock guard -np 2"
+mpirun --timeout 300 -np 2 $PYTHON ./ptest_0203_wallclock_guard_parallel.py
+echo "ptest 0203 wall-clock guard -np 4"
+mpirun --timeout 300 -np 4 $PYTHON ./ptest_0203_wallclock_guard_parallel.py

--- a/tests/parallel/ptest_0203_wallclock_guard_parallel.py
+++ b/tests/parallel/ptest_0203_wallclock_guard_parallel.py
@@ -1,0 +1,109 @@
+"""MPI test for the wall-clock guard (``systems/solver_health.py``).
+
+Run via mpi_runner.sh (mpirun -np N python ptest_0203_*.py).
+
+The parallel hazard is specific and severe: a PETSc convergence test that returns
+different verdicts on different ranks leaves the ranks on different code paths, and the
+next collective inside PETSc deadlocks. Wall clocks are not synchronised across ranks,
+so "has the budget run out" is exactly the kind of question that would split them —
+which is why the guard reduces the answer over the solver's communicator.
+
+**This script completing at all is the main assertion.** A split verdict hangs rather
+than fails; the runner's timeout is what catches it. The explicit assertions then check
+that the ranks agree about what happened, and that a guarded solve with a generous
+budget still produces the same answer as an unguarded one.
+"""
+import numpy as np
+import sympy
+
+import underworld3 as uw
+
+mesh = uw.meshing.UnstructuredSimplexBox(
+    minCoords=(0.0, 0.0), maxCoords=(1.0, 1.0), cellSize=0.05, qdegree=3
+)
+v = uw.discretisation.MeshVariable("Up", mesh, mesh.dim, degree=2)
+p = uw.discretisation.MeshVariable("Pp", mesh, 1, degree=1, continuous=True)
+
+stokes = uw.systems.Stokes(mesh, velocityField=v, pressureField=p)
+stokes.constitutive_model = uw.constitutive_models.ViscousFlowModel
+stokes.constitutive_model.Parameters.shear_viscosity_0 = 1.0
+x, y = mesh.X
+stokes.bodyforce = sympy.Matrix(
+    [0.0, -sympy.cos(sympy.pi * x) * sympy.sin(sympy.pi * y)]
+)
+for wall in ("Top", "Bottom", "Left", "Right"):
+    stokes.add_dirichlet_bc((0.0, 0.0), wall)
+stokes.petsc_options["snes_error_if_not_converged"] = "false"
+
+# Unguarded reference.
+stokes.solve()
+stokes.solve(zero_init_guess=True)
+reference = np.asarray(v.array).copy()
+assert stokes.solve_report.converged, f"rank {uw.mpi.rank}: reference solve failed"
+
+# A generous budget must not disturb the answer on any rank.
+stokes.guard(wall_per_step=600.0)
+stokes.solve(zero_init_guess=True)
+report = stokes.solve_report
+assert report.converged, f"rank {uw.mpi.rank}: generous budget broke a healthy solve"
+assert not report.deadline_expired
+drift = float(np.abs(np.asarray(v.array) - reference).max())
+assert drift < 1.0e-6, f"rank {uw.mpi.rank}: guarded answer drifted by {drift:.3e}"
+
+# A budget that cannot be met. Every rank must reach the same verdict — if the reduction
+# in deadline_passed() were dropped, the ranks whose clock had not yet expired would
+# keep iterating while the others reported failure, and PETSc would deadlock here.
+stokes.guard(wall_per_step=1.0e-6)
+stokes.solve(zero_init_guess=True)
+cut = stokes.solve_report
+stokes.unguard()
+
+assert cut.deadline_expired, f"rank {uw.mpi.rank}: the deadline never fired"
+assert not cut.converged, f"rank {uw.mpi.rank}: a cut solve reported success"
+
+verdicts = uw.mpi.comm.allgather((cut.deadline_expired, cut.converged, cut.reason))
+assert len(set(verdicts)) == 1, f"ranks disagree about the guarded solve: {verdicts}"
+
+# And the guard must come off cleanly on every rank.
+stokes.solve(zero_init_guess=True)
+assert stokes.solve_report.converged, f"rank {uw.mpi.rank}: unguard did not restore"
+
+
+# --- the hazard, provoked deliberately ------------------------------------------------
+# The checks above cannot show the reduction is doing anything: with a 1e-6 s budget
+# every rank's clock expires at once, so a per-rank decision would agree by luck. Skew
+# the clocks instead — rank 0's runs fast, the others' barely move — so the ranks WOULD
+# reach opposite verdicts if each decided alone. This relies on every rank calling the
+# convergence tests the same number of times, which holds because Krylov iterations are
+# globally synchronised; that is what makes the reduction well-posed rather than a
+# guess. Without the reduction this section deadlocks.
+from underworld3.systems import solver_health
+
+
+class _RankSkewedClock:
+    def __init__(self, rank):
+        self.now = 0.0
+        self.tick = 10.0 if rank == 0 else 1.0e-9
+
+
+    def monotonic(self):
+        self.now += self.tick
+        return self.now
+
+
+solver_health.time = _RankSkewedClock(uw.mpi.rank)
+stokes.guard(wall_per_step=50.0)          # only rank 0's clock can reach this
+stokes.solve(zero_init_guess=True)
+skewed = stokes.solve_report
+stokes.unguard()
+
+assert skewed.deadline_expired, (
+    f"rank {uw.mpi.rank}: one rank's clock expired but this rank did not follow — "
+    "the expiry decision was not reduced across the communicator"
+)
+skewed_verdicts = uw.mpi.comm.allgather((skewed.deadline_expired, skewed.reason))
+assert len(set(skewed_verdicts)) == 1, (
+    f"ranks disagree under skewed clocks: {skewed_verdicts}"
+)
+
+uw.pprint(f"ptest_0203: wall-clock guard consistent across {uw.mpi.size} ranks")

--- a/tests/test_0203_solver_wallclock_guard.py
+++ b/tests/test_0203_solver_wallclock_guard.py
@@ -1,19 +1,24 @@
 """Sub-solve work gauge and the wall-clock guard (``systems/solver_health.py``).
 
-These tests are written against the two ways the feature could be fake:
+Written against the ways the feature could be fake:
 
-* the gauge could be the outer Krylov count under a new name, which would be useless —
-  so it is asserted to see work the outer count cannot;
-* the guard could fail to stop a grind, or could stop a healthy solve. Both are checked,
-  and the healthy-solve check compares the *answer* against an unguarded solve, because
-  the guard replaces PETSc's convergence tests and a sloppy replacement would quietly
-  move where the solve stops.
+* the gauge could be the outer Krylov count under a new name — so it is asserted to see
+  work the outer count cannot, and to admit when its count is only a lower bound;
+* the guard could fail to stop a grind, or stop a healthy solve. Both are checked, and
+  the healthy-solve check compares *iteration counts* as well as the answer: the guard
+  runs a test in front of PETSc's own, and a test that perturbed convergence would move
+  the cost long before it moved the answer;
+* ``wall_per_step`` could mean per *solve* rather than per Newton step, which one linear
+  solve cannot distinguish — so the re-arming is exercised on a nonlinear model;
+* ``unguard()`` could leave the guard half-attached.
 
-The test that has to prove the guard bites *inside* the fieldsplit blocks — the claim
-the whole design rests on — drives a fake clock rather than a wall-clock budget. A
-budget in seconds cannot express "expire during the block solves" on an unknown machine:
-too large and the solve finishes, too small and it expires at the outer iteration
-before the blocks are ever reached.
+The tests that must prove *where* the deadline bites drive an injected clock rather than
+a wall-clock budget. A budget in seconds cannot express "expire during the block solves"
+on an unknown machine: too large and the solve finishes, too small and it expires at the
+outer iteration before the blocks are reached. Its limitation is stated where it is used.
+
+Tier B, not A: these are new, and Charter §8 reserves tier A for tests that have been
+through review and use in anger.
 """
 
 import numpy as np
@@ -23,13 +28,17 @@ import sympy
 import underworld3 as uw
 from underworld3.systems import solver_health
 
+pytestmark = [pytest.mark.level_1, pytest.mark.tier_b]
+
 
 class _TickingClock:
     """A clock that advances one tick per reading.
 
-    Makes the deadline expire after a known number of convergence-test checks instead
-    of after an interval of real time, so the test asserts the same thing on a fast
-    machine and a slow one.
+    Makes the deadline expire after a known number of convergence-test checks instead of
+    after an interval of real time, so the test asserts the same thing on a fast machine
+    and a slow one. Note what this cannot do: because PETSc's real work costs zero ticks,
+    expiry is guaranteed for any budget — these tests can catch a guard that never fires,
+    not one that fires too eagerly. The real-clock test below covers that direction.
     """
 
     def __init__(self, tick=1.0):
@@ -41,22 +50,16 @@ class _TickingClock:
         return self.now
 
 
-@pytest.fixture(scope="module")
-def stokes_box():
-    """A small, well-conditioned Stokes solve.
-
-    Deliberately easy: these tests are about the instrumentation, and a genuinely hard
-    solve would make them slow and their timing fragile.
-    """
+def _stokes(tag, viscosity):
     mesh = uw.meshing.UnstructuredSimplexBox(
         minCoords=(0.0, 0.0), maxCoords=(1.0, 1.0), cellSize=0.1, qdegree=3
     )
-    v = uw.discretisation.MeshVariable("Ug", mesh, mesh.dim, degree=2)
-    p = uw.discretisation.MeshVariable("Pg", mesh, 1, degree=1, continuous=True)
+    v = uw.discretisation.MeshVariable(f"U{tag}", mesh, mesh.dim, degree=2)
+    p = uw.discretisation.MeshVariable(f"P{tag}", mesh, 1, degree=1, continuous=True)
 
     solver = uw.systems.Stokes(mesh, velocityField=v, pressureField=p)
     solver.constitutive_model = uw.constitutive_models.ViscousFlowModel
-    solver.constitutive_model.Parameters.shear_viscosity_0 = 1.0
+    solver.constitutive_model.Parameters.shear_viscosity_0 = viscosity(v)
     x, y = mesh.X
     solver.bodyforce = sympy.Matrix(
         [0.0, -sympy.cos(sympy.pi * x) * sympy.sin(sympy.pi * y)]
@@ -65,17 +68,36 @@ def stokes_box():
         solver.add_dirichlet_bc((0.0, 0.0), wall)
     # Guard exits are reports, not errors — a driver reads them and steps back.
     solver.petsc_options["snes_error_if_not_converged"] = "false"
-
-    solver.solve()          # first solve: pays the JIT, and attaches the instrumentation
     return solver, v
 
 
-@pytest.mark.level_1
-@pytest.mark.tier_a
-def test_sub_solve_gauge_sees_work_the_outer_count_cannot(stokes_box):
+@pytest.fixture(scope="module")
+def linear_box():
+    """A small, well-conditioned LINEAR Stokes solve — one Newton step."""
+    solver, v = _stokes("g", lambda v: 1.0)
+    solver.solve()        # first solve: pays the JIT, and attaches the instrumentation
+    yield solver, v
+    solver.unguard()
+
+
+@pytest.fixture
+def guarded(linear_box):
+    """Hands back the shared solver and guarantees it is disarmed afterwards.
+
+    Without this a test that fails part-way leaves the module-scoped solver armed at a
+    microsecond budget, and every later test in the file fails for the wrong reason.
+    """
+    solver, v = linear_box
+    try:
+        yield solver, v
+    finally:
+        solver.unguard()
+
+
+def test_sub_solve_gauge_sees_work_the_outer_count_cannot(guarded):
     """``ksp_its`` counts outer Krylov iterations, which Eisenstat--Walker collapses to
     about one per Newton step. The multigrid cycles are in the velocity block."""
-    solver, _ = stokes_box
+    solver, _ = guarded
     solver.solve(zero_init_guess=True)
     report = solver.solve_report
 
@@ -90,68 +112,85 @@ def test_sub_solve_gauge_sees_work_the_outer_count_cannot(stokes_box):
     assert report.sub["velocity"].complete
 
 
-@pytest.mark.level_1
-@pytest.mark.tier_a
-def test_generous_budget_leaves_a_healthy_solve_alone(stokes_box):
-    """The guard replaces PETSc's convergence tests. If the replacement were wrong the
-    solve would stop somewhere else — so compare the answer, not just the reason."""
-    solver, v = stokes_box
+def test_first_solve_admits_its_count_is_a_lower_bound():
+    """A fresh solver cannot see the fieldsplit blocks until PETSc has set up the
+    preconditioner, part-way through its first solve. The count that results is short —
+    measured, by about half — so the report must say so rather than pass it off as
+    exact."""
+    solver, _ = _stokes("lb", lambda v: 1.0)
+    solver.solve()
+    first = solver.solve_report.sub["velocity"]
+    solver.solve(zero_init_guess=True)
+    second = solver.solve_report.sub["velocity"]
+
+    assert not first.complete, "the first solve claimed an exact count it cannot have"
+    assert second.complete
+    assert second.its > first.its, (
+        "the first solve should undercount; if it does not, the 'lower bound' contract "
+        "is either wrong or no longer needed"
+    )
+
+
+def test_generous_budget_changes_neither_the_answer_nor_the_cost(guarded):
+    """The guard runs a test in front of PETSc's own. If that composition perturbed
+    convergence at all, the iteration counts would move first — long before the answer
+    did, and invisibly for anything confined to the sub-blocks."""
+    solver, v = guarded
     solver.unguard()
     solver.solve(zero_init_guess=True)
     unguarded = np.asarray(v.array).copy()
-    assert solver.solve_report.converged
+    before = solver.solve_report
+    assert before.converged
 
     solver.guard(wall_per_step=600.0)
     solver.solve(zero_init_guess=True)
-    guarded_report = solver.solve_report
-    solver.unguard()
+    after = solver.solve_report
 
-    assert guarded_report.converged
-    assert not guarded_report.deadline_expired
+    assert after.converged
+    assert not after.deadline_expired
     drift = np.abs(np.asarray(v.array) - unguarded).max()
     assert drift < 1.0e-6, f"guarded answer differs from unguarded by {drift:.3e}"
+    # Cost parity — the sharp assertion. An armed-but-unexpired guard must hand every
+    # convergence decision straight back to PETSc.
+    assert after.nl_its == before.nl_its
+    assert after.ksp_its == before.ksp_its
+    assert after.sub["velocity"].its == before.sub["velocity"].its
+    assert after.sub["pressure"].its == before.sub["pressure"].its
 
 
-@pytest.mark.level_1
-@pytest.mark.tier_a
-def test_exhausted_budget_stops_the_solve_and_reports_it(stokes_box):
+def test_exhausted_budget_stops_the_solve_and_reports_it(guarded):
     """A budget too small to finish must stop the solve, and must not claim success.
 
     Reporting matters as much as stopping: a solve cut short that still said
-    ``converged`` would silently corrupt a continuation driver, which reads exactly
-    this to decide whether a parameter station is reachable.
+    ``converged`` would silently corrupt a continuation driver, which reads exactly this
+    to decide whether a parameter station is reachable.
     """
-    solver, _ = stokes_box
+    solver, _ = guarded
     solver.guard(wall_per_step=1.0e-6)
     solver.solve(zero_init_guess=True)
     report = solver.solve_report
-    solver.unguard()
 
     assert report.deadline_expired, "the wall-clock deadline never fired"
     assert not report.converged, "a solve cut short by the deadline reported success"
     assert report.reason_str == "DIVERGED_LINEAR_SOLVE"
 
 
-@pytest.mark.level_1
-@pytest.mark.tier_a
-def test_deadline_bites_inside_the_fieldsplit_blocks(stokes_box, monkeypatch):
+def test_deadline_bites_inside_the_fieldsplit_blocks(guarded, monkeypatch):
     """The claim the design rests on: the deadline is honoured *below* the outer Krylov
     iteration, where an iteration cap has nothing to count.
 
-    The clock is set to expire after roughly fifty convergence-test checks. The outer
-    test contributes only a couple of those, so expiry necessarily happens inside the
-    block solves — and the assertions confirm it: the outer iteration never completed
+    The clock expires after roughly fifty convergence-test checks. The outer test
+    contributes only a couple of those, so expiry necessarily happens inside the block
+    solves — and the assertions confirm it: the outer iteration never completed
     (``ksp_its == 0``, so no cap on it could have fired) while the velocity block had
     already run many multigrid cycles.
     """
-    solver, _ = stokes_box
-    clock = _TickingClock(tick=1.0)
-    monkeypatch.setattr(solver_health, "time", clock)
+    solver, _ = guarded
+    monkeypatch.setattr(solver_health, "time", _TickingClock(tick=1.0))
 
     solver.guard(wall_per_step=50.0)          # fifty ticks == fifty checks
     solver.solve(zero_init_guess=True)
     report = solver.solve_report
-    solver.unguard()
 
     assert report.deadline_expired
     assert not report.converged
@@ -162,42 +201,106 @@ def test_deadline_bites_inside_the_fieldsplit_blocks(stokes_box, monkeypatch):
     )
 
 
-@pytest.mark.level_1
-@pytest.mark.tier_a
-def test_unguard_restores_normal_convergence(stokes_box):
-    """The deadline must be removable — otherwise a driver that guards one probe would
-    poison every later solve on the same solver."""
-    solver, _ = stokes_box
+def test_the_budget_is_per_newton_step_not_per_solve(monkeypatch):
+    """``wall_per_step`` is the only parameter the feature takes, and a linear solve
+    cannot tell its two possible meanings apart — one Newton step is one solve.
+
+    On a nonlinear model, run the solve once to learn how many clock ticks it costs in
+    total, then re-run it with a budget of 90% of that. A per-SOLVE budget expires; a
+    per-STEP budget does not, because no single Newton step costs that much. So the
+    solve converging *is* the proof that the deadline restarted, and the tick count
+    confirms it really did outlive one budget's worth.
+    """
+    solver, _ = _stokes("ps", lambda v: 1.0 + 5.0 * v.sym.dot(v.sym))
+    solver.solve()
+    assert solver.solve_report.nl_its >= 2, (
+        "fixture is not nonlinear enough to distinguish per-step from per-solve"
+    )
+
+    clock = _TickingClock(tick=1.0)
+    monkeypatch.setattr(solver_health, "time", clock)
+    solver.guard(wall_per_step=1.0e9)          # never expires: just count the ticks
+    try:
+        solver.solve(zero_init_guess=True)
+        assert not solver.solve_report.deadline_expired
+        total = clock.now
+
+        clock.now = 0.0
+        budget = 0.9 * total
+        solver.guard(wall_per_step=budget)
+        solver.solve(zero_init_guess=True)
+    finally:
+        solver.unguard()
+
+    report = solver.solve_report
+    assert not report.deadline_expired, (
+        f"a budget of {budget:.0f} ticks expired, so it was being applied to the whole "
+        f"solve rather than restarted for each of its {report.nl_its} Newton steps"
+    )
+    assert report.converged
+    assert clock.now > budget, (
+        f"the solve cost only {clock.now:.0f} ticks against a {budget:.0f}-tick budget, "
+        "so it never outlived one budget and proves nothing about restarting"
+    )
+
+
+def test_a_guard_armed_before_the_first_solve_still_fires():
+    """The documented usage is ``guard(...)`` then ``solve()`` on a fresh solver, where
+    the KSP the guard must attach to does not exist yet."""
+    solver, _ = _stokes("cold", lambda v: 1.0)
+    solver.guard(wall_per_step=1.0e-6)
+    try:
+        solver.solve()
+    finally:
+        solver.unguard()
+    assert solver.solve_report.deadline_expired
+    assert not solver.solve_report.converged
+
+
+def test_unguard_leaves_the_solver_exactly_as_it_was(guarded):
+    """The deadline must come off completely — otherwise a driver that guards one probe
+    poisons every later solve on the same solver, in cost if not in answer."""
+    solver, _ = guarded
+    solver.unguard()
+    solver.solve(zero_init_guess=True)
+    never_guarded = solver.solve_report
+
     solver.guard(wall_per_step=1.0e-6)
     solver.solve(zero_init_guess=True)
     assert solver.solve_report.deadline_expired
 
     solver.unguard()
     solver.solve(zero_init_guess=True)
-    report = solver.solve_report
-    assert report.converged
-    assert not report.deadline_expired
+    after = solver.solve_report
+    assert after.converged
+    assert not after.deadline_expired
+    assert after.nl_its == never_guarded.nl_its
+    assert after.ksp_its == never_guarded.ksp_its
+    assert after.sub["velocity"].its == never_guarded.sub["velocity"].its
 
 
-@pytest.mark.level_1
-@pytest.mark.tier_a
-def test_guard_rejects_a_meaningless_budget(stokes_box):
-    solver, _ = stokes_box
+def test_guard_rejects_a_meaningless_budget(guarded):
+    solver, _ = guarded
     for bad in (0.0, -1.0):
         with pytest.raises(ValueError, match="positive"):
             solver.guard(wall_per_step=bad)
 
 
-@pytest.mark.level_1
-@pytest.mark.tier_a
-def test_guard_refuses_the_rotated_free_slip_path(stokes_box):
+def test_guard_refuses_the_rotated_free_slip_path_whichever_order():
     """Rotated free-slip runs its own Krylov loop outside ``self.snes``, so the deadline
-    cannot reach it. Refusing is the point: a guard that attaches and never fires looks
-    like protection and is not."""
-    solver, _ = stokes_box
+    cannot reach it. Refusing is the point — a guard that attaches and never fires looks
+    like protection and is not.
+
+    Both orders matter: arming the guard first and adding the BC afterwards used to slip
+    through the arm-time check and produce exactly that silent no-op.
+    """
+    solver, _ = _stokes("rot1", lambda v: 1.0)
     solver.add_rotated_freeslip_bc(0, "Top")
-    try:
-        with pytest.raises(NotImplementedError, match="rotated free-slip"):
-            solver.guard(wall_per_step=10.0)
-    finally:
-        solver._rotated_freeslip_bcs.clear()
+    with pytest.raises(NotImplementedError, match="rotated free-slip"):
+        solver.guard(wall_per_step=10.0)
+
+    other, _ = _stokes("rot2", lambda v: 1.0)
+    other.guard(wall_per_step=10.0)
+    other.add_rotated_freeslip_bc(0, "Top")
+    with pytest.raises(NotImplementedError, match="rotated free-slip"):
+        other.solve()

--- a/tests/test_0203_solver_wallclock_guard.py
+++ b/tests/test_0203_solver_wallclock_guard.py
@@ -1,0 +1,203 @@
+"""Sub-solve work gauge and the wall-clock guard (``systems/solver_health.py``).
+
+These tests are written against the two ways the feature could be fake:
+
+* the gauge could be the outer Krylov count under a new name, which would be useless —
+  so it is asserted to see work the outer count cannot;
+* the guard could fail to stop a grind, or could stop a healthy solve. Both are checked,
+  and the healthy-solve check compares the *answer* against an unguarded solve, because
+  the guard replaces PETSc's convergence tests and a sloppy replacement would quietly
+  move where the solve stops.
+
+The test that has to prove the guard bites *inside* the fieldsplit blocks — the claim
+the whole design rests on — drives a fake clock rather than a wall-clock budget. A
+budget in seconds cannot express "expire during the block solves" on an unknown machine:
+too large and the solve finishes, too small and it expires at the outer iteration
+before the blocks are ever reached.
+"""
+
+import numpy as np
+import pytest
+import sympy
+
+import underworld3 as uw
+from underworld3.systems import solver_health
+
+
+class _TickingClock:
+    """A clock that advances one tick per reading.
+
+    Makes the deadline expire after a known number of convergence-test checks instead
+    of after an interval of real time, so the test asserts the same thing on a fast
+    machine and a slow one.
+    """
+
+    def __init__(self, tick=1.0):
+        self.tick = tick
+        self.now = 0.0
+
+    def monotonic(self):
+        self.now += self.tick
+        return self.now
+
+
+@pytest.fixture(scope="module")
+def stokes_box():
+    """A small, well-conditioned Stokes solve.
+
+    Deliberately easy: these tests are about the instrumentation, and a genuinely hard
+    solve would make them slow and their timing fragile.
+    """
+    mesh = uw.meshing.UnstructuredSimplexBox(
+        minCoords=(0.0, 0.0), maxCoords=(1.0, 1.0), cellSize=0.1, qdegree=3
+    )
+    v = uw.discretisation.MeshVariable("Ug", mesh, mesh.dim, degree=2)
+    p = uw.discretisation.MeshVariable("Pg", mesh, 1, degree=1, continuous=True)
+
+    solver = uw.systems.Stokes(mesh, velocityField=v, pressureField=p)
+    solver.constitutive_model = uw.constitutive_models.ViscousFlowModel
+    solver.constitutive_model.Parameters.shear_viscosity_0 = 1.0
+    x, y = mesh.X
+    solver.bodyforce = sympy.Matrix(
+        [0.0, -sympy.cos(sympy.pi * x) * sympy.sin(sympy.pi * y)]
+    )
+    for wall in ("Top", "Bottom", "Left", "Right"):
+        solver.add_dirichlet_bc((0.0, 0.0), wall)
+    # Guard exits are reports, not errors — a driver reads them and steps back.
+    solver.petsc_options["snes_error_if_not_converged"] = "false"
+
+    solver.solve()          # first solve: pays the JIT, and attaches the instrumentation
+    return solver, v
+
+
+@pytest.mark.level_1
+@pytest.mark.tier_a
+def test_sub_solve_gauge_sees_work_the_outer_count_cannot(stokes_box):
+    """``ksp_its`` counts outer Krylov iterations, which Eisenstat--Walker collapses to
+    about one per Newton step. The multigrid cycles are in the velocity block."""
+    solver, _ = stokes_box
+    solver.solve(zero_init_guess=True)
+    report = solver.solve_report
+
+    assert report.converged
+    assert "velocity" in report.sub, "no velocity block work recorded"
+    assert "pressure" in report.sub, "no pressure block work recorded"
+    # The point of the gauge: the outer count is not the cost. Two orders of magnitude
+    # apart in practice; one order of magnitude is a safe floor for the assertion.
+    assert report.sub["velocity"].its > 10 * report.ksp_its
+    assert report.sub["velocity"].applications >= 1
+    # Attached before this solve began, so the count is exact rather than a lower bound.
+    assert report.sub["velocity"].complete
+
+
+@pytest.mark.level_1
+@pytest.mark.tier_a
+def test_generous_budget_leaves_a_healthy_solve_alone(stokes_box):
+    """The guard replaces PETSc's convergence tests. If the replacement were wrong the
+    solve would stop somewhere else — so compare the answer, not just the reason."""
+    solver, v = stokes_box
+    solver.unguard()
+    solver.solve(zero_init_guess=True)
+    unguarded = np.asarray(v.array).copy()
+    assert solver.solve_report.converged
+
+    solver.guard(wall_per_step=600.0)
+    solver.solve(zero_init_guess=True)
+    guarded_report = solver.solve_report
+    solver.unguard()
+
+    assert guarded_report.converged
+    assert not guarded_report.deadline_expired
+    drift = np.abs(np.asarray(v.array) - unguarded).max()
+    assert drift < 1.0e-6, f"guarded answer differs from unguarded by {drift:.3e}"
+
+
+@pytest.mark.level_1
+@pytest.mark.tier_a
+def test_exhausted_budget_stops_the_solve_and_reports_it(stokes_box):
+    """A budget too small to finish must stop the solve, and must not claim success.
+
+    Reporting matters as much as stopping: a solve cut short that still said
+    ``converged`` would silently corrupt a continuation driver, which reads exactly
+    this to decide whether a parameter station is reachable.
+    """
+    solver, _ = stokes_box
+    solver.guard(wall_per_step=1.0e-6)
+    solver.solve(zero_init_guess=True)
+    report = solver.solve_report
+    solver.unguard()
+
+    assert report.deadline_expired, "the wall-clock deadline never fired"
+    assert not report.converged, "a solve cut short by the deadline reported success"
+    assert report.reason_str == "DIVERGED_LINEAR_SOLVE"
+
+
+@pytest.mark.level_1
+@pytest.mark.tier_a
+def test_deadline_bites_inside_the_fieldsplit_blocks(stokes_box, monkeypatch):
+    """The claim the design rests on: the deadline is honoured *below* the outer Krylov
+    iteration, where an iteration cap has nothing to count.
+
+    The clock is set to expire after roughly fifty convergence-test checks. The outer
+    test contributes only a couple of those, so expiry necessarily happens inside the
+    block solves — and the assertions confirm it: the outer iteration never completed
+    (``ksp_its == 0``, so no cap on it could have fired) while the velocity block had
+    already run many multigrid cycles.
+    """
+    solver, _ = stokes_box
+    clock = _TickingClock(tick=1.0)
+    monkeypatch.setattr(solver_health, "time", clock)
+
+    solver.guard(wall_per_step=50.0)          # fifty ticks == fifty checks
+    solver.solve(zero_init_guess=True)
+    report = solver.solve_report
+    solver.unguard()
+
+    assert report.deadline_expired
+    assert not report.converged
+    assert report.ksp_its == 0, "the outer Krylov iteration completed; nothing to prove"
+    assert report.sub["velocity"].its >= 10, (
+        "the velocity block did no real work before the deadline fired, so this does "
+        "not show the deadline reaching inside the blocks"
+    )
+
+
+@pytest.mark.level_1
+@pytest.mark.tier_a
+def test_unguard_restores_normal_convergence(stokes_box):
+    """The deadline must be removable — otherwise a driver that guards one probe would
+    poison every later solve on the same solver."""
+    solver, _ = stokes_box
+    solver.guard(wall_per_step=1.0e-6)
+    solver.solve(zero_init_guess=True)
+    assert solver.solve_report.deadline_expired
+
+    solver.unguard()
+    solver.solve(zero_init_guess=True)
+    report = solver.solve_report
+    assert report.converged
+    assert not report.deadline_expired
+
+
+@pytest.mark.level_1
+@pytest.mark.tier_a
+def test_guard_rejects_a_meaningless_budget(stokes_box):
+    solver, _ = stokes_box
+    for bad in (0.0, -1.0):
+        with pytest.raises(ValueError, match="positive"):
+            solver.guard(wall_per_step=bad)
+
+
+@pytest.mark.level_1
+@pytest.mark.tier_a
+def test_guard_refuses_the_rotated_free_slip_path(stokes_box):
+    """Rotated free-slip runs its own Krylov loop outside ``self.snes``, so the deadline
+    cannot reach it. Refusing is the point: a guard that attaches and never fires looks
+    like protection and is not."""
+    solver, _ = stokes_box
+    solver.add_rotated_freeslip_bc(0, "Top")
+    try:
+        with pytest.raises(NotImplementedError, match="rotated free-slip"):
+            solver.guard(wall_per_step=10.0)
+    finally:
+        solver._rotated_freeslip_bcs.clear()


### PR DESCRIPTION
## The problem

A viscoplastic Stokes solve near its conditioning floor does not fail. It *grinds* — for
hours, inside a single Newton step, with no error and no sign of stopping. Any study that
sweeps a parameter plane hits this immediately, because the interesting cells are exactly
the unreachable ones.

Two obvious defences were tried first and both were measured to not work:

**An iteration cap does not bound wall time.** The grind happens *within one outer Krylov
iteration*, so the counter any cap watches never advances. Measured: 3814 s inside one
outer iteration. Nor can caps be tuned around it — tight caps misclassify in both
directions (a continuation march settles at its starting parameter and reports success;
a step that would have converged in fifteen iterations is called unreachable at ten),
loose caps classify correctly and run past ten minutes a station. The number of iterations
a feasible step needs is not knowable in advance, which is exactly why a *time* budget has
to be an independent guard.

**A Python timer does not fire.** `signal.alarm` schedules a handler, but Python runs
handlers only between bytecodes, and during the grind control is inside PETSc's C code the
whole time. Measured: a 90 s alarm still unfired at 10 minutes.

So the only code that runs during a grind is PETSc's own, and that is where the deadline
has to live.

## What this adds

```python
stokes.guard(wall_per_step=150.0)
stokes.solve()
if stokes.solve_report.deadline_expired:
    ...                # too hard at these parameters — back off a continuation step
stokes.unguard()

cycles = stokes.solve_report.sub["velocity"].its      # the honest work axis
```

A guard exit is a report, not an exception: the current iterate stays in the fields so a
continuation driver can revert or retry from it.

**The clock starts at the beginning of each solve and restarts at each outer KSP
iteration 0**, which is once per Newton step — so no SNES hook is needed. Starting it at
the beginning of the solve is not cosmetic: PETSc defaults GMRES to *left* preconditioning,
and `KSPInitialResidual` applies the preconditioner before iteration 0, so a clock armed
only at iteration 0 leaves one full velocity solve plus one pressure solve outside the
budget on every solve.

**The deadline is checked inside the fieldsplit sub-KSP tests**, which is where the
granularity is. In a representative solve the outer KSP performed 1 iteration while the
velocity block performed 285; only the sub-KSP tests can interrupt anything finer than a
whole Newton step.

**The guard runs in front of PETSc's own test, not instead of it.**
`KSP.addConvergenceTest(..., prepend=True)` composes with whatever native test the KSP is
configured with, so returning `ITERATING` hands the decision straight back to
`KSPConvergedDefault` with its options-configured context intact. Verified: a prepended
always-`ITERATING` test gives identical iteration count and reason to an uninstrumented
solve. That is also what makes `unguard()` exact — PETSc cannot remove an added test, so
it stays installed and goes inert, which *is* the uninstrumented behaviour.

## The part that is easy to get wrong

PETSc's `KSPCheckSolve` **deliberately exempts `KSP_DIVERGED_ITS`** from marking the
preconditioner failed — truncating an inner solve at its iteration cap is normal
behaviour, not an error. A guard that returns `DIVERGED_MAX_IT` from a sub-KSP therefore
does nothing at all. Measured: the outer solve absorbed 36 truncated velocity solves and
reported CONVERGED. The earlier prototype in `~/+Simulations/spiegelman_hardcase` used
exactly that reason, so its wall-time cap was weaker than it appeared.

`DIVERGED_BREAKDOWN` marks the sub-preconditioner failed, which surfaces as
`DIVERGED_PC_FAILED` at the outer KSP and `DIVERGED_LINEAR_SOLVE` at the SNES.

## Parallel

Wall clocks are not synchronised across ranks, and a PETSc convergence test that returns
different verdicts on different ranks leaves the ranks on different code paths — the next
collective deadlocks. The expiry decision is therefore reduced over the solver's
communicator. That is well posed because Krylov iterations are globally synchronised, so
every rank reaches the same check the same number of times.

`ptest_0203` does not take this on trust. It provokes the hazard with deliberately skewed
per-rank clocks (rank 0 fast, the others effectively frozen), so the ranks *would* reach
opposite verdicts if each decided alone. It passes at np=2 and np=4 — and **deadlocks when
the reduction is removed**, confirmed against a 90 s `mpirun --timeout`.

Extra reductions are paid only when a guard is armed. An unarmed solver installs no
convergence tests at all.

## The work axis (needed before any of this means anything)

`solve_report.ksp_its` counts *outer* Krylov iterations, which Eisenstat–Walker collapses
to about one per Newton step. It is not a measure of cost, and using it as one understates
a Stokes solve by two orders of magnitude — measured, outer 1 against 285 multigrid cycles
in the velocity block.

`solve_report.sub` records iterations and applications per fieldsplit block. For the
velocity block under `pc_type=mg` that count *is* the multigrid cycle count. It is
collected by monitors, which observe and never decide, so it cannot change a solve.

Cost of leaving it always on: 624 monitor callbacks in a 280 ms solve, with no measurable
change in wall time (medians 282 ms instrumented against 284 ms not, run alternately;
run-to-run noise exceeds the difference).

## Limitations, made honest rather than hidden

- **First solve's counts.** The fieldsplit blocks do not exist until `PCSetUp`, which runs
  part-way through the first `KSPSolve`. So that solve's sub-counts are a lower bound
  (measured: about half, because left-preconditioned GMRES applies the preconditioner once
  in `KSPInitialResidual` before the guard can attach). `SubSolveReport.complete` is
  `False` to say so. The *deadline* is unaffected — the clock runs from the start of the
  solve. A driver wanting exact work should do one cheap solve before arming, which it
  usually does anyway to pay for the JIT compile.
- **Rotated free-slip.** `guard()` raises there, matching `estimate_difficulty()`: that
  path runs its own Krylov loop outside `self.snes`, so a guard would attach and never
  fire — protection in appearance only.
- **`preonly` and `richardson` outer KSPs** are skipped entirely: both change what they
  *do* when a monitor is attached (they are gated on `ksp->numbermonitors` in PETSc), and
  neither iterates, so instrumenting them would be all cost and no information.

## Review

Two independent adversarial reviewers were given this branch and told to break it. They
found **four major defects in the new code** — including a deadline that was disabled for
the first preconditioner application of *every* solve, and instrumentation that re-opened
the memory leak `BUGFIX(#157)` closed — plus a test suite that one of them demonstrated
would pass with several parts of the feature broken. All are fixed; the full report is in
`docs/reviews/2026-07/solver-wall-clock-guard-adversarial-review.md` and reproduced as a
comment on this PR.

One reviewer finding is recorded as *not sustained*: they argued a retry or continuation
stage would be handed a fresh budget after an expiry. Measurement says PETSc prevents this
itself (34 clock ticks against 32 with the expiry latch removed), so the latch is kept as
belt-and-braces and no test claims to prove it.

## Testing

- `tests/test_0203_solver_wallclock_guard.py` — 10 tests, tier_b. Each verified to fail
  without its feature by neutering the implementation: the deadline, the counting, and the
  per-Newton-step re-arming each break a distinct set.
- Cost parity, not just answer parity, is asserted between a guarded and an unguarded
  solve — a change confined to the sub-blocks moves the cost and not the answer.
- The per-step meaning of `wall_per_step` is exercised on a *nonlinear* model, because one
  linear solve cannot distinguish per-step from per-solve.
- The test that has to prove the deadline bites *inside* the blocks drives an injected
  ticking clock rather than a seconds budget. A budget in seconds cannot express "expire
  during the block solves" on an unknown machine — too large and the solve finishes, too
  small and it expires at the outer iteration before the blocks are reached. Both
  real-budget versions were fixture-dependent and flaky before being replaced.
- `tests/parallel/ptest_0203_wallclock_guard_parallel.py` — np=2 and np=4, registered in
  `tests/parallel/mpi_runner.sh`. It hangs rather than fails if the reduction is dropped,
  so it must be run under a timeout.
- `level_1` across **all** tiers: 966 passed. (Tier A alone is not a sufficient gate for a
  change that touches solver behaviour — that lesson came from this session.)

## Design note

`docs/developer/design/solver-wall-clock-guard.md`.

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)
