### PR TITLE
Skill: refinement=R is a factor on the background spacing, not a grading ratio

### DIFF
--- a/.claude/skills/adaptive-meshing/SKILL.md
+++ b/.claude/skills/adaptive-meshing/SKILL.md
@@ -71,8 +71,10 @@ adapt a mesh to a field `T` each step:
 ```python
 import underworld3 as uw
 
-# metric from |grad T|: refinement = finest:coarsest cell-size ratio (~5).
-# Use refinement=R, NOT strategy= (strategy caps at ~2 and under-grades).
+# metric from |grad T|: refinement=R is a factor on the BACKGROUND spacing h0,
+# not a finest:coarsest ratio. The envelope is h in [h0/R, h0*coarsening], and
+# coarsening="auto" is R**(1/d) — so R=5 in 2-D spans h0/5 to 2.2*h0, a ratio
+# of R**(1+1/d) ~ 11. Use refinement=R, NOT strategy= (caps at ~2, under-grades).
 rho = uw.meshing.metric_density_from_gradient(
     mesh, T, refinement=5, coarsening="auto", metric_choice="front-following")
 
@@ -124,10 +126,15 @@ method_kwargs=dict(step_frac=0.2, accel="cg", momentum=0.0), slip_surfaces=True)
 
 ### 2. Metric
 - Thermal: `metric_density_from_gradient(mesh, T, refinement=R,
-  metric_choice="front-following")` — `refinement=R` (≈5) is the finest:coarsest
-  grading ratio; named `strategy=` caps at ~2 and under-grades. R≈5 extracts ~all
-  the grading the node budget/layout allows; don't over-tune R (benign no-op above
-  budget).
+  metric_choice="front-following")`. `refinement=R` (≈5) is the maximum local
+  refinement **on the background cell size h0**, not the finest:coarsest ratio:
+  the metric targets `h ∈ [h0/R, h0·coarsening]`, and `coarsening="auto"` takes
+  the budget-conserving `R**(1/d)`. So R=5 in 2-D asks for h0/5 up to 2.2·h0 —
+  a finest:coarsest ratio of `R**(1+1/d)` ≈ 11, and ≈ 8.5 in 3-D. Named
+  `strategy=` caps at ~2 and under-grades. R≈5 extracts ~all the grading the
+  node budget/layout allows; don't over-tune R (benign no-op above budget).
+  Passing `refinement` takes the **envelope branch**, which ignores `amp`,
+  `lo/hi_percentile`, `mode` and `power`.
 - Fault / sharp feature: a **hand-built anisotropic SPD tensor**
   `M = ρ·I + (Rf²−1)·exp(−(d/w)²)·n nᵀ` (thin ACROSS the feature normal n). A
   scalar bump refines a fat isotropic corridor and leaves the centre-line coarse.


### PR DESCRIPTION
The `adaptive-meshing` skill described `refinement=R` as the finest:coarsest cell-size ratio.

It is the maximum local refinement on the **background** cell size `h0`. The metric targets the envelope `h ∈ [h0/R, h0·coarsening]`, and `coarsening="auto"` takes the budget-conserving `R**(1/d)`. The realised finest:coarsest ratio is `R**(1+1/d)` — about 11 for `R=5` in 2-D and 8.5 in 3-D, not 5.

Source of truth: `metric_density_from_gradient` in `src/underworld3/meshing/smoothing/metrics.py`.

The skill is the first thing a session reads about the mover, so anyone sizing a mesh from it was asking for roughly twice the grading they thought. Also records that passing `refinement` takes the envelope branch, which ignores `amp`, `lo/hi_percentile`, `mode` and `power`.

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)