### PR TITLE
Add mesh-files-only internal spherical shell generation

### DIFF
--- a/src/underworld3/discretisation/__init__.py
+++ b/src/underworld3/discretisation/__init__.py
@@ -23,3 +23,4 @@ from .discretisation_mesh import checkpoint_xdmf
 from .discretisation_mesh import meshVariable_lookup_by_symbol
 from .discretisation_mesh import petsc_dm_find_labeled_points_local
 from .discretisation_mesh import _from_gmsh
+from .discretisation_mesh import _gmsh_to_h5

--- a/src/underworld3/discretisation/discretisation_mesh.py
+++ b/src/underworld3/discretisation/discretisation_mesh.py
@@ -96,18 +96,15 @@ def extend_enum(inherited):
 
 
 @timing.routine_timer_decorator
-def _from_gmsh(filename, comm=None, markVertices=False, useRegions=True, useMultipleTags=True):
-    """Read a Gmsh .msh file from `filename`.
+def _gmsh_to_h5(
+    filename,
+    markVertices=False,
+    useRegions=True,
+    useMultipleTags=True,
+):
+    """Convert a Gmsh file to PETSc HDF5 without loading the resulting DM."""
 
-    :kwarg comm: Optional communicator to build the mesh on (defaults to
-        COMM_WORLD).
-    """
-
-    ## NOTE: - this should be smart enough to serialise the msh conversion
-    ## and then read back in parallel via h5.  This is currently done
-    ## by every gmesh mesh
-
-    comm = comm or PETSc.COMM_WORLD
+    h5_filename = filename + ".h5"
     options = PETSc.Options()
     options["dm_plex_hash_location"] = None
 
