### PR TITLE
Fix the red trunk: inverted inside-test in the fault-network line clip, and a gmsh finalize cascade

### DIFF
--- a/src/underworld3/meshing/cartesian.py
+++ b/src/underworld3/meshing/cartesian.py
@@ -1217,9 +1217,20 @@ def BoxInternalPatch(
             gmsh.option.setNumber("Mesh.MeshSizeExtendFromBoundary", 0)
             gmsh.option.setNumber("Mesh.MeshSizeFromPoints", 0)
             gmsh.option.setNumber("Mesh.MeshSizeFromCurvature", 0)
-        gmsh.model.mesh.generate(3)
-        gmsh.write(uw_filename)
-        gmsh.finalize()
+        # TODO(BUG): patch sets the crossing pre-check cannot classify
+        # (coplanar overlaps, patches touching along an edge) can still
+        # make the 3-D mesher fail with a raw "PLC Error" from tetgen;
+        # the embed should catch that and re-raise with its own
+        # message. Fault-session follow-up.
+        try:
+            gmsh.model.mesh.generate(3)
+            gmsh.write(uw_filename)
+        finally:
+            # A mesher failure must not leave the gmsh session
+            # initialized: a poisoned session makes the NEXT mesh
+            # constructor in the same process write an invalid .msh,
+            # which PETSc rejects with error 79 ("expecting $Nodes").
+            gmsh.finalize()
 
     new_mesh = Mesh(
         uw_filename,

--- a/src/underworld3/meshing/fault_network_3d.py
+++ b/src/underworld3/meshing/fault_network_3d.py
@@ -115,7 +115,15 @@ def _line_clip_interval(poly2, p0, d):
         den = float(nrm @ d)
         num = float(nrm @ (A - p0))
         if abs(den) < 1e-30:
-            if num < 0:
+            # parallel edge: the line is inside this half-plane iff
+            # nrm . (p0 - A) >= 0, i.e. num <= 0.  (num > 0 means p0
+            # sits OUTSIDE the edge's half-plane.)  The sign here was
+            # inverted; on LAPACK builds that return exact zeros for
+            # axis-aligned plane bases (den == 0.0 exactly) that made
+            # crossing_segment miss genuine crossings, while builds
+            # with ~1e-17 jitter in den took the (correct) division
+            # branch and passed by luck.
+            if num > 0:
                 return None                        # parallel, outside
             continue
         t = num / den

--- a/tests/test_0851_fault_network_3d.py
+++ b/tests/test_0851_fault_network_3d.py
@@ -44,6 +44,37 @@ def test_crossing_segment_analytic():
     assert crossing_segment(P_A, P_A + [0, 0.1, 0]) is None  # parallel
 
 
+def test_crossing_segment_exact_parallel_edges():
+    """Regression: axis-aligned patches make the polygon side edges
+    EXACTLY parallel to the plane-plane intersection line (den == 0.0,
+    no LAPACK jitter). The parallel-edge branch of the line clip had an
+    inverted inside test, so exactly this configuration reported "no
+    crossing" — which is what CI's OpenBLAS produced for the tilted
+    P_A/P_B pair too, while macOS Accelerate left ~1e-17 jitter in den
+    and dodged the branch. This test fails on EVERY platform without
+    the fix."""
+    # plane y = 0.5 crossed by plane x = 0.42: intersection line
+    # x = 0.42, y = 0.5, z in [0.32, 0.68] (clipped by the second patch)
+    P_C = np.array([[0.42, 0.30, 0.32], [0.42, 0.70, 0.32],
+                    [0.42, 0.70, 0.68], [0.42, 0.30, 0.68]])
+    seg = crossing_segment(P_A, P_C)
+    assert seg is not None, (
+        "exactly-parallel polygon edges must not hide a genuine "
+        "crossing (inverted parallel-edge inside test)")
+    P0, P1 = seg
+    for P in (P0, P1):
+        assert abs(P[0] - 0.42) < 1e-9 and abs(P[1] - 0.5) < 1e-9
+    zs = sorted([P0[2], P1[2]])
+    assert abs(zs[0] - 0.32) < 1e-9 and abs(zs[1] - 0.68) < 1e-9
+
+    # negative control for the sign flip: same exact-parallel setup but
+    # the plane-plane line (x = 0.82) misses P_A (x in [0.3, 0.7]) —
+    # still no crossing
+    P_D = np.array([[0.82, 0.30, 0.32], [0.82, 0.70, 0.32],
+                    [0.82, 0.70, 0.68], [0.82, 0.30, 0.68]])
+    assert crossing_segment(P_A, P_D) is None
+
+
 def test_preparer_trims_junior_and_records_segment():
     fsA, fsB = _surfaces(("Main", P_A), ("Cross", P_B))
     prepared, report, junctions = prepare_fault_surfaces(


### PR DESCRIPTION
# Fix the four CI-only test_0851 failures: one inverted sign, one missing finally

All four CI failures (Linux, conda PETSc 3.25.3) trace to a single source
bug plus one missing cleanup — not to geometry constants in the tests.

## What was environment-dependent

`_line_clip_interval` (fault_network_3d.py) had an inverted inside test in
its parallel-edge branch: for an interior point, `num = nrm.(A - p0)` is
NEGATIVE, but the code returned "outside" on `num < 0`. The branch only
fires when an edge is EXACTLY parallel to the clipped line (`den == 0.0`,
guard 1e-30). CI's OpenBLAS returns exact zeros for the axis-aligned
patch's SVD plane basis, so `den == 0.0` and the inverted branch made
`crossing_segment` report "no crossing" for genuinely crossing patches.
macOS Accelerate leaves ~1e-17 jitter in `den`, dodging the branch into
the sign-correct division path — the dev boxes passed by luck. Verified
by probe: with the module's own code, an exactly axis-aligned crossing
pair returns None pre-fix on macOS too.

## Per-test diagnosis

1. `test_preparer_trims_junior_and_records_segment` and
3. `test_network_3d_end_to_end`: `crossing_segment(Main, Cross)` returned
   None on CI, so the preparer fell through to the near-miss ligament
   refusal (dmin 0.02233 is the true rim-rim distance of the test pair —
   correct data, wrong branch). Fixed by the sign fix.
2. `test_embed_refuses_crossing_patches`: `BoxInternalPatch`'s crossing
   pre-check uses the same `crossing_segment`; the miss let the geometry
   reach gmsh/tetgen, whose raw PLC error escaped. Fixed by the sign fix
   (the designed ValueError now fires on every platform).
4. `test_mesh_simple_array_view_std` (PETSc error 79): a CASCADE from 2.
   The escaped PLC exception aborted `BoxInternalPatch` after
   `gmsh.initialize()` and before `gmsh.finalize()`; the poisoned session
   made the next `StructuredQuadBox` (first test of the next file in the
   same `test_08*` pytest batch) write an invalid .msh, which PETSc
   rejects: error 79, "expecting $Nodes, not $". Reproduced exactly on
   macOS by blinding the crossing check and replaying the sequence.
   Fixed by `try/finally gmsh.finalize()` around generate/write.
   The std test itself is sound (no solver is involved; the error was at
   mesh file read) and is unchanged.

## How the tests now pin the property

New `test_crossing_segment_exact_parallel_edges`: axis-aligned patches
make `den` exactly 0.0 on EVERY platform — the CI condition becomes
deterministic everywhere. Asserts the crossing segment analytically
(x=0.42, y=0.5, z in [0.32, 0.68]).

## Negative controls

- Pre-fix, the new regression test's crossing call returns None on macOS
  (probe-verified) — the test genuinely detects the bug on all platforms.
- Same test includes a non-crossing exact-parallel pair (plane x=0.82
  outside the square) that must STAY None — guards against a blanket
  sign inversion.
- `test_preparer_refusals` (near-miss NotImplementedError, non-convex
  refusal) still passes — the refusal arms still fire.
- Cascade probe: with the crossing check monkeypatched blind, the PLC
  error still escapes but `gmsh.isInitialized() == 0` afterwards and the
  follow-on `StructuredQuadBox` succeeds (pre-fix: exact CI error 79).

## Verification (sequential, worktree amr-dev)

- `test_0851_fault_network_3d.py test_0851_std_reduction_method.py
  test_0851_surface_influence_edge.py`: 17 passed.
- `test_0845_fault_split.py test_0846_fault_contact.py
  test_0847_fault_api.py test_0848_fault_split_3d.py`: 29 passed
  (unchanged set, stays green).

## Remaining for the fault session

Patch sets the crossing pre-check cannot classify — coplanar overlaps,
patches touching along an edge/point — can still reach tetgen and fail
with a raw PLC error instead of the embed's own message. TODO(BUG) is
placed at the `generate(3)` call in `BoxInternalPatch`. The `finally`
means such a failure can no longer poison later meshes, but the refusal
message should become the preparer's own.

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)
