### PR TITLE
Quickfix batch: clone() arguments (#498), print_table keywords (#499), and 56 orphaned test files rejoined to CI (#504)

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -53,10 +53,12 @@ if [ $PARALLEL_ONLY -eq 0 ]; then
   echo "Running serial test suite..."
   echo ""
 
-  # Run simple tests (0000-0199: basic functionality, imports, simple operations)
+  # Run simple tests (0000-0299: basic functionality, imports, simple operations)
   $PYTEST tests/test_00[0-4]*py || status=1
   #$PYTEST tests/test_0050*py    || status=1 # disable auditor test for now
+  $PYTEST tests/test_005[1-9]*py tests/test_006[0-1]*py || status=1
   $PYTEST tests/test_01*py || status=1
+  $PYTEST tests/test_02*py || status=1
 
   # Intermediate tests (0500-0799: data structures, transformations, enhanced interfaces)
   # NOTE: Temporarily disabling test_06*py regression tests (potentially problematic)
@@ -70,11 +72,26 @@ if [ $PARALLEL_ONLY -eq 0 ]; then
   $PYTEST tests/test_100[0-9]*py || status=1
 
   # Solver / system tests (advanced solver problems)
-  $PYTEST tests/test_1010*py tests/test_1011*py tests/test_1050*py || status=1
+  # test_101* / test_102* include the rotated free-slip suite (test_1018,
+  # issue #504) and the MG / boundary-flux suites, which previously matched
+  # no batch glob and never ran in CI.
+  $PYTEST tests/test_101*py tests/test_102*py || status=1
+  $PYTEST tests/test_105*py || status=1
+  # NOT yet batched (issue #504 audit): test_106*py and test_107*py contain
+  # level_2/level_3 + slow + tier_b/tier_c suites (e.g. test_1064) and need
+  # a triage/deselect decision before being wired into CI.
 
   # Diffusion / Advection tests
   $PYTEST tests/test_1100*py || status=1
-  $PYTEST tests/test_1110*py # Annulus version || status=1
+  $PYTEST tests/test_1110*py tests/test_1120*py || status=1  # Annulus + vector SL
+  $PYTEST tests/test_1450*py || status=1
+
+  # Named (un-numbered) test files - JIT, docstrings, projections
+  $PYTEST tests/test_docstring_utils.py tests/test_jit_cache.py \
+          tests/test_jit_deterministic_ordering.py \
+          tests/test_multicomponent_projection.py \
+          tests/test_snes_vector_asymmetric_jacobian.py \
+          tests/test_symbol_disambiguation_prototype.py || status=1
 else
   echo "Skipping serial tests (--parallel-only specified)"
   echo ""

--- a/src/underworld3/discretisation/enhanced_variables.py
+++ b/src/underworld3/discretisation/enhanced_variables.py
@@ -463,9 +463,34 @@ class EnhancedMeshVariable(DimensionalityMixin, MathematicalMixin):
 
     # === ADDITIONAL DELEGATED METHODS ===
 
-    def clone(self):
-        """Clone the variable."""
-        return self._base_var.clone()
+    def clone(self, name, varsymbol):
+        """Create a copy of this variable with a new name and symbol.
+
+        Mirrors ``MeshVariable.clone(name, varsymbol)``: the new variable
+        shares the mesh, shape, type, degree and continuity of this one,
+        but has its own (zero-initialised) data.
+
+        Parameters
+        ----------
+        name : str
+            Name for the new variable.
+        varsymbol : str
+            LaTeX symbol for the new variable.
+
+        Returns
+        -------
+        EnhancedMeshVariable
+            New variable with copied structure but independent data.
+        """
+        return type(self)(
+            varname=name,
+            mesh=self._base_var.mesh,
+            num_components=self._base_var.shape,
+            vtype=self._base_var.vtype,
+            degree=self._base_var.degree,
+            continuous=self._base_var.continuous,
+            varsymbol=varsymbol,
+        )
 
     def max(self):
         """Maximum value of the variable."""

--- a/src/underworld3/timing.py
+++ b/src/underworld3/timing.py
@@ -135,7 +135,13 @@ def reset():
         pass
 
 
-def print_table(filename=None, format="auto"):
+def print_table(
+    filename=None,
+    format="auto",
+    display_fraction=None,
+    group_by=None,
+    output_file=None,
+):
     """
     Display comprehensive performance results.
 
@@ -157,6 +163,19 @@ def print_table(filename=None, format="auto"):
         - ``"auto"`` : Detect from filename (default)
         - ``"ascii"`` : Human-readable table
         - ``"csv"`` : Comma-separated values
+    display_fraction : float, optional
+        Deprecated (legacy timing module). The PETSc log table is not
+        cullable, so the value is accepted for compatibility but has no
+        effect. A ``FutureWarning`` is emitted.
+    group_by : str, optional
+        Deprecated (legacy timing module: ``'line'`` / ``'routine'`` /
+        ``'line_routine'``). PETSc logging groups by event, so the value
+        is accepted for compatibility but has no effect. A
+        ``FutureWarning`` is emitted.
+    output_file : str, optional
+        Deprecated alias for ``filename`` — the old behaviour (write the
+        table to this file) is preserved. Passing both ``filename`` and
+        ``output_file`` is an error.
 
     Example
     -------
@@ -181,6 +200,44 @@ def print_table(filename=None, format="auto"):
     The behaviour is in PETSc, not Underworld; choosing CSV at scale is
     the recommended workaround.
     """
+    import warnings
+
+    # Legacy keywords from the pre-PETSc-log timing module (issue #499).
+    # output_file is an alias for filename (behaviour preserved); the
+    # others cannot be honoured by the PETSc log backend, so they are
+    # accepted with a visible warning rather than a TypeError.
+    if output_file is not None:
+        if filename is not None:
+            raise TypeError(
+                "print_table() received both 'filename' and its deprecated "
+                "alias 'output_file'; pass only 'filename'."
+            )
+        warnings.warn(
+            "print_table(output_file=...) is deprecated; use "
+            "print_table(filename=...) instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        filename = output_file
+
+    if display_fraction is not None:
+        warnings.warn(
+            "print_table(display_fraction=...) is deprecated and has no "
+            "effect: the PETSc log table cannot be culled. The full table "
+            "is shown.",
+            FutureWarning,
+            stacklevel=2,
+        )
+
+    if group_by is not None:
+        warnings.warn(
+            "print_table(group_by=...) is deprecated and has no effect: "
+            "PETSc logging groups timings by event, not by "
+            "line/routine. The event table is shown.",
+            FutureWarning,
+            stacklevel=2,
+        )
+
     print_petsc_log(filename=filename, format=format)
 
 

--- a/tests/test_0055_timing_print_table.py
+++ b/tests/test_0055_timing_print_table.py
@@ -1,0 +1,77 @@
+"""
+Regression tests for uw.timing.print_table legacy keywords.
+
+Issue #499: print_table was reduced to (filename, format) when timing moved
+to the PETSc log backend, but 18 shipped examples still pass the legacy
+display_fraction / group_by / output_file keywords and aborted with
+TypeError. The keywords are accepted again: output_file is a working alias
+for filename; display_fraction and group_by are accepted with a visible
+warning (the PETSc log table cannot honour them).
+"""
+
+import os
+
+import pytest
+
+import underworld3 as uw
+
+pytestmark = [pytest.mark.level_1, pytest.mark.tier_a]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def petsc_logging():
+    """print_table needs PETSc logging active to produce any output."""
+    uw.timing.start()
+    yield
+
+
+def test_legacy_kwargs_accepted_together(tmp_path):
+    """The exact call pattern from Ex_Stokes_*_Benchmark_Kramer."""
+    out = tmp_path / "mesh_create_time.txt"
+    with pytest.warns((FutureWarning, DeprecationWarning)):
+        uw.timing.print_table(
+            group_by="line_routine",
+            output_file=str(out),
+            display_fraction=1.00,
+        )
+    if uw.mpi.rank == 0:
+        assert out.exists()
+        assert os.path.getsize(out) > 0
+
+
+def test_display_fraction_alone_warns_not_raises(capsys):
+    """Ex_Sheared_Layer_Elastic et al.: print_table(display_fraction=1)."""
+    with pytest.warns(FutureWarning, match="display_fraction"):
+        uw.timing.print_table(display_fraction=1)
+
+
+def test_output_file_writes(tmp_path):
+    """output_file alone must behave exactly like filename."""
+    out = tmp_path / "timing.txt"
+    with pytest.warns(DeprecationWarning, match="output_file"):
+        uw.timing.print_table(output_file=str(out))
+    if uw.mpi.rank == 0:
+        assert out.exists()
+        assert os.path.getsize(out) > 0
+
+
+def test_filename_and_output_file_conflict(tmp_path):
+    with pytest.raises(TypeError, match="output_file"):
+        uw.timing.print_table(
+            filename=str(tmp_path / "a.txt"),
+            output_file=str(tmp_path / "b.txt"),
+        )
+
+
+def test_group_by_warns(capsys):
+    with pytest.warns(FutureWarning, match="group_by"):
+        uw.timing.print_table(group_by="routine")
+
+
+def test_new_signature_still_works(tmp_path):
+    """The current (filename, format) interface is unchanged."""
+    out = tmp_path / "timing.csv"
+    uw.timing.print_table(str(out), format="csv")
+    if uw.mpi.rank == 0:
+        assert out.exists()
+        assert os.path.getsize(out) > 0

--- a/tests/test_0508_enhanced_variable_clone.py
+++ b/tests/test_0508_enhanced_variable_clone.py
@@ -1,0 +1,85 @@
+"""
+Regression tests for EnhancedMeshVariable.clone(name, varsymbol).
+
+Issue #498: the enhanced wrapper declared clone(self) and forwarded no
+arguments, while the base MeshVariable.clone requires (name, varsymbol).
+Every in-tree caller uses the two-argument form, so clone was broken in
+both directions and six shipped examples aborted on it.
+
+These tests assert each documented argument takes effect and that the
+clone is structurally identical but has independent data.
+"""
+
+import numpy as np
+import pytest
+
+import underworld3 as uw
+
+pytestmark = [pytest.mark.level_1, pytest.mark.tier_a]
+
+
+@pytest.fixture(scope="module")
+def mesh():
+    return uw.meshing.UnstructuredSimplexBox(
+        minCoords=(0.0, 0.0), maxCoords=(1.0, 1.0), cellSize=0.5
+    )
+
+
+def test_clone_accepts_two_arguments_scalar(mesh):
+    """The exact call pattern the examples use: var.clone(name, symbol)."""
+    p = uw.discretisation.MeshVariable(
+        "P_clone_src", mesh, vtype=uw.VarType.SCALAR, degree=2, varsymbol=r"{p}"
+    )
+    p2 = p.clone("P_clone_dst", r"{p_2}")
+
+    # name argument takes effect
+    assert "P_clone_dst" in p2.name
+    # varsymbol argument takes effect
+    assert "p_2" in str(p2.symbol)
+    # structure is copied
+    assert p2.num_components == p.num_components
+    assert p2.degree == p.degree
+    assert p2.continuous == p.continuous
+    assert p2.vtype == p.vtype
+    assert p2.mesh is p.mesh
+
+
+def test_clone_of_clone_vector(mesh):
+    """Ex_Stokes_Cartesian_SolC clones a clone: v0 = v.clone(...); v1 = v0.clone(...)."""
+    v = uw.discretisation.MeshVariable(
+        "V_clone_src", mesh, vtype=uw.VarType.VECTOR, degree=2, varsymbol=r"{v}"
+    )
+    v0 = v.clone("v0_clone", r"{v_0}")
+    v1 = v0.clone("v1_clone", r"{v_1}")
+
+    for cloned, nm in ((v0, "v0_clone"), (v1, "v1_clone")):
+        assert nm in cloned.name
+        assert cloned.num_components == v.num_components
+        assert cloned.degree == v.degree
+        assert cloned.vtype == v.vtype
+
+    # clones stay the enhanced type so chained clone/units/math ops work
+    assert isinstance(v1, uw.discretisation.MeshVariable)
+
+
+def test_clone_data_is_independent(mesh):
+    """Writing to the clone must not touch the original."""
+    t = uw.discretisation.MeshVariable(
+        "T_clone_src", mesh, vtype=uw.VarType.SCALAR, degree=1
+    )
+    t.array[...] = 1.0
+    t2 = t.clone("T_clone_dst", r"{T_2}")
+    t2.array[...] = 2.0
+
+    assert np.allclose(np.asarray(t.array), 1.0)
+    assert np.allclose(np.asarray(t2.array), 2.0)
+
+
+def test_clone_preserves_discontinuous(mesh):
+    """continuous=False must survive the clone (P0/P-disc pressure spaces)."""
+    p0 = uw.discretisation.MeshVariable(
+        "P0_clone_src", mesh, vtype=uw.VarType.SCALAR, degree=0, continuous=False
+    )
+    p0c = p0.clone("P0_clone_dst", r"{p_0}")
+    assert p0c.continuous is False
+    assert p0c.degree == 0


### PR DESCRIPTION
Fixes #498, fixes #499, fixes #504

Three small independent fixes, one commit each.

**#498 — EnhancedMeshVariable.clone() drops its arguments.** The enhanced wrapper declared `clone(self)` and forwarded nothing, while the base `MeshVariable.clone` requires `(name, varsymbol)` — so clone was uncallable in both directions and six shipped examples aborted on it. `clone(name, varsymbol)` now mirrors the base signature and returns an `EnhancedMeshVariable` (same mesh/shape/type/degree/continuity, independent data), so chained clones (`v1 = v0.clone(...)`, as in Ex_Stokes_Cartesian_SolC) keep the enhanced type. New regression suite `tests/test_0508_enhanced_variable_clone.py` (4 tests) covers each documented argument, clone-of-clone, data independence and discontinuous spaces; all four failed with the reported `TypeError: clone() takes 1 positional argument but 3 were given` before the fix. Spot-run: Ex_Darcy_1D_benchmark.py now runs past its clone calls, both Darcy solves and rendering (it still trips much later on a pre-existing, unrelated matplotlib shape issue — `evaluate` output shaped `(100,1,1)` fed to `plt.plot`).

**#499 — timing.print_table dropped display_fraction/group_by/output_file.** The PETSc-log rewrite cut the signature to `(filename, format)`; 18 examples still pass the legacy keywords and aborted with `TypeError` at their first timing report. `output_file` is restored as a working alias for `filename` (identical behaviour — the table is written to the file; passing both raises `TypeError`). The PETSc backend cannot honour `display_fraction` (no row culling) or `group_by` (events, not lines/routines), so those are accepted with a visible `FutureWarning` rather than raising or being silently swallowed — per the issue's own analysis that silent ignoring of behaviour-changing keywords would be worse than raising, while a hard error keeps the 18 examples broken. New regression suite `tests/test_0055_timing_print_table.py` (6 tests) covers the exact example call patterns (including the Kramer three-keyword form), that `output_file` really writes, the conflict case, and that the current `(filename, format)` interface is unchanged; four failed with the reported `TypeError` pre-fix.

**#504 — test_1018_* in no scripts/test.sh batch, plus the orphan audit.** `test_101*py tests/test_102*py` now runs as a serial batch, so the rotated free-slip suite (19 tests, incl. the #497 guard) is live in CI; verified locally with the exact test.sh invocation: `pytest --config-file=tests/pytest.ini tests/test_1018*py` → 19 passed in 52 s.

One-off audit of every `tests/test_*.py` against the batch globs found **56 orphaned files** (not counting the deliberately disabled `test_0050*` auditor and `test_06xx` regression batches). Added to batches after verifying each batch passes locally:

- `test_005[1-9]*` + `test_006[0-1]*` (mesh/vtk/deform/callback utilities, 43 tests, 4 s)
- `test_02*` (solver smoke/warm-start/wallclock, 27 tests, 16 s)
- `test_101*` + `test_102*` (stokes DMPlex/nullspace/MG, rotated free-slip, boundary flux, FMG lockout, MG bundle — 91 tests, ~2.5 min total)
- `test_105*` (VE/VEP, ddt, yield smoother/homotopy/anchor, solve report — 78 tests + the existing test_1050, 5.3 min)
- `test_1120*` + `test_1450*` (vector SL, vector projection, 6 tests, 17 s)
- named files: `test_docstring_utils`, `test_jit_cache`, `test_jit_deterministic_ordering`, `test_multicomponent_projection`, `test_snes_vector_asymmetric_jacobian`, `test_symbol_disambiguation_prototype` (74 passed, 1 skipped, 21 s)
Also fixed in passing: line 77 read `$PYTEST tests/test_1110*py # Annulus version || status=1` — the inline comment swallowed the `|| status=1`, so annulus adv-diff failures could never fail the script. Same gap class as #504.

Left as listed findings (not added):

- `test_106*` (Nitsche/constrained free-slip, jacobian layout, Newton cold start) and `test_107*` (free surface plume / moving mesh / spherical): these carry `level_2`/`level_3` + `slow` + `tier_b`/`tier_c` markers (test_1064 is level_3 + slow + tier_c), and a probe run of the 106x batch was still grinding after 20 min wall / 12 min CPU — not a "trivially safe" add. They need a triage/deselect decision before gating CI; noted with a comment in test.sh.
- `tests/parallel/` has its own orphans: the parallel batch runs only `tests/parallel/test_075*py`, so `test_0005_xdmf_viz_topology_mpi`, `test_0700_*`, `test_076x`–`test_079x`, `test_0855_*`, `test_1017_*`, and `test_106x_*_parallel` there never run via test.sh. Verifying those needs mpirun time and belongs in its own pass.

Gate: `pixi run -e amr-dev pytest tests -m "level_1 and tier_a" -q -p no:cacheprovider --ignore=tests/test_0050_utils.py` → **590 passed, 0 failed**, 17 skipped (need `--with-mpi`), 1 xfailed, in 7:21.

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)
