### PR TITLE
hotfix: bump petsc 3.21.5 → 3.24; add v3.1.0 Binder badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ The full documentation including tutorials, API reference, and developer guides 
 Try Underworld3 in your browser — no installation required:
 
  - [![Launch v0.99 on Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/underworldcode/uw3-binder-launcher/v0.99?urlpath=git-pull%3Frepo%3Dhttps%25253A%25252F%25252Fgithub.com%25252Funderworldcode%25252Funderworld3%26branch%3Dmain%26urlpath%3Dlab%25252Ftree%25252Funderworld3) **v0.99** — JOSS publication release (stable)
- - [![Launch v3.0.0 on Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/underworldcode/uw3-binder-launcher/v3.0.0?urlpath=git-pull%3Frepo%3Dhttps%25253A%25252F%25252Fgithub.com%25252Funderworldcode%25252Funderworld3%26branch%3Dmain%26urlpath%3Dlab%25252Ftree%25252Funderworld3) **v3.0.0** — current release
+ - [![Launch v3.0.0 on Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/underworldcode/uw3-binder-launcher/v3.0.0?urlpath=git-pull%3Frepo%3Dhttps%25253A%25252F%25252Fgithub.com%25252Funderworldcode%25252Funderworld3%26branch%3Dmain%26urlpath%3Dlab%25252Ftree%25252Funderworld3) **v3.0.0** — previous release
+ - [![Launch v3.1.0 on Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/underworldcode/uw3-binder-launcher/v3.1.0?urlpath=git-pull%3Frepo%3Dhttps%25253A%25252F%25252Fgithub.com%25252Funderworldcode%25252Funderworld3%26branch%3Dmain%26urlpath%3Dlab%25252Ftree%25252Funderworld3) **v3.1.0** — current release
  - [![Launch development on Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/underworldcode/uw3-binder-launcher/development?urlpath=git-pull%3Frepo%3Dhttps%25253A%25252F%25252Fgithub.com%25252Funderworldcode%25252Funderworld3%26branch%3Ddevelopment%26urlpath%3Dlab%25252Ftree%25252Funderworld3) **development** — bleeding edge
 
 Use `scripts/binder_wizard.py` to generate launch URLs for your own repositories using the Underworld3 environment.

--- a/environment.yaml
+++ b/environment.yaml
@@ -5,8 +5,8 @@ dependencies:
   - python <= 3.11
   - compilers
   - mpich
-  - petsc=3.21.5
-  - petsc4py=3.21.5
+  - petsc=3.24
+  - petsc4py=3.24
   - cython=3.*
   - mpmath<=1.3
   - mesalib


### PR DESCRIPTION
- **environment.yaml**: bump `petsc`/`petsc4py` `3.21.5` → `3.24` to fix the command-line container build (`DMCopyFields` signature mismatch). Same fix already on `development` via PR #356; `pixi.lock` already uses 3.24.
- **README.md**: add v3.1.0 Binder badge; mark v3.0.0 as previous release.

Build tested on fork via `workflow_dispatch` (run 30358340515) — compilation succeeded, only push failed due to fork permissions.

---
Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)