### PR TITLE
TI-VEP viscosity reports the yield-limited weak-plane value; Nitsche scales on K (#463)

### DIFF
--- a/src/underworld3/constitutive_models.py
+++ b/src/underworld3/constitutive_models.py
@@ -3713,27 +3713,25 @@ class TransverseIsotropicVEPFlowModel(TransverseIsotropicFlowModel):
         r"""Effective viscosity for the fault-plane shear component.
 
         Applies the yield mode (softmin/min/harmonic) to η₁, leaving
-        η₀ (bulk) unchanged. The anisotropic tensor handles the
-        directional dependence.
+        η₀ (bulk) unchanged — the anisotropic tensor handles the
+        directional dependence, and the bulk/stiffness scale stays
+        ``Parameters.shear_viscosity_0`` (reported by :attr:`K`).
+
+        Delegates to :meth:`_eta_for_tensor` with the ACTIVE integrator
+        mode, so this reports exactly the coefficient the stress tensor
+        is built from — under yield that is the persistent
+        ``_eta1_yield_eff`` container (a wrapped atom, so the Picard
+        freezing contract holds for anything that bakes this property).
+        For the hybrid integrator this reports the BDF (yield-clipped)
+        branch, matching the default ``self._c``.
+
+        Issue #463: this property previously computed the yield-limited
+        η₁_eff and then returned the un-yielded bulk η₀, so diagnostics,
+        renders and projections saw no yielding at all.
         """
-        inner_self = self.Parameters
-
-        if inner_self.yield_stress.sym == sympy.oo:
-            return inner_self.shear_viscosity_0
-
-        # η₁ is the fault-plane viscosity that gets yield-limited
-        eta_1_eff = inner_self.ve_effective_viscosity
-
-        if self.is_viscoplastic:
-            vp_eff = self._plastic_effective_viscosity
-            # Same yield envelope as the isotropic models: _combine_yield owns the
-            # harmonic / soft-min / hard-Min choice, reads delta from the
-            # constants[] atom (so a homotopy can ramp it without a recompile) and
-            # honours yield_smoother. Previously inlined here, which pinned this
-            # model to the sqrt family and to a baked float delta.
-            eta_1_eff = self._combine_yield(eta_1_eff, vp_eff)
-
-        return inner_self.shear_viscosity_0
+        mode = "etd" if self._integrator == "etd" else "bdf"
+        _, eta_1_eff = self._eta_for_tensor(mode, apply_yield=True)
+        return eta_1_eff
 
     @property
     def K(self):
@@ -4064,12 +4062,18 @@ class TransverseIsotropicVEPFlowModel(TransverseIsotropicFlowModel):
 
     @property
     def plastic_fraction(self):
-        """Fraction of strain rate that is plastic."""
-        eta_1_ve = self.Parameters.ve_effective_viscosity
-        eta_1_eff = self.viscosity
-        # viscosity property returns η₀, need to compare η₁ effective vs η₁ ve
-        # This is approximate for the anisotropic case
-        return sympy.Max(0, 1 - eta_1_eff / eta_1_ve.sym if hasattr(eta_1_ve, 'sym') else 0)
+        r"""Fraction of the fault-plane response that is plastic:
+        ``1 - η₁_eff / η₁_ve`` (zero when the yield limit is inactive).
+
+        Only the weak-plane channel is compared — the bulk η₀ is
+        structurally non-yieldable. Pre-#463 this was identically zero
+        for a yielding fault because ``.viscosity`` returned the bulk
+        η₀ (and a misplaced ternary made the ratio unconditional)."""
+        if not self.is_viscoplastic:
+            return sympy.sympify(0)
+        mode = "etd" if self._integrator == "etd" else "bdf"
+        _, eta_1_ve = self._eta_for_tensor(mode, apply_yield=False)
+        return sympy.Max(0, 1 - self.viscosity / eta_1_ve)
 
 
 class TransverseIsotropicMaxwellExponentialFlowModel(TransverseIsotropicVEPFlowModel):

--- a/src/underworld3/constitutive_models.py
+++ b/src/underworld3/constitutive_models.py
@@ -1727,6 +1727,18 @@ class ViscoElasticPlasticFlowModel(ViscousFlowModel):
         self._bdf_c2 = expression(r"{c_2^{\mathrm{BDF}}}", sympy.Integer(0), "BDF history coefficient 2")
         self._bdf_c3 = expression(r"{c_3^{\mathrm{BDF}}}", sympy.Integer(0), "BDF history coefficient 3")
 
+        # Persistent container for the yield-limited VEP effective viscosity
+        # (the ViscoPlasticFlowModel._plastic_eff_viscosity pattern): the
+        # combined coefficient is stored INSIDE this atom so the c-tensor
+        # bakes a wrapped atom and the default (Picard) tangent stays frozen;
+        # only _jacobian_unwrap (Newton) sees the strain-rate dependence of
+        # the yield law. Same freezing contract as the TI classes (#457/#493).
+        self._vep_eff_viscosity = expression(
+            R"{\eta_{\textrm{eff}}}",
+            1,
+            "Yield-limited visco-elastic effective viscosity",
+        )
+
         self._reset()
 
         super().__init__(unknowns, material_name=material_name)
@@ -2190,20 +2202,28 @@ class ViscoElasticPlasticFlowModel(ViscousFlowModel):
                 # An explicit rounding scale makes the cutoff differentiable, which is
                 # what the skip below existed to avoid needing: there is no outer Max to
                 # nest, so the floor can be honoured in the smooth yield modes too.
-                return self._apply_floor(
+                effective_viscosity = self._apply_floor(
                     effective_viscosity, inner_self.shear_viscosity_min,
                     rounding=rounding,
                 )
-            if self.is_viscoplastic and self._yield_mode in ("harmonic", "softmin"):
-                return effective_viscosity
+            elif self.is_viscoplastic and self._yield_mode in ("harmonic", "softmin"):
+                # Already smooth and bounded; a hard outer Max would nest
+                # Min/Max and break the BDF-2 Jacobian — skip the floor.
+                pass
             else:
-                return sympy.Max(
+                effective_viscosity = sympy.Max(
                     effective_viscosity,
                     inner_self.shear_viscosity_min,
                 )
 
-        else:
-            return effective_viscosity
+        # Store the combined coefficient INSIDE the persistent container (the
+        # ViscoPlasticFlowModel._plastic_eff_viscosity pattern) so the
+        # c-tensor bakes ONE wrapped atom: sympy.diff treats it as a constant
+        # and the default (Picard) tangent stays frozen; only the Newton path
+        # (_jacobian_unwrap) sees the yield law's strain-rate dependence.
+        # (Same freezing contract as the TI classes — issue #457 / PR #493.)
+        self._vep_eff_viscosity._sym = effective_viscosity
+        return self._vep_eff_viscosity
 
     # NOTE: a hard-Min smooth-tangent override (flux_jacobian = harmonic) was
     # prototyped here but deferred to the yield-law / δ-homotopy follow-up. The
@@ -2273,42 +2293,12 @@ class ViscoElasticPlasticFlowModel(ViscousFlowModel):
         return correction
         # return sympy.Min(1, correction)
 
-    ## Is this really different from the original ?
-
-    def _build_c_tensor(self):
-        """For this constitutive law, we expect just a viscosity function"""
-
-        if self._is_setup:
-            print("Using cached value of c matrix", flush=True)
-            return
-
-        print("Building c matrix", flush=True)
-
-        d = self.dim
-        # inner_self = self.Parameters
-        viscosity = self.viscosity
-
-        try:
-            # CRITICAL: Use .sym property to avoid UWexpression array corruption issues
-            # See ViscousFlowModel._build_c_tensor() for detailed explanation
-            viscosity_sym = viscosity.sym if hasattr(viscosity, "sym") else viscosity
-            self._c = 2 * uw.maths.tensor.rank4_identity(d) * viscosity_sym
-        except:
-            d = self.dim
-            dv = uw.maths.tensor.idxmap[d][0]
-            if isinstance(viscosity, sympy.Matrix) and viscosity.shape == (dv, dv):
-                self._c = 2 * uw.maths.tensor.mandel_to_rank4(viscosity, d)
-            elif isinstance(viscosity, sympy.Array) and viscosity.shape == (d, d, d, d):
-                self._c = 2 * viscosity
-            else:
-                raise RuntimeError(
-                    "Viscosity is not a known type (scalar, Mandel matrix, or rank 4 tensor"
-                )
-
-        self._is_setup = True
-        self._solver_is_setup = False
-
-        return
+    # NOTE: no _build_c_tensor override — the base ViscousFlowModel build is
+    # used, which bakes the WRAPPED self.viscosity atom (the persistent
+    # _vep_eff_viscosity container) element-wise into the rank-4 tensor.
+    # The previous override here baked the UNWRAPPED `.sym` contents (the
+    # tidy deferred on PR #493); values are identical, but the wrapped atom
+    # is the freezing contract every other yielding model follows.
 
     # Modify flux to use the stress history term
     # This may be preferable to using strain rate which can be discontinuous

--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -4335,8 +4335,12 @@ class SNES_Vector(SolverBaseClass):
                 "Nitsche mesh size parameter (global)",
             ).sym
 
-        # Viscosity from constitutive model
-        mu = self.constitutive_model.viscosity
+        # Penalty scale from the constitutive model: use K (the stiffness /
+        # preconditioner scale) rather than .viscosity — for the transverse-
+        # isotropic models .viscosity now reports the yield-limited WEAK-PLANE
+        # eta_1 (issue #463), which would under-scale the penalty; K is the
+        # bulk eta_0 there and identical to .viscosity for isotropic models.
+        mu = self.constitutive_model.K
 
         # Constitutive flux
         flux = self._constitutive_model.flux
@@ -6482,8 +6486,12 @@ class SNES_Stokes_SaddlePt(SolverBaseClass):
                 "Nitsche mesh size parameter (global)",
             ).sym
 
-        # Viscosity from constitutive model
-        mu = self.constitutive_model.viscosity
+        # Penalty scale from the constitutive model: use K (the stiffness /
+        # preconditioner scale) rather than .viscosity — for the transverse-
+        # isotropic models .viscosity now reports the yield-limited WEAK-PLANE
+        # eta_1 (issue #463), which would under-scale the penalty; K is the
+        # bulk eta_0 there and identical to .viscosity for isotropic models.
+        mu = self.constitutive_model.K
 
         # Constitutive flux (stress tensor) — includes VE history if active
         flux = self._constitutive_model.flux  # dim x dim Matrix

--- a/tests/test_1066_stokes_jacobian_layout.py
+++ b/tests/test_1066_stokes_jacobian_layout.py
@@ -291,6 +291,81 @@ def test_ti_vep_c_tensor_coefficients_are_frozen():
     )
 
 
