### PR TITLE
Fix RegionalSphericalBox bounds helper

### DIFF
--- a/src/underworld3/meshing/geographic.py
+++ b/src/underworld3/meshing/geographic.py
@@ -359,6 +359,22 @@ def RegionalSphericalBox(
 
         return
 
+    def sphere_return_coords_to_bounds(coords):
+        Rsq = coords[:, 0] ** 2 + coords[:, 1] ** 2 + coords[:, 2] ** 2
+
+        outside = Rsq > radiusOuter**2
+        inside = Rsq < radiusInner**2
+
+        coords[outside, :] *= (
+            0.99 * radiusOuter / np.sqrt(Rsq[outside].reshape(-1, 1))
+        )
+        coords[inside, :] *= (
+            1.01 * radiusInner / np.sqrt(Rsq[inside].reshape(-1, 1))
+        )
+
+        return coords
+
+
     new_mesh = Mesh(
         uw_filename,
         degree=degree,


### PR DESCRIPTION
This PR fixes a NameError in RegionalSphericalBox().

RegionalSphericalBox() passes sphere_return_coords_to_bounds to Mesh(), but that helper was not defined in src/underworld3/meshing/geographic.py. This adds the local bounds helper used to keep coordinates inside the spherical shell bounds.

This does not change solver internals.

Validation:
- python -m py_compile src/underworld3/meshing/geographic.py
- pixi run python docs/examples/tutorials/geographic/Ex_Spherical_Meshes.py

The example now completes the regional spherical mesh section and gravity check without the previous NameError.