### PR TITLE
Quick-fix batch: pressure nullspace, mesh cache filename, test number

### DIFF
--- a/docs/developer/subsystems/analytic-solutions.md
+++ b/docs/developer/subsystems/analytic-solutions.md
@@ -990,7 +990,7 @@ are under `.self_gravity`. Velocity is unchanged by that postprocessing.
 
 ### Validation
 
-`tests/test_1029_analytic_zhong2008.py` checks every parenthesized analytical
+`tests/test_1030_analytic_zhong2008.py` checks every parenthesized analytical
 entry in Zhong et al. (2008) Tables 2 and 3: three load depths, four harmonic
 degrees, isoviscous and `10^4`-lid cases, and eight response quantities per
 case. The 192 comparisons agree within the precision printed in the paper. The

--- a/src/underworld3/analytic/kramer.py
+++ b/src/underworld3/analytic/kramer.py
@@ -266,16 +266,16 @@ class CylindricalStokes(AnalyticSolution):
         to use" section of ``docs/developer/subsystems/rotated-freeslip.md``.
         """
 
+        # The pressure nullspace belongs to the DOMAIN, not to the wall type.
+        # Both cases here are an enclosed annulus — velocity prescribed
+        # everywhere on both arcs, or wall-normal flow zero on both — so in
+        # either the pressure is determined only up to a constant and the
+        # nullspace has to be removed. It used to be set after an early
+        # `return` that the zero-slip branch took, so that case ran a singular
+        # saddle and could return a quiet, wrong answer (#577).
         if self.boundary == "zero":
-            # TODO(BUG): issue #577 — the zero-slip case leaves the pressure
-            # nullspace in place, where every other enclosed case in the suite
-            # removes it. An annulus with both arcs held at zero velocity is
-            # enclosed, so its pressure is determined only up to a constant and
-            # a direct solve on the singular saddle can return a quiet, wrong
-            # answer. Preserved here because this refactor is
-            # behaviour-preserving by contract; fix it under its own test.
             prescribed_velocity(solver, self.boundaries, (0.0, 0.0))
-            return
+        else:
+            free_slip(solver, self.boundaries)
 
-        free_slip(solver, self.boundaries)
         solver.petsc_use_pressure_nullspace = True

--- a/src/underworld3/meshing/cartesian.py
+++ b/src/underworld3/meshing/cartesian.py
@@ -1427,7 +1427,16 @@ def StructuredQuadBox(
         if uw.mpi.rank == 0:
             os.makedirs(mesh_file_dir(), exist_ok=True)
 
-        uw_filename = f"{mesh_file_dir()}/uw_structuredQuadBox_minC{minCoords}_maxC{maxCoords}.msh"
+        # `elementRes` is part of the name because it is part of the mesh.
+        # Without it every StructuredQuadBox on the same box — 16x16, 32x32,
+        # a resolution sweep — writes and reads ONE path, so two processes at
+        # different resolutions race on it and one reads the other's mesh
+        # (#618). The annulus already carries its cell size for this reason:
+        # `uw_annulus_ro1.0_ri0.5_csize0.05.msh`.
+        uw_filename = (
+            f"{mesh_file_dir()}/uw_structuredQuadBox_minC{minCoords}"
+            f"_maxC{maxCoords}_res{tuple(elementRes)}.msh"
+        )
     else:
         uw_filename = filename
 

--- a/tests/test_1030_analytic_zhong2008.py
+++ b/tests/test_1030_analytic_zhong2008.py
@@ -5,7 +5,7 @@ solutions, not the CitcomS finite-element results.  This test pins every
 published propagator row so a sign, stress scaling, layer-order, or self-gravity
 regression cannot hide behind agreement with one selected case.
 
-Run: pixi run python -m pytest tests/test_1029_analytic_zhong2008.py -v
+Run: pixi run python -m pytest tests/test_1030_analytic_zhong2008.py -v
 """
 
 import numpy as np


### PR DESCRIPTION
Closes #577. Closes #600. Closes #618.

Three small independent fixes, batched because none warrants its own change —
the same shape as #456 and #532.

## #577 — the zero-slip annulus ran a singular saddle

`CylindricalStokes.apply_boundary_conditions` returned before the line that
removes the pressure nullspace:

```python
if self.boundary == "zero":
    prescribed_velocity(solver, self.boundaries, (0.0, 0.0))
    return                                   # <- before the nullspace line

free_slip(solver, self.boundaries)
solver.petsc_use_pressure_nullspace = True
```

Both cases are an enclosed annulus, so in both the pressure is determined only
up to a constant. The nullspace belongs to the domain, not to the wall type, and
is now set once after the branch.

Measured, reading the flag back off the solver:

| `boundary` | before | after |
|---|---|---|
| `"zero"` | unset | `True` |
| `"free"` | `True` | `True` |

## #618 — one cache file for every resolution

```python
uw_filename = f"{mesh_file_dir()}/uw_structuredQuadBox_minC{minCoords}_maxC{maxCoords}.msh"
```

`elementRes` was not in the name, so every `StructuredQuadBox` on the same box
wrote and read one path whatever its resolution, and two processes at different
resolutions raced on it. The annulus already carries its cell size for this
reason. Resolution is now part of the name; a 4x4 and an 8x8 produce
`..._res(4, 4).msh` and `..._res(8, 8).msh` where they previously produced one
file between them.

## #600 — two test files numbered 1029

`test_1029_analytic_zhong2008.py` collided with
`test_1029_analytic_faulted_medium.py`; the two PRs were written against
different bases and neither could see the other's choice. Zhong moves to 1030,
the faulted medium keeps 1029 because it merged first. The reference in
`docs/developer/subsystems/analytic-solutions.md` is updated and no stale
mention remains anywhere in `src/`, `tests/`, `docs/` or `scripts/`.

## Verified

Full `./uw test`: 1556 passed, 32 skipped, 2 xfailed. The analytic contract,
conformance and Zhong files: 132 passed.

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)
