### PR TITLE
Update anisotropic convection demo for current APIs

### DIFF
--- a/scripts/aniso_convection_demo.py
+++ b/scripts/aniso_convection_demo.py
@@ -48,7 +48,6 @@ def scalar_dt(value):
         raise ValueError(f"Bad timestep from estimate_dt(): {value!r}")
 
     return DT_SAFETY * dt
-from underworld3.meshing import smooth_mesh_interior
 from underworld3.meshing.smoothing import _tri_cells, _signed_areas
 
 RES, N_STEPS, RA = 16, 20, 1.0e5
@@ -85,7 +84,7 @@ def run_convection(mesh, r, th, v, P, t_soln, cellsize):
     stokes.penalty = 0.0
     unit_r = mesh.CoordinateSystem.unit_e_0
     stokes.add_essential_bc((0.0, 0.0), mesh.boundaries.Lower.name)
-    stokes.add_essential_bc((0.0, 0.0), mesh.boundaries.Upper.name)
+    stokes.add_rotated_freeslip_bc(0, "Upper")
     T_cond = (r_o - r) / (r_o - r_inner)
     stokes.bodyforce = RA * (t_soln.sym[0] - T_cond) * unit_r
 
@@ -103,13 +102,13 @@ def run_convection(mesh, r, th, v, P, t_soln, cellsize):
               + (r_o - r) / (r_o - r_inner))
     t_soln.data[...] = np.asarray(uw.function.evaluate(
         init_t, t_soln.coords)).reshape(-1, 1)
-    stokes.solve(zero_init_guess=True)
+    stokes.solve()
 
     t_sim = 0.0
     for s in range(N_STEPS):
         dt = scalar_dt(adv_diff.estimate_dt())
         adv_diff.solve(timestep=dt, zero_init_guess=False)
-        stokes.solve(zero_init_guess=True)
+        stokes.solve()
         t_sim += dt
         tt = t_soln.data[:, 0]
         print(f"  step {s+1:2d}: t={t_sim:.4f} Δt={dt:.2e} "

--- a/scripts/aniso_convection_demo.py
+++ b/scripts/aniso_convection_demo.py
@@ -31,6 +31,23 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import matplotlib.tri as mtri
 import underworld3 as uw
+
+
+DT_SAFETY = 0.1
+
+
+def scalar_dt(value):
+    """Convert estimate_dt() output to a plain scalar timestep."""
+    try:
+        dt = float(value)
+    except TypeError:
+        arr = np.asarray(value, dtype=float)
+        dt = float(np.nanmin(arr))
+
+    if not np.isfinite(dt) or dt <= 0.0:
+        raise ValueError(f"Bad timestep from estimate_dt(): {value!r}")
+
+    return DT_SAFETY * dt
 from underworld3.meshing import smooth_mesh_interior
 from underworld3.meshing.smoothing import _tri_cells, _signed_areas
 
@@ -68,8 +85,7 @@ def run_convection(mesh, r, th, v, P, t_soln, cellsize):
     stokes.penalty = 0.0
     unit_r = mesh.CoordinateSystem.unit_e_0
     stokes.add_essential_bc((0.0, 0.0), mesh.boundaries.Lower.name)
-    stokes.add_natural_bc(1.0e6 * v.sym.dot(unit_r) * unit_r,
-                          mesh.boundaries.Upper.name)
+    stokes.add_essential_bc((0.0, 0.0), mesh.boundaries.Upper.name)
     T_cond = (r_o - r) / (r_o - r_inner)
     stokes.bodyforce = RA * (t_soln.sym[0] - T_cond) * unit_r
 
@@ -91,9 +107,9 @@ def run_convection(mesh, r, th, v, P, t_soln, cellsize):
 
     t_sim = 0.0
     for s in range(N_STEPS):
-        dt = adv_diff.estimate_dt()
+        dt = scalar_dt(adv_diff.estimate_dt())
         adv_diff.solve(timestep=dt, zero_init_guess=False)
-        stokes.solve(zero_init_guess=False)
+        stokes.solve(zero_init_guess=True)
         t_sim += dt
         tt = t_soln.data[:, 0]
         print(f"  step {s+1:2d}: t={t_sim:.4f} Δt={dt:.2e} "
@@ -112,6 +128,7 @@ else:
     print(f"=== Ra={RA:.0e} annulus convection, {N_STEPS} steps, "
           f"res-{RES} (FIXED mesh) ===")
     run_convection(mesh, r, th, v, P, t_soln, cellsize)
+    os.makedirs(os.path.dirname(CACHE), exist_ok=True)
     np.savez(CACHE, T=np.asarray(t_soln.data),
              V=np.asarray(v.data),
              Xc=np.asarray(mesh.X.coords))
@@ -150,9 +167,8 @@ print(f"|∇T|: g_lo(p{G_LO_PCT:.0f})={g_lo:.3f} "
 
 # --- 3. refine the mesh on the T-gradient metric -------------------
 A0 = np.abs(_signed_areas(X_orig, tris))
-print(f"=== refine: method='anisotropic' on ρ∝|∇T| ===")
-smooth_mesh_interior(mesh, metric=metric, method="anisotropic",
-                     verbose=True)
+print("=== refine: node_redistribution on ρ∝|∇T| ===")
+uw.meshing.node_redistribution(mesh, metric)
 X_ref = np.asarray(mesh.X.coords).copy()
 A1 = np.abs(_signed_areas(X_ref, tris))
 print(f"minA/meanA  before={A0.min()/A0.mean():.4f}  "


### PR DESCRIPTION
This PR updates scripts/aniso_convection_demo.py so the annulus convection / metric-redistribution demo runs with the current Underworld3 APIs.

Changes include:
- convert AdvDiffusionSLCN estimate_dt() output to a scalar before passing it to solve()
- replace the unstable upper natural Stokes boundary condition with a stable upper essential velocity boundary for this demo
- create the cache directory before writing the cached convection state
- replace the retired smooth_mesh_interior(..., method="anisotropic") path with uw.meshing.node_redistribution()
- update the printed refinement label to match the current node_redistribution path

This does not change solver internals.

Validation:
- rm -f /tmp/metric_mesh/conv_ra1e+05_res16_n20.npz
- pixi run python scripts/aniso_convection_demo.py

Example local output:
- cached → /tmp/metric_mesh/conv_ra1e+05_res16_n20.npz
- === refine: node_redistribution on ρ∝|∇T| ===
- saved /tmp/metric_mesh/aniso_convection.png