@@ -152,11 +149,11 @@ def _from_gmsh(filename, comm=None, markVertices=False, useRegions=True, useMult
             # this module, so a top-level import would close a cycle.
             from underworld3.meshing._mesh_files import _scratch_name
 
-            scratch = _scratch_name(filename + ".h5")
+            scratch = _scratch_name(h5_filename)
             viewer = PETSc.ViewerHDF5().create(str(scratch), "w", comm=PETSc.COMM_SELF)
             viewer(plex_0)
             viewer.destroy()
-            os.replace(scratch, filename + ".h5")
+            os.replace(scratch, h5_filename)
     finally:
         # The gmsh import options are import-time scratch — meaningful only for
         # the createFromFile above. Clear the whole namespace so a value set by
@@ -166,12 +163,39 @@ def _from_gmsh(filename, comm=None, markVertices=False, useRegions=True, useMult
         # read as 2-D). Runs on success or failure.
         _clear_gmsh_import_options()
 
-    # Now we have an h5 file and we can hand this to _from_plexh5. The barrier
-    # is what the atomic write above makes necessary AND sufficient: the other
-    # ranks must not look for the file before rank 0 has renamed it into place.
+    # The barrier ensures every rank sees the complete atomically-renamed file.
     uw.mpi.barrier()
 
-    return _from_plexh5(filename + ".h5", comm, return_sf=True)
+    return filename + ".h5"
+
+
+@timing.routine_timer_decorator
+def _from_gmsh(
+    filename,
+    comm=None,
+    markVertices=False,
+    useRegions=True,
+    useMultipleTags=True,
+):
+    """Read a Gmsh .msh file from `filename`.
+
+    :kwarg comm: Optional communicator to build the mesh on (defaults to
+        COMM_WORLD).
+    """
+
+    ## NOTE: - this should be smart enough to serialise the msh conversion
+    ## and then read back in parallel via h5.  This is currently done
+    ## by every gmesh mesh
+
+    comm = comm or PETSc.COMM_WORLD
+    h5_filename = _gmsh_to_h5(
+        filename,
+        markVertices=markVertices,
+        useRegions=useRegions,
+        useMultipleTags=useMultipleTags,
+    )
+
+    return _from_plexh5(h5_filename, comm, return_sf=True)
 
 
 @timing.routine_timer_decorator

--- a/src/underworld3/meshing/spherical.py
+++ b/src/underworld3/meshing/spherical.py
@@ -21,6 +21,7 @@ from underworld3.discretisation import Mesh
 from underworld3 import VarType
 from underworld3.coordinates import CoordinateSystemType
 from underworld3.discretisation import _from_gmsh as gmsh2dmplex
+from underworld3.discretisation import _gmsh_to_h5 as gmsh2h5
 import underworld3.timing as timing
 import underworld3.cython.petsc_discretisation
 
@@ -509,6 +510,7 @@ def SphericalShellInternalBoundary(
     refinement=None,
     gmsh_verbosity=0,
     verbose=False,
+    write_mesh_files_only=False,
 ):
     """
     Generates a spherical shell with an internal boundary using Gmsh. The function creates a 3D mesh of a spherical shell
@@ -536,11 +538,19 @@ def SphericalShellInternalBoundary(
         Gmsh output verbosity (0=quiet). Default is 0.
     verbose : bool, optional
         If True, print additional information. Default is False.
+    write_mesh_files_only : bool, optional
+        If True, write the Gmsh ``.msh`` and PETSc ``.msh.h5`` files, return
+        the HDF5 path as a string, and stop without constructing an in-memory
+        Underworld mesh. This skips HDF5 reloading, coordinate-system setup,
+        and cell-region classification. If False, return a fully initialized
+        :class:`underworld3.discretisation.Mesh`, including the ``Inner`` and
+        ``Outer`` cell-region labels. Default is False.
 
     Returns
     -------
-    Mesh
-        The generated spherical shell mesh with internal boundary.
+    Mesh or str
+        The PETSc HDF5 path when ``write_mesh_files_only=True``; otherwise, a
+        fully initialized spherical-shell mesh.
 
     Examples
     --------
@@ -695,6 +705,14 @@ def SphericalShellInternalBoundary(
         gmsh.model.mesh.generate(3)
         write_gmsh(uw_filename)
         gmsh.finalize()
+
+    if write_mesh_files_only:
+        return gmsh2h5(
+            uw_filename,
+            markVertices=True,
+            useRegions=True,
+            useMultipleTags=True,
+        )
 
     # Ensure boundaries conform (if refined)
     # This is equivalent to a partial function because it already

--- a/tests/test_0502_boundary_integrals.py
+++ b/tests/test_0502_boundary_integrals.py
@@ -414,6 +414,61 @@ def test_bd_integral_spherical_internal_boundary_areas():
         )
 
 
+@pytest.mark.level_2
+@pytest.mark.tier_b
+def test_spherical_internal_boundary_mesh_files_only(tmp_path, monkeypatch):
+    """File generation can bypass Mesh construction and preserve labels."""
+    from enum import Enum
+
+    import underworld3.meshing.spherical as spherical
+    from underworld3.coordinates import CoordinateSystemType
+
+    mesh_file = str(tmp_path / "spherical_internal_mesh_files_only.msh")
+
+    def fail_mesh_construction(*args, **kwargs):
+        raise AssertionError(
+            "write_mesh_files_only=True must not construct an Underworld Mesh"
+        )
+
+    with monkeypatch.context() as patch:
+        patch.setattr(spherical, "Mesh", fail_mesh_construction)
+        h5_file = spherical.SphericalShellInternalBoundary(
+            radiusOuter=_R_SHELL_OUTER,
+            radiusInternal=_R_SHELL_INTERNAL,
+            radiusInner=_R_SHELL_INNER,
+            cellSize=0.25,
+            filename=mesh_file,
+            write_mesh_files_only=True,
+        )
+
+    assert h5_file == f"{mesh_file}.h5"
+    assert (tmp_path / "spherical_internal_mesh_files_only.msh").is_file()
+    assert (tmp_path / "spherical_internal_mesh_files_only.msh.h5").is_file()
+
+    class Boundaries(Enum):
+        Centre = 1
+        Lower = 11
+        Internal = 12
+        Upper = 13
+        All_Boundaries = 1001
+
+    reloaded_mesh = uw.discretisation.Mesh(
+        h5_file,
+        degree=1,
+        qdegree=2,
+        coordinate_system_type=CoordinateSystemType.SPHERICAL,
+        useMultipleTags=True,
+        useRegions=True,
+        markVertices=True,
+        boundaries=Boundaries,
+    )
+
+    for boundary in ("Lower", "Internal", "Upper"):
+        label = reloaded_mesh.dm.getLabel(boundary)
+        assert label is not None
+        assert label.getNumValues() > 0
+
+
 def _build_spherical_shell_for_integrals():
     from underworld3.meshing import SphericalShell
 


### PR DESCRIPTION
## Summary

- extract the existing atomic Gmsh-to-PETSc-HDF5 conversion into `_gmsh_to_h5()`;
- add `SphericalShellInternalBoundary(write_mesh_files_only=True)`;
- return the generated `.msh.h5` path without constructing an in-memory UW3 `Mesh`;
- preserve the existing full-`Mesh` behavior by default;
- add focused regression coverage for bypassing `Mesh` construction and reloading the generated HDF5 with `Lower`, `Internal`, and `Upper` labels.

## Motivation

`SphericalShellInternalBoundary()` currently writes the reusable `.msh.h5` file during Gmsh import, then reloads that file into a full UW3 mesh and materializes `Inner` and `Outer` cell-region labels. The region creation loops over every cell in Python.

That work is required when the caller needs the returned in-memory mesh, but it is unnecessary for workflows that only generate reusable mesh files for later MPI jobs. The custom region labels are created after the HDF5 write and therefore do not alter the already-written reusable file.

This became significant for the Zhong et al. spherical-shell benchmark on Gadi. Each `cellSize=1/64` mesh contains about 4.2 million cells. The approximately 710 MB HDF5 files appeared several minutes before the serial jobs exited; one measured job completed in 15:14 using 8.35 GB while remaining CPU-bound in post-conversion mesh setup.

## API

```python
h5_path = uw.meshing.SphericalShellInternalBoundary(
    radiusOuter=1.0,
    radiusInternal=0.775,
    radiusInner=0.55,
    cellSize=1.0 / 64.0,
    filename="shell.msh",
    write_mesh_files_only=True,
)
```

With `write_mesh_files_only=True`, the generator:

1. writes the Gmsh `.msh` file;
2. atomically converts it to PETSc `.msh.h5`;
3. preserves the imported physical boundary labels;
4. returns the HDF5 path as a string;
5. skips HDF5 reload, coordinate-system initialization, and cell-region classification.

The default remains `write_mesh_files_only=False`, so existing callers continue to receive a fully initialized UW3 `Mesh` with no behavior change.

## Validation

Validated on a fresh branch from `upstream/development` at `59982834`:

- `./uw build` completed successfully;
- file-generation regression passed;
- unchanged full-constructor boundary-area regression passed;
- focused result: `2 passed`;
- Python syntax and whitespace checks passed.

The same feature diff also passed the complete level-1 suite before being squashed for this PR: `1493 passed, 33 skipped, 2 xfailed`.