+def _ti_vep_yielding():
+    """TI-VEP with an ACTIVE yield limit — shared by the reporting and
+    freezing tests below (same parameters as the frozen-tensor test)."""
+    mesh = uw.meshing.StructuredQuadBox(elementRes=(4, 4))
+    v = uw.discretisation.MeshVariable("V_tvr", mesh, mesh.dim, degree=2)
+    p = uw.discretisation.MeshVariable("P_tvr", mesh, 1, degree=1)
+    stokes = uw.systems.Stokes(mesh, velocityField=v, pressureField=p)
+    cm = uw.constitutive_models.TransverseIsotropicVEPFlowModel(stokes.Unknowns)
+    stokes.constitutive_model = cm
+    cm.Parameters.shear_viscosity_0 = 1.0
+    cm.Parameters.shear_viscosity_1 = 0.01
+    cm.Parameters.shear_modulus = 100.0
+    cm.Parameters.dt_elastic = 0.1  # BDF eta_0 composite is nan at the oo default
+    cm.Parameters.yield_stress = 0.5
+    cm.Parameters.director = sympy.Matrix([0.0, 1.0])
+    cm.Parameters.strainrate_inv_II_min = 1.0e-6
+    return stokes, cm, mesh
+
+
+@pytest.mark.level_1
+@pytest.mark.tier_a
+def test_ti_vep_viscosity_property_reports_yield_limited_eta1():
+    """Issue #463: TransverseIsotropicVEPFlowModel.viscosity computed the
+    yield-limited fault-plane viscosity and then returned the UN-yielded bulk
+    eta_0 — so diagnostics/renders saw no yielding while the flux yielded.
+    The property must report exactly the coefficient the stress tensor is
+    built from: the persistent _eta1_yield_eff container (wrapped atom)."""
+    stokes, cm, mesh = _ti_vep_yielding()
+    assert cm.is_viscoplastic
+
+    visc = cm.viscosity
+    # The drift (#463): the un-yielded bulk value came back.
+    assert visc is not cm.Parameters.shear_viscosity_0, (
+        "TI-VEP .viscosity returned the un-yielded bulk eta_0 — the "
+        "yield-limited eta_1_eff is being discarded (issue #463)"
+    )
+    # The property must hand back the very container the c-tensor bakes.
+    assert visc is cm._eta1_yield_eff, (
+        ".viscosity does not return the persistent yield container the "
+        "flux tensor uses"
+    )
+    _, eta1_tensor = cm._eta_for_tensor("bdf", apply_yield=True)
+    assert eta1_tensor is visc, (
+        ".viscosity and _eta_for_tensor disagree about the fault-plane "
+        "coefficient — reporting has drifted from the flux again"
+    )
+
+    # Freezing contract: the reported value is a wrapped atom (Picard-frozen),
+    # with the strain-rate dependence of the yield law INSIDE it.
+    L = stokes.Unknowns.L
+    d = mesh.dim
+    assert all(
+        sympy.diff(sympy.sympify(visc), L[k, l]) == 0
+        for k in range(d) for l in range(d)
+    ), ".viscosity leaks grad-v to sympy.diff — the freezing contract is broken"
+    from underworld3.cython.generic_solvers import _jacobian_unwrap
+
+    unwrapped = _jacobian_unwrap(sympy.Matrix([visc]))
+    assert any(
+        sympy.diff(sympy.sympify(unwrapped[0]), L[k, l]) != 0
+        for k in range(d) for l in range(d)
+    ), (
+        "positive control failed: the Newton unwrap of .viscosity reveals no "
+        "strain-rate dependence, so the frozen assertion above is vacuous"
+    )
+
+    # Negative control: with the yield limit disabled the property reports the
+    # unlimited VE fault-plane viscosity, not a stale yield container.
+    cm.Parameters.yield_stress = sympy.oo
+    assert not cm.is_viscoplastic
+    visc_off = cm.viscosity
+    assert visc_off is not cm._eta1_yield_eff
+    assert visc_off is cm.Parameters.ve_effective_viscosity
+
+
 def _nitsche_annulus_stokes(anisotropic):
     """Annulus + Nitsche free-slip on the outer wall — the issue #239 setup.
 

--- a/tests/test_1066_stokes_jacobian_layout.py
+++ b/tests/test_1066_stokes_jacobian_layout.py
@@ -366,6 +366,63 @@ def test_ti_vep_viscosity_property_reports_yield_limited_eta1():
     assert visc_off is cm.Parameters.ve_effective_viscosity
 
 
+@pytest.mark.level_1
+@pytest.mark.tier_a
+def test_vep_c_tensor_coefficients_are_frozen():
+    """Isotropic VEP with yield active: same freezing contract as the TI
+    classes (the .sym tidy deferred on PR #493) — the c-tensor coefficients
+    must live inside UWexpression atoms so the default (Picard) tangent stays
+    frozen; only the Newton unwrap sees the yield law's strain-rate
+    dependence."""
+    import itertools
+
+    mesh = uw.meshing.StructuredQuadBox(elementRes=(4, 4))
+    v = uw.discretisation.MeshVariable("V_vf", mesh, mesh.dim, degree=2)
+    p = uw.discretisation.MeshVariable("P_vf", mesh, 1, degree=1)
+    stokes = uw.systems.Stokes(mesh, velocityField=v, pressureField=p)
+    cm = uw.constitutive_models.ViscoElasticPlasticFlowModel(stokes.Unknowns)
+    stokes.constitutive_model = cm
+    cm.Parameters.shear_viscosity_0 = 1.0
+    cm.Parameters.shear_modulus = 100.0
+    cm.Parameters.dt_elastic = 0.1
+    cm.Parameters.yield_stress = 0.5
+    cm.Parameters.strainrate_inv_II_min = 1.0e-6
+    assert cm.is_viscoplastic
+
+    cm._build_c_tensor()
+
+    L = stokes.Unknowns.L
+    d = mesh.dim
+    c = sympy.Array(cm.c)
+    live = [
+        (idx, k, l)
+        for idx in itertools.product(range(d), repeat=4)
+        for k in range(d)
+        for l in range(d)
+        if sympy.diff(sympy.sympify(c[idx]), L[k, l]) != 0
+    ]
+    assert not live, (
+        "isotropic VEP c-tensor depends on the velocity gradient (yield-"
+        "limited viscosity baked unwrapped) — Picard tangent un-frozen: "
+        f"first hits {live[:4]}"
+    )
+
+    # Positive control: the dependence must exist INSIDE the atoms.
+    from underworld3.cython.generic_solvers import _jacobian_unwrap
+
+    c_unwrapped = _jacobian_unwrap(c)
+    revealed = any(
+        sympy.diff(sympy.sympify(c_unwrapped[idx]), L[k, l]) != 0
+        for idx in itertools.product(range(d), repeat=4)
+        for k in range(d)
+        for l in range(d)
+    )
+    assert revealed, (
+        "Newton unwrap of the VEP c-tensor reveals no strain-rate "
+        "dependence — the yield law has been lost from the tangent chain"
+    )
+
+
 def _nitsche_annulus_stokes(anisotropic):
     """Annulus + Nitsche free-slip on the outer wall — the issue #239 setup.
 


### PR DESCRIPTION
## TI-VEP `.viscosity` now reports the yield-limited fault-plane viscosity the stress actually uses

Fixes #463

### The bug

`TransverseIsotropicVEPFlowModel.viscosity` computed the yield-limited
fault-plane viscosity `eta_1_eff` and then returned the un-yielded bulk
`shear_viscosity_0` — the computed value was a dead local. The residual was
never affected (the flux path builds the rank-4 tensor through
`_eta_for_tensor`, which applies the yield correctly), but every reporting
surface that reads `.viscosity` — diagnostics, viscosity renders, projections —
saw no yielding at all.

Measured on a yielding shear state (tau_y = 0.5, fault-plane shear rate 50,
eta_0 = 1, eta_1 = 0.01): projecting `.viscosity` gave a constant **1.0**
(bulk) while the tensor coefficient the stress uses projects to **0.005**
(the yield limit tau_y / (2 |gamma_dot|)).

### The fix

- `viscosity` now delegates to `_eta_for_tensor` with the ACTIVE integrator
  mode, so the property returns exactly the coefficient the stress tensor is
  built from. Under yield that is the persistent `_eta1_yield_eff` container
  introduced in #493 — a wrapped UWexpression atom, so the Picard freezing
  contract holds for anything that bakes the property. For the hybrid
  integrator it reports the BDF (yield-clipped) branch, matching the default
  `self._c`.
- `TransverseIsotropicVEPFlowModel.plastic_fraction` had the same drift
  squared: it compared the bulk `eta_0` against `eta_1_ve` (identically zero
  after the `Max(0, ...)`), and a misplaced ternary made the `hasattr` guard
  a no-op. It now reports `1 - eta_1_eff / eta_1_ve` on the weak-plane
  channel (the bulk is structurally non-yieldable).
- `K` (the Schur/stiffness scale) stays `shear_viscosity_0` — deliberately,
  per the issue.
- The two Nitsche boundary kernels (`SNES_Vector.add_nitsche_bc`,
  `SNES_Stokes_SaddlePt.add_nitsche_bc`) used `.viscosity` as their PENALTY
  scale. That consumer wants the stiffness scale, not the (now weak-plane,
  possibly yield-collapsed) effective viscosity — they now read `.K`, which
  is bit-identical to the old behaviour for every model (isotropic models:
  `K == viscosity`; TI models: `K == eta_0 ==` the old `.viscosity` return).

### The deferred `.sym` tidy from #493 (isotropic VEP)

PR #493 noted that `ViscoElasticPlasticFlowModel._build_c_tensor` still baked
the UNWRAPPED `.sym` contents of the effective viscosity into the c-tensor
(tangents were symmetric either way because the VEP solve flux goes through
`stress()`). That tidy is done here for contract uniformity:

- `ViscoElasticPlasticFlowModel.viscosity` now stores the combined
  (yield-limited, floored) coefficient inside a persistent
  `_vep_eff_viscosity` container and returns it — the
  `ViscoPlasticFlowModel._plastic_eff_viscosity` pattern. (Bonus: the
  property now always returns a UWexpression, so `_object_viewer` no longer
  breaks on a yielding VEP model.)
- The `_build_c_tensor` override is deleted; the base `ViscousFlowModel`
  build bakes the wrapped container atom element-wise (and the stray debug
  `print`s in the override go with it).

Proof nothing changes:

- The isotropic Picard tangent was ALREADY frozen before the tidy (the
  strain-rate content sat inside wrapped atoms one level down) — the new
  frozenness test `test_vep_c_tensor_coefficients_are_frozen` passes on both
  sides of the change, with a Newton-unwrap positive control.
- Solve identity: a 6-step shear-box loading sequence through yield
  (`_yield_mode="min"`, tau_y = 0.5, the test_1052 configuration) was run on
  the pre-change and post-change builds for BOTH the isotropic VEP and the
  TI-VEP models. TI-VEP: v, p and the tau_xy trace are **bitwise identical**
  (its flux path is untouched). Isotropic VEP: identical to **3.2e-10**
  max-abs (v: 9.4e-11, p: 2.3e-10, tau_xy: 3.2e-10) against a 1e-6 solver
  tolerance — not bitwise, because routing the coefficient through the
  container changes the compiled kernel's expression form, not its value.

### Tests

`tests/test_1066_stokes_jacobian_layout.py` (alongside the #457/#493
freezing-contract tests):

- `test_ti_vep_viscosity_property_reports_yield_limited_eta1` — the property
  must return the same container `_eta_for_tensor` bakes; frozen under
  `d/dL`, Newton unwrap reveals the yield law (positive control), and with
  the yield limit disabled it reports the unlimited VE fault-plane viscosity
  (negative control). **Validated fail-before**: on pre-fix code it fails at
  `assert visc is not cm.Parameters.shear_viscosity_0`.
- `test_vep_c_tensor_coefficients_are_frozen` — isotropic VEP pin for the
  tidy (passes pre- and post-change, as intended for a no-behaviour-change
  refactor).

Stakeholder suites: test_1066 (7 passed), test_0104 / test_0610 / test_1055 /
test_1057 / test_1059 / test_1060 / test_1065 / test_1067 (69 passed),
test_1052 VEP stability regression, level_2 (5 passed).

Gate: `pytest tests -m "level_1 and tier_a" -q --ignore=tests/test_0050_utils.py`
→ **592 passed, 0 failed**, 17 skipped (MPI opt-in), 1 xfailed, in 7:09.

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)
