### PR TITLE
CI: raise the job timeout to 120 minutes — the suite outgrew 60

### DIFF
--- a/.github/workflows/build_uw3_and_test.yaml
+++ b/.github/workflows/build_uw3_and_test.yaml
@@ -31,7 +31,14 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # The suite has outgrown 60 minutes. Measured 2026-08-15: the SERIAL phase
+    # alone is ~55 min (three batches at 14-15 min each), so the parallel phase
+    # - which runs last - was being cut off mid-run and reported as a failure
+    # that looked like a test failure. Any addition at all pushed a run over.
+    # This is a stop-gap that unblocks landing work; the durable fix is to split
+    # the batches across parallel jobs so wall-clock stops tracking total test
+    # time. See the CI-runtime issue for that.
+    timeout-minutes: 120
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Two PRs were cancelled at exactly 1h00m and reported as failures when nothing had failed. Measured from the logs on 2026-08-15:

- **PR #568** (no test additions): the job took **55m07s** and passed.
- **PR #571**: cancelled at 1h00m22s and again at 1h00m19s. Zero FAILED lines in both. The second run's serial phase ran 06:47→07:42 — **55 minutes** — and the parallel phase, which runs last, got 2 minutes before the cap killed it mid-run.

So the cap is the binding constraint, not the content: a run with no additions was already within five minutes of it, and three individual serial batches take 14–15 minutes each.

The failure mode is worse than slow CI, because a cancellation looks like a red X. #571's first timeout sent us hunting a test failure that did not exist, and the same would happen to anyone else adding tests.

This raises the cap to 120 so work can land. It is a **stop-gap**, and the comment in the workflow says so: the durable fix is splitting the batches across parallel jobs so wall-clock stops tracking total test time — filed separately.

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)