### PR TITLE
Update solver template DDT imports

### DIFF
--- a/src/underworld3/systems/solver_template.py
+++ b/src/underworld3/systems/solver_template.py
@@ -9,7 +9,7 @@ import sympy
 from typing import Optional, Union, Callable
 import underworld3 as uw
 from underworld3.systems import SNES_Scalar, SNES_Vector, SNES_Stokes_SaddlePt
-from underworld3.systems.ddt import SemiLagrangian_DDt, Lagrangian_DDt, Eulerian_DDt
+from underworld3.systems.ddt import SemiLagrangian, Lagrangian, Eulerian
 from underworld3 import timing
 from underworld3.systems.solvers import expression
 
@@ -89,8 +89,8 @@ class SNES_MyEquation(SNES_Scalar):
         u_Field: Optional[uw.discretisation.MeshVariable] = None,
         degree: int = 2,
         verbose: bool = False,
-        DuDt: Optional[Union[SemiLagrangian_DDt, Lagrangian_DDt, Eulerian_DDt]] = None,
-        DFDt: Optional[Union[SemiLagrangian_DDt, Lagrangian_DDt, Eulerian_DDt]] = None,
+        DuDt: Optional[Union[SemiLagrangian, Lagrangian, Eulerian]] = None,
+        DFDt: Optional[Union[SemiLagrangian, Lagrangian, Eulerian]] = None,
     ):
         """
         Initialize the solver.


### PR DESCRIPTION
This PR updates src/underworld3/systems/solver_template.py to use the current DDT class names exported by underworld3.systems.ddt.

The old names SemiLagrangian_DDt, Lagrangian_DDt, and Eulerian_DDt are no longer exported. The current public names are SemiLagrangian, Lagrangian, and Eulerian.

This updates the import and matching type hints only.

Validation:

- pixi run python src/underworld3/systems/solver_template.py