### PR TITLE
CI: pin UCX transports — retire the MANA-NIC MPI_Init flake (#461)

### DIFF
--- a/.github/workflows/build_uw3_and_test.yaml
+++ b/.github/workflows/build_uw3_and_test.yaml
@@ -19,6 +19,15 @@ on:
 
   workflow_dispatch:
 
+env:
+  # Some Azure runners carry a MANA NIC whose InfiniBand verbs device UCX
+  # advertises but cannot open: uct_iface_open(ud_verbs/mana_0) fails inside
+  # MPI_Init, so `import underworld3` dies before any UW3 code runs (issues
+  # #461/#528 — four hits in the first week of 2026-08, each costing a manual
+  # re-roll). A single-node CI runner needs only shared memory and TCP, so pin
+  # the UCX transports and retire the whole flake class.
+  UCX_TLS: tcp,sm,self
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes the runner-lottery flake tracked in #461 (dup #528): some Azure runners carry a MANA NIC whose InfiniBand verbs device UCX advertises but cannot open — `uct_iface_open(ud_verbs/mana_0)` fails inside MPI_Init and `import underworld3` dies before any UW3 code runs. Four hits in the first week of August across #466/#526/#527, each burning a manual re-run.

One workflow-level env: `UCX_TLS: tcp,sm,self`. A single-node CI runner needs only shared memory and TCP; the pin covers the import smoke test (where the flake fires) and every pytest batch. Local and HPC environments are untouched — this is CI-only, deliberately not in pixi.toml activation, so real InfiniBand fabrics (e.g. the Gadi work in #516) keep their transports.

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)