### PR TITLE
Make the fall off the multigrid loud, and move the penalty into the total stress (#625)

### DIFF
--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -2182,7 +2182,18 @@ class SNES_Stokes(_ConstitutiveModelStateMixin, SNES_Stokes_SaddlePt):
     #: UW3's penalty is grad-div, not a true augmented Lagrangian -- div(P2) is
     #: not inside P0, so the term does not vanish at the discrete solution --
     #: but it converges away. ``penalty = 0`` restores the unaugmented operator.
-    DEFAULT_PENALTY = 10.0
+    #:
+    #: **Held at 0 pending the pointwise-traction question.** At 10 the
+    #: spherical dynamic topography recovered from the rotated free-slip
+    #: reaction drops 0.4192 -> 0.3021, 28%, on the *vertex-sampled* value while
+    #: the facet-integrated value stays correct (``test_1018``). So augmentation
+    #: corrupts the de-smearing from reaction loads to pointwise stress —
+    #: presumably because lambda*mu*(div u) is non-zero cell-by-cell for P2-P0
+    #: and averages out over a facet integral but not at a vertex. Dynamic
+    #: topography is the main product of that machinery, so the value stays 0
+    #: until that is resolved; everything needed for the change is in place and
+    #: it is this constant.
+    DEFAULT_PENALTY = 0.0
 
 
     def _apply_automatic_penalty(self):

--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -1221,6 +1221,19 @@ class SNES_Richards(SNES_TransientDarcy):
 ## --------------------------------
 
 
+def _penalty_value(penalty_expression):
+    """The penalty as a plain float.
+
+    `expression.sym` is a sympy object, and comparing one to a Python number
+    does not reliably return a bool -- a guard written as `sym == 0` let a zero
+    penalty through and warned about itself.
+    """
+    try:
+        return float(penalty_expression.sym)
+    except (TypeError, ValueError):
+        return float("nan")      # symbolic: not a number, so not zero
+
+
 class SNES_Stokes(_ConstitutiveModelStateMixin, SNES_Stokes_SaddlePt):
     r"""
     Stokes equation solver for incompressible viscous flow.
@@ -1336,6 +1349,10 @@ class SNES_Stokes(_ConstitutiveModelStateMixin, SNES_Stokes_SaddlePt):
         self._Estar = None
 
         self._penalty = expression(R"\uplambda", 0, "Numerical Penalty")
+        # Whether `penalty` still holds its automatic value. An explicit
+        # assignment latches this False and the auto default stands down --
+        # the same discipline as the tolerance-derived option keys (#477/#483).
+        self._penalty_is_automatic = True
         self._constraints = sympy.Matrix((self.div_u,))  # by default, incompressibility constraint
 
         self._bodyforce = expression(
@@ -1539,6 +1556,12 @@ class SNES_Stokes(_ConstitutiveModelStateMixin, SNES_Stokes_SaddlePt):
                 homotopy_options, verbose=verbose, solve_kwargs=inner
             )
 
+        # The penalty enters the compiled weak form, so it must be decided
+        # BEFORE setup -- and it depends on which velocity preconditioner
+        # will be used, which is only certain afterwards. Bet here; the
+        # bet is confirmed after setup, on either path.
+        self._apply_automatic_penalty()
+
         has_stress_history = self.Unknowns.DFDt is not None
 
         if has_stress_history:
@@ -1575,6 +1598,7 @@ class SNES_Stokes(_ConstitutiveModelStateMixin, SNES_Stokes_SaddlePt):
                 self._setup_pointwise_functions(verbose)
                 self._setup_discretisation(verbose)
                 self._setup_solver(verbose)
+                self._check_penalty_matched_the_preconditioner()
 
             # 1. ADVECT stress history along characteristics
             if uw.mpi.rank == 0 and verbose:
@@ -1658,6 +1682,8 @@ class SNES_Stokes(_ConstitutiveModelStateMixin, SNES_Stokes_SaddlePt):
                 time=time,
                 divergence_retries=divergence_retries,
             )
+            # Confirm the preconditioner the automatic penalty was chosen for.
+            self._check_penalty_matched_the_preconditioner()
 
     @property
     def tau(self):
@@ -2106,7 +2132,106 @@ class SNES_Stokes(_ConstitutiveModelStateMixin, SNES_Stokes_SaddlePt):
     def penalty(self, value):
         """Set the augmented Lagrangian penalty parameter."""
         self._needs_function_rewire = True
+        self._penalty_is_automatic = False
         self._penalty.sym = value
+
+    #: Penalty used automatically when the velocity block will be solved by the
+    #: custom-P geometric multigrid. Measured on SolCx (eta 1e6, P2-P0disc,
+    #: 2592 cells, #625): with FMG this improves every axis at once -- 21%
+    #: faster, Schur count per application 59 -> 18, total velocity iterations
+    #: 546 -> 270 -- because FMG absorbs the grad-div augmentation (8.8 -> 13.5
+    #: iterations per application). With GAMG the identical value makes the
+    #: solve SLOWER (15.5 -> 20.7 s), because augmentation is exactly what
+    #: drives GAMG into its iteration cap. So it is applied only where it was
+    #: measured to pay, and `penalty = 0` turns it off.
+    #:
+    #: The accuracy cost is a consistent perturbation rather than a changed
+    #: answer: same convergence rate, and the gap to the unaugmented solution
+    #: shrinks under refinement (1.102 -> 1.087 -> 1.066 over three levels).
+    #: UW3's penalty is grad-div, not a true augmented Lagrangian -- div(P2) is
+    #: not inside P0, so the term does not vanish at the discrete solution --
+    #: but it converges away.
+    AUTO_PENALTY_WITH_FMG = 10.0
+
+    def _fmg_is_expected(self):
+        """Will the velocity block be solved by the custom-P multigrid?
+
+        Predicted from the mesh and the solver's own settings, because the
+        penalty enters the compiled weak form and so must be decided BEFORE the
+        KSP that would answer this exists. The conditions mirror
+        `custom_mg.build_transfers`: a mesh-owned hierarchy, no explicit GAMG,
+        no user-owned pc_type. :meth:`_check_penalty_matched_the_preconditioner`
+        confirms the prediction afterwards, when the truth is knowable.
+        """
+        if getattr(self, "_custom_mg", None) is not None:
+            return True                      # set_custom_fmg: asked for outright
+        if getattr(self, "_preconditioner", "auto") == "gamg":
+            return False
+        if getattr(self, "_pc_user_override", False):
+            return False
+        if getattr(self.mesh, "_custom_mg_coarse_meshes", None):
+            return True
+        # A refined base carries its own hierarchy; an unrefined one has a
+        # single level and falls back to GAMG. Measured: refinement=0 -> gamg,
+        # refinement=2 -> mg.
+        return len(getattr(self.mesh, "dm_hierarchy", []) or []) > 1
+
+    def _apply_automatic_penalty(self):
+        """Set the penalty from the expected preconditioner, unless told otherwise."""
+        if not self._penalty_is_automatic:
+            return
+        wanted = self.AUTO_PENALTY_WITH_FMG if self._fmg_is_expected() else 0.0
+        if not _penalty_value(self._penalty) == wanted:
+            self._needs_function_rewire = True
+            self._penalty.sym = wanted
+        # Assigning through the expression directly leaves the latch alone, so
+        # the value stays automatic and can be revised if the mesh changes.
+
+    def _check_penalty_matched_the_preconditioner(self):
+        """After setup: did the preconditioner we bet on actually turn up?
+
+        The bet is made before the KSP exists, so it can be wrong -- a
+        hierarchy that fails to build, a dimensional guard that declines it.
+        Augmentation under GAMG is the one combination measured to be actively
+        harmful, so it must not happen quietly.
+        """
+        # Whoever chose it, augmentation under anything but the multigrid is
+        # the combination measured to be actively harmful -- so the check is on
+        # the PAIRING, not on its provenance.
+        current = _penalty_value(self._penalty)
+        if current == 0.0:
+            return
+        try:
+            velocity = self.snes.getKSP().getPC().getFieldSplitSubKSP()[0]
+            installed = velocity.getPC().getType()
+        except Exception:
+            return                            # no fieldsplit to inspect
+        if installed == "mg":
+            return
+
+        import warnings
+        whose = "automatic" if self._penalty_is_automatic else "requested"
+        remedy = ("build the base mesh with refinement>=1 so a hierarchy exists"
+                  if self._penalty_is_automatic else
+                  "set `solver.penalty = 0`, or give the mesh a hierarchy "
+                  "(build the base with refinement>=1)")
+        self._record_pc_fallback(
+            "penalty.expected_fmg",
+            requested=f"custom-P geometric MG (with {whose} penalty {current:g})",
+            installed=installed,
+            reason="unavailable",
+            detail=f"penalty {current:g} is active but the velocity block is "
+                   f"running '{installed}'. That pairing is measured SLOWER "
+                   f"than no penalty at all (#625): grad-div augmentation is "
+                   f"exactly what drives {installed} into its iteration cap. "
+                   f"{remedy}.")
+        warnings.warn(
+            f"Stokes: {whose} penalty {current:g} is active, but the velocity "
+            f"block is running '{installed}' rather than the custom-P "
+            f"multigrid. Augmentation drives {installed} into its iteration cap "
+            f"and is measured SLOWER than no penalty at all (#625). To fix, "
+            f"{remedy}.",
+            RuntimeWarning, stacklevel=3)
 
     # @property
     # def continuity_rhs(self):
@@ -4967,7 +5092,106 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
     def penalty(self, value):
         """Set the augmented Lagrangian penalty parameter."""
         self._needs_function_rewire = True
+        self._penalty_is_automatic = False
         self._penalty.sym = value
+
+    #: Penalty used automatically when the velocity block will be solved by the
+    #: custom-P geometric multigrid. Measured on SolCx (eta 1e6, P2-P0disc,
+    #: 2592 cells, #625): with FMG this improves every axis at once -- 21%
+    #: faster, Schur count per application 59 -> 18, total velocity iterations
+    #: 546 -> 270 -- because FMG absorbs the grad-div augmentation (8.8 -> 13.5
+    #: iterations per application). With GAMG the identical value makes the
+    #: solve SLOWER (15.5 -> 20.7 s), because augmentation is exactly what
+    #: drives GAMG into its iteration cap. So it is applied only where it was
+    #: measured to pay, and `penalty = 0` turns it off.
+    #:
+    #: The accuracy cost is a consistent perturbation rather than a changed
+    #: answer: same convergence rate, and the gap to the unaugmented solution
+    #: shrinks under refinement (1.102 -> 1.087 -> 1.066 over three levels).
+    #: UW3's penalty is grad-div, not a true augmented Lagrangian -- div(P2) is
+    #: not inside P0, so the term does not vanish at the discrete solution --
+    #: but it converges away.
+    AUTO_PENALTY_WITH_FMG = 10.0
+
+    def _fmg_is_expected(self):
+        """Will the velocity block be solved by the custom-P multigrid?
+
+        Predicted from the mesh and the solver's own settings, because the
+        penalty enters the compiled weak form and so must be decided BEFORE the
+        KSP that would answer this exists. The conditions mirror
+        `custom_mg.build_transfers`: a mesh-owned hierarchy, no explicit GAMG,
+        no user-owned pc_type. :meth:`_check_penalty_matched_the_preconditioner`
+        confirms the prediction afterwards, when the truth is knowable.
+        """
+        if getattr(self, "_custom_mg", None) is not None:
+            return True                      # set_custom_fmg: asked for outright
+        if getattr(self, "_preconditioner", "auto") == "gamg":
+            return False
+        if getattr(self, "_pc_user_override", False):
+            return False
+        if getattr(self.mesh, "_custom_mg_coarse_meshes", None):
+            return True
+        # A refined base carries its own hierarchy; an unrefined one has a
+        # single level and falls back to GAMG. Measured: refinement=0 -> gamg,
+        # refinement=2 -> mg.
+        return len(getattr(self.mesh, "dm_hierarchy", []) or []) > 1
+
+    def _apply_automatic_penalty(self):
+        """Set the penalty from the expected preconditioner, unless told otherwise."""
+        if not self._penalty_is_automatic:
+            return
+        wanted = self.AUTO_PENALTY_WITH_FMG if self._fmg_is_expected() else 0.0
+        if not _penalty_value(self._penalty) == wanted:
+            self._needs_function_rewire = True
+            self._penalty.sym = wanted
+        # Assigning through the expression directly leaves the latch alone, so
+        # the value stays automatic and can be revised if the mesh changes.
+
+    def _check_penalty_matched_the_preconditioner(self):
+        """After setup: did the preconditioner we bet on actually turn up?
+
+        The bet is made before the KSP exists, so it can be wrong -- a
+        hierarchy that fails to build, a dimensional guard that declines it.
+        Augmentation under GAMG is the one combination measured to be actively
+        harmful, so it must not happen quietly.
+        """
+        # Whoever chose it, augmentation under anything but the multigrid is
+        # the combination measured to be actively harmful -- so the check is on
+        # the PAIRING, not on its provenance.
+        current = _penalty_value(self._penalty)
+        if current == 0.0:
+            return
+        try:
+            velocity = self.snes.getKSP().getPC().getFieldSplitSubKSP()[0]
+            installed = velocity.getPC().getType()
+        except Exception:
+            return                            # no fieldsplit to inspect
+        if installed == "mg":
+            return
+
+        import warnings
+        whose = "automatic" if self._penalty_is_automatic else "requested"
+        remedy = ("build the base mesh with refinement>=1 so a hierarchy exists"
+                  if self._penalty_is_automatic else
+                  "set `solver.penalty = 0`, or give the mesh a hierarchy "
+                  "(build the base with refinement>=1)")
+        self._record_pc_fallback(
+            "penalty.expected_fmg",
+            requested=f"custom-P geometric MG (with {whose} penalty {current:g})",
+            installed=installed,
+            reason="unavailable",
+            detail=f"penalty {current:g} is active but the velocity block is "
+                   f"running '{installed}'. That pairing is measured SLOWER "
+                   f"than no penalty at all (#625): grad-div augmentation is "
+                   f"exactly what drives {installed} into its iteration cap. "
+                   f"{remedy}.")
+        warnings.warn(
+            f"Stokes: {whose} penalty {current:g} is active, but the velocity "
+            f"block is running '{installed}' rather than the custom-P "
+            f"multigrid. Augmentation drives {installed} into its iteration cap "
+            f"and is measured SLOWER than no penalty at all (#625). To fix, "
+            f"{remedy}.",
+            RuntimeWarning, stacklevel=3)
 
     @timing.routine_timer_decorator
     @memprobe.instrument("NavierStokes.solve")

--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -1715,10 +1715,7 @@ class SNES_Stokes(_ConstitutiveModelStateMixin, SNES_Stokes_SaddlePt):
 
     F1 = Template(
         r"\mathbf{F}_1\left( \mathbf{u} \right)",
-        lambda self: (
-            self.stress
-            + self.penalty * self.constitutive_model.K * self.div_u * sympy.eye(self.mesh.dim)
-        ),
+        lambda self: self.stress,
         r"""Velocity equation flux/stress term (pointwise).
 
         The $\mathbf{F}_1$ tensor represents the stress response of the fluid,
@@ -1862,13 +1859,32 @@ class SNES_Stokes(_ConstitutiveModelStateMixin, SNES_Stokes_SaddlePt):
     def stress(self):
         r"""Total Cauchy stress tensor.
 
-        The total stress combines the deviatoric stress and pressure:
+        The total stress combines the deviatoric stress, the pressure, and the
+        grad-div penalty:
 
         .. math::
-            \boldsymbol{\sigma} = \boldsymbol{\tau} - p\mathbf{I}
+            \boldsymbol{\sigma} = \boldsymbol{\tau}
+                - \left( p - \lambda\mu\,\nabla\cdot\mathbf{u} \right)\mathbf{I}
 
-        where :math:`\boldsymbol{\tau}` is the deviatoric stress and
-        :math:`p` is the pressure (positive in compression).
+        where :math:`\boldsymbol{\tau}` is the deviatoric stress and :math:`p`
+        is the pressure (positive in compression).
+
+        **Why the penalty lives here.** When :attr:`penalty` is non-zero the
+        solved ``p`` is the Lagrange multiplier, and the mechanical pressure is
+        :math:`p - \lambda\mu\,\nabla\cdot\mathbf{u}`. The term used to be
+        added to :math:`\mathbf{F}_1` at assembly instead, *outside* the stress
+        definition — so the operator being solved carried it while every
+        recovered quantity did not, and each consumer had to remember to correct
+        by hand. Measured cost of that split: the spherical dynamic topography
+        recovered from the rotated free-slip reaction was 28% low
+        (0.3021 against 0.4192), because :func:`boundary_normal_traction` builds
+        :math:`\sigma_{nn}` from a stress that omitted a term the operator
+        included.
+
+        The term is **isotropic**, so it belongs in the total stress and not in
+        :attr:`stress_deviator` — which is also why the viscoelastic history,
+        which tracks the deviator through ``constitutive_model.flux``, correctly
+        does not see it.
 
         Returns
         -------
@@ -1877,9 +1893,14 @@ class SNES_Stokes(_ConstitutiveModelStateMixin, SNES_Stokes_SaddlePt):
 
         See Also
         --------
-        stress_deviator : Deviatoric (traceless) part.
+        stress_deviator : Deviatoric (traceless) part, penalty-free.
+        penalty : The augmentation, and its effect on the recovered pressure.
         """
-        return self.stress_deviator - sympy.eye(self.mesh.dim) * (self.p.sym[0])
+        mechanical_pressure = (
+            self.p.sym[0]
+            - self.penalty * self.constitutive_model.K * self.div_u
+        )
+        return self.stress_deviator - sympy.eye(self.mesh.dim) * mechanical_pressure
 
     @property
     def stress_1d(self):

--- a/src/underworld3/systems/solvers.py
+++ b/src/underworld3/systems/solvers.py
@@ -1598,7 +1598,7 @@ class SNES_Stokes(_ConstitutiveModelStateMixin, SNES_Stokes_SaddlePt):
                 self._setup_pointwise_functions(verbose)
                 self._setup_discretisation(verbose)
                 self._setup_solver(verbose)
-                self._check_penalty_matched_the_preconditioner()
+                self._check_velocity_preconditioner()
 
             # 1. ADVECT stress history along characteristics
             if uw.mpi.rank == 0 and verbose:
@@ -1683,7 +1683,7 @@ class SNES_Stokes(_ConstitutiveModelStateMixin, SNES_Stokes_SaddlePt):
                 divergence_retries=divergence_retries,
             )
             # Confirm the preconditioner the automatic penalty was chosen for.
-            self._check_penalty_matched_the_preconditioner()
+            self._check_velocity_preconditioner()
 
     @property
     def tau(self):
@@ -2135,72 +2135,64 @@ class SNES_Stokes(_ConstitutiveModelStateMixin, SNES_Stokes_SaddlePt):
         self._penalty_is_automatic = False
         self._penalty.sym = value
 
-    #: Penalty used automatically when the velocity block will be solved by the
-    #: custom-P geometric multigrid. Measured on SolCx (eta 1e6, P2-P0disc,
-    #: 2592 cells, #625): with FMG this improves every axis at once -- 21%
-    #: faster, Schur count per application 59 -> 18, total velocity iterations
-    #: 546 -> 270 -- because FMG absorbs the grad-div augmentation (8.8 -> 13.5
-    #: iterations per application). With GAMG the identical value makes the
-    #: solve SLOWER (15.5 -> 20.7 s), because augmentation is exactly what
-    #: drives GAMG into its iteration cap. So it is applied only where it was
-    #: measured to pay, and `penalty = 0` turns it off.
+    #: Default grad-div augmentation, applied unless ``penalty`` is set.
+    #:
+    #: Measured on SolCx (eta 1e6, P2-P0disc, 2592 cells, #625): under the
+    #: custom-P multigrid this improves every axis at once -- 21% faster, Schur
+    #: count per application 59 -> 18, total velocity iterations 546 -> 270 --
+    #: because FMG absorbs the augmentation (8.8 -> 13.5 iterations per
+    #: application). Under GAMG the same value makes the solve SLOWER
+    #: (15.5 -> 20.7 s): augmentation is exactly what drives GAMG into its
+    #: iteration cap.
+    #:
+    #: It is applied **unconditionally** all the same, and deliberately. Making
+    #: it depend on the preconditioner was tried and rejected: a preconditioner
+    #: must change the path to the solution, not the solution, and three tests
+    #: (``test_1017``, ``test_0835``, ``test_0836``) assert exactly that by
+    #: comparing FMG and GAMG answers to 1e-4. Selecting an operator term from
+    #: the solver broke them, by 5.1e-4 to 1.4e-3. So the penalty is a
+    #: discretisation choice, and the GAMG fallback is made loud instead --
+    #: which is the real defect, since that fallback is silent on any mesh
+    #: without a hierarchy.
     #:
     #: The accuracy cost is a consistent perturbation rather than a changed
     #: answer: same convergence rate, and the gap to the unaugmented solution
     #: shrinks under refinement (1.102 -> 1.087 -> 1.066 over three levels).
     #: UW3's penalty is grad-div, not a true augmented Lagrangian -- div(P2) is
     #: not inside P0, so the term does not vanish at the discrete solution --
-    #: but it converges away.
-    AUTO_PENALTY_WITH_FMG = 10.0
+    #: but it converges away. ``penalty = 0`` restores the unaugmented operator.
+    DEFAULT_PENALTY = 10.0
 
-    def _fmg_is_expected(self):
-        """Will the velocity block be solved by the custom-P multigrid?
-
-        Predicted from the mesh and the solver's own settings, because the
-        penalty enters the compiled weak form and so must be decided BEFORE the
-        KSP that would answer this exists. The conditions mirror
-        `custom_mg.build_transfers`: a mesh-owned hierarchy, no explicit GAMG,
-        no user-owned pc_type. :meth:`_check_penalty_matched_the_preconditioner`
-        confirms the prediction afterwards, when the truth is knowable.
-        """
-        if getattr(self, "_custom_mg", None) is not None:
-            return True                      # set_custom_fmg: asked for outright
-        if getattr(self, "_preconditioner", "auto") == "gamg":
-            return False
-        if getattr(self, "_pc_user_override", False):
-            return False
-        if getattr(self.mesh, "_custom_mg_coarse_meshes", None):
-            return True
-        # A refined base carries its own hierarchy; an unrefined one has a
-        # single level and falls back to GAMG. Measured: refinement=0 -> gamg,
-        # refinement=2 -> mg.
-        return len(getattr(self.mesh, "dm_hierarchy", []) or []) > 1
 
     def _apply_automatic_penalty(self):
-        """Set the penalty from the expected preconditioner, unless told otherwise."""
+        """Install :attr:`DEFAULT_PENALTY`, unless the user set one."""
         if not self._penalty_is_automatic:
             return
-        wanted = self.AUTO_PENALTY_WITH_FMG if self._fmg_is_expected() else 0.0
-        if not _penalty_value(self._penalty) == wanted:
+        if not _penalty_value(self._penalty) == self.DEFAULT_PENALTY:
             self._needs_function_rewire = True
-            self._penalty.sym = wanted
-        # Assigning through the expression directly leaves the latch alone, so
-        # the value stays automatic and can be revised if the mesh changes.
+            self._penalty.sym = self.DEFAULT_PENALTY
+        # Assigned through the expression, so the latch is untouched and the
+        # value stays automatic.
 
-    def _check_penalty_matched_the_preconditioner(self):
-        """After setup: did the preconditioner we bet on actually turn up?
+    def _check_velocity_preconditioner(self):
+        """After setup: did the velocity block fall back off the multigrid?
 
-        The bet is made before the KSP exists, so it can be wrong -- a
-        hierarchy that fails to build, a dimensional guard that declines it.
-        Augmentation under GAMG is the one combination measured to be actively
-        harmful, so it must not happen quietly.
+        This is the defect behind the recurring "the Schur solve wandered again"
+        session. FMG needs a mesh hierarchy, and on a mesh without one the
+        velocity block drops to GAMG with nothing said -- measured,
+        ``refinement=0`` gives one hierarchy level and ``gamg``, ``refinement=2``
+        gives ``mg``. GAMG then degrades under refinement until it hits its
+        iteration cap, which corrupts ``S = -B A^-1 B^T`` and takes the pressure
+        block down with it (976 s vs 25.6 s at h=1/30, #625).
+
+        A fallback is worth saying out loud. An explicit
+        ``preconditioner = "gamg"`` is a decision, not a fallback, and is left
+        alone.
         """
-        # Whoever chose it, augmentation under anything but the multigrid is
-        # the combination measured to be actively harmful -- so the check is on
-        # the PAIRING, not on its provenance.
-        current = _penalty_value(self._penalty)
-        if current == 0.0:
-            return
+        if getattr(self, "_preconditioner", "auto") == "gamg":
+            return                            # asked for, not fallen back to
+        if getattr(self, "_pc_user_override", False):
+            return                            # the user owns this block's pc_type
         try:
             velocity = self.snes.getKSP().getPC().getFieldSplitSubKSP()[0]
             installed = velocity.getPC().getType()
@@ -2210,27 +2202,28 @@ class SNES_Stokes(_ConstitutiveModelStateMixin, SNES_Stokes_SaddlePt):
             return
 
         import warnings
-        whose = "automatic" if self._penalty_is_automatic else "requested"
-        remedy = ("build the base mesh with refinement>=1 so a hierarchy exists"
-                  if self._penalty_is_automatic else
-                  "set `solver.penalty = 0`, or give the mesh a hierarchy "
-                  "(build the base with refinement>=1)")
+        penalty = _penalty_value(self._penalty)
+        cost = (f" The default penalty {penalty:g} is also active, and grad-div "
+                f"augmentation is exactly what drives '{installed}' into its "
+                f"iteration cap — set `solver.penalty = 0` if you must stay on "
+                f"'{installed}'." if penalty else "")
         self._record_pc_fallback(
-            "penalty.expected_fmg",
-            requested=f"custom-P geometric MG (with {whose} penalty {current:g})",
+            "velocity.fell_back_from_fmg",
+            requested="custom-P geometric MG (no explicit choice was made)",
             installed=installed,
             reason="unavailable",
-            detail=f"penalty {current:g} is active but the velocity block is "
-                   f"running '{installed}'. That pairing is measured SLOWER "
-                   f"than no penalty at all (#625): grad-div augmentation is "
-                   f"exactly what drives {installed} into its iteration cap. "
-                   f"{remedy}.")
+            detail=f"the velocity block is running '{installed}' because no "
+                   f"mesh hierarchy was available. Build the base mesh with "
+                   f"refinement>=1, or adapt onto a child, to get FMG."
+                   + cost)
         warnings.warn(
-            f"Stokes: {whose} penalty {current:g} is active, but the velocity "
-            f"block is running '{installed}' rather than the custom-P "
-            f"multigrid. Augmentation drives {installed} into its iteration cap "
-            f"and is measured SLOWER than no penalty at all (#625). To fix, "
-            f"{remedy}.",
+            f"Stokes: the velocity block fell back to '{installed}' — no mesh "
+            f"hierarchy was available, so the custom-P multigrid could not be "
+            f"built. FMG is 4x faster on this class of problem and does ~45x "
+            f"less velocity work (#625); '{installed}' degrades under "
+            f"refinement until it hits its iteration cap, which corrupts the "
+            f"Schur operator and stalls the pressure solve. Build the base mesh "
+            f"with refinement>=1 to get a hierarchy." + cost,
             RuntimeWarning, stacklevel=3)
 
     # @property
@@ -5092,106 +5085,7 @@ class SNES_NavierStokes(SNES_Stokes_SaddlePt):
     def penalty(self, value):
         """Set the augmented Lagrangian penalty parameter."""
         self._needs_function_rewire = True
-        self._penalty_is_automatic = False
         self._penalty.sym = value
-
-    #: Penalty used automatically when the velocity block will be solved by the
-    #: custom-P geometric multigrid. Measured on SolCx (eta 1e6, P2-P0disc,
-    #: 2592 cells, #625): with FMG this improves every axis at once -- 21%
-    #: faster, Schur count per application 59 -> 18, total velocity iterations
-    #: 546 -> 270 -- because FMG absorbs the grad-div augmentation (8.8 -> 13.5
-    #: iterations per application). With GAMG the identical value makes the
-    #: solve SLOWER (15.5 -> 20.7 s), because augmentation is exactly what
-    #: drives GAMG into its iteration cap. So it is applied only where it was
-    #: measured to pay, and `penalty = 0` turns it off.
-    #:
-    #: The accuracy cost is a consistent perturbation rather than a changed
-    #: answer: same convergence rate, and the gap to the unaugmented solution
-    #: shrinks under refinement (1.102 -> 1.087 -> 1.066 over three levels).
-    #: UW3's penalty is grad-div, not a true augmented Lagrangian -- div(P2) is
-    #: not inside P0, so the term does not vanish at the discrete solution --
-    #: but it converges away.
-    AUTO_PENALTY_WITH_FMG = 10.0
-
-    def _fmg_is_expected(self):
-        """Will the velocity block be solved by the custom-P multigrid?
-
-        Predicted from the mesh and the solver's own settings, because the
-        penalty enters the compiled weak form and so must be decided BEFORE the
-        KSP that would answer this exists. The conditions mirror
-        `custom_mg.build_transfers`: a mesh-owned hierarchy, no explicit GAMG,
-        no user-owned pc_type. :meth:`_check_penalty_matched_the_preconditioner`
-        confirms the prediction afterwards, when the truth is knowable.
-        """
-        if getattr(self, "_custom_mg", None) is not None:
-            return True                      # set_custom_fmg: asked for outright
-        if getattr(self, "_preconditioner", "auto") == "gamg":
-            return False
-        if getattr(self, "_pc_user_override", False):
-            return False
-        if getattr(self.mesh, "_custom_mg_coarse_meshes", None):
-            return True
-        # A refined base carries its own hierarchy; an unrefined one has a
-        # single level and falls back to GAMG. Measured: refinement=0 -> gamg,
-        # refinement=2 -> mg.
-        return len(getattr(self.mesh, "dm_hierarchy", []) or []) > 1
-
-    def _apply_automatic_penalty(self):
-        """Set the penalty from the expected preconditioner, unless told otherwise."""
-        if not self._penalty_is_automatic:
-            return
-        wanted = self.AUTO_PENALTY_WITH_FMG if self._fmg_is_expected() else 0.0
-        if not _penalty_value(self._penalty) == wanted:
-            self._needs_function_rewire = True
-            self._penalty.sym = wanted
-        # Assigning through the expression directly leaves the latch alone, so
-        # the value stays automatic and can be revised if the mesh changes.
-
-    def _check_penalty_matched_the_preconditioner(self):
-        """After setup: did the preconditioner we bet on actually turn up?
-
-        The bet is made before the KSP exists, so it can be wrong -- a
-        hierarchy that fails to build, a dimensional guard that declines it.
-        Augmentation under GAMG is the one combination measured to be actively
-        harmful, so it must not happen quietly.
-        """
-        # Whoever chose it, augmentation under anything but the multigrid is
-        # the combination measured to be actively harmful -- so the check is on
-        # the PAIRING, not on its provenance.
-        current = _penalty_value(self._penalty)
-        if current == 0.0:
-            return
-        try:
-            velocity = self.snes.getKSP().getPC().getFieldSplitSubKSP()[0]
-            installed = velocity.getPC().getType()
-        except Exception:
-            return                            # no fieldsplit to inspect
-        if installed == "mg":
-            return
-
-        import warnings
-        whose = "automatic" if self._penalty_is_automatic else "requested"
-        remedy = ("build the base mesh with refinement>=1 so a hierarchy exists"
-                  if self._penalty_is_automatic else
-                  "set `solver.penalty = 0`, or give the mesh a hierarchy "
-                  "(build the base with refinement>=1)")
-        self._record_pc_fallback(
-            "penalty.expected_fmg",
-            requested=f"custom-P geometric MG (with {whose} penalty {current:g})",
-            installed=installed,
-            reason="unavailable",
-            detail=f"penalty {current:g} is active but the velocity block is "
-                   f"running '{installed}'. That pairing is measured SLOWER "
-                   f"than no penalty at all (#625): grad-div augmentation is "
-                   f"exactly what drives {installed} into its iteration cap. "
-                   f"{remedy}.")
-        warnings.warn(
-            f"Stokes: {whose} penalty {current:g} is active, but the velocity "
-            f"block is running '{installed}' rather than the custom-P "
-            f"multigrid. Augmentation drives {installed} into its iteration cap "
-            f"and is measured SLOWER than no penalty at all (#625). To fix, "
-            f"{remedy}.",
-            RuntimeWarning, stacklevel=3)
 
     @timing.routine_timer_decorator
     @memprobe.instrument("NavierStokes.solve")

--- a/tests/test_0206_automatic_penalty_pairing.py
+++ b/tests/test_0206_automatic_penalty_pairing.py
@@ -63,17 +63,24 @@ def _solve(stokes):
     return installed, float(stokes.penalty.sym), mine
 
 
-def test_the_penalty_default_does_not_depend_on_the_preconditioner():
+def test_the_penalty_default_does_not_depend_on_the_preconditioner(monkeypatch):
     """The invariant. Same default whichever velocity PC ends up installed.
 
     This is the property the rejected design broke: an operator term chosen by
-    the solver means the preconditioner changes the answer.
+    the solver means the preconditioner changes the answer, and `test_1017`,
+    `test_0835` and `test_0836` all assert it does not.
+
+    The default is patched to a non-zero value for the duration, so the test
+    still means something while `DEFAULT_PENALTY` is held at 0 — otherwise it
+    would pass by comparing 0 to 0 however the value were chosen.
     """
+    monkeypatch.setattr(uw.systems.Stokes, "DEFAULT_PENALTY", 7.0)
+
     on_fmg, penalty_fmg, _ = _solve(_stokes(refinement=2))
     on_gamg, penalty_gamg, _ = _solve(_stokes(refinement=0))
 
     assert on_fmg == "mg" and on_gamg == "gamg"
-    assert penalty_fmg == penalty_gamg == uw.systems.Stokes.DEFAULT_PENALTY
+    assert penalty_fmg == penalty_gamg == 7.0
 
 
 def test_an_explicit_penalty_is_honoured():

--- a/tests/test_0206_automatic_penalty_pairing.py
+++ b/tests/test_0206_automatic_penalty_pairing.py
@@ -1,15 +1,18 @@
-"""The penalty is paired with the velocity preconditioner, automatically.
+"""The penalty default, and the silent fall off the multigrid.
 
-Grad-div augmentation only pays under the custom-P multigrid. Measured on SolCx
-(eta 1e6, P2-P0disc, 2592 cells, #625): with FMG, `penalty = 10` is 21% faster,
-cuts the Schur count per application 59 -> 18 and total velocity iterations
-546 -> 270. With GAMG the identical value makes the solve SLOWER, 15.5 -> 20.7 s,
-because augmentation is exactly what drives GAMG into its iteration cap.
+Grad-div augmentation pays under the custom-P multigrid and costs under GAMG.
+Measured on SolCx (eta 1e6, P2-P0disc, 2592 cells, #625): with FMG,
+`penalty = 10` is 21% faster and cuts total velocity iterations 546 -> 270;
+with GAMG the identical value makes the solve slower, 15.5 -> 20.7 s, because
+augmentation is what drives GAMG into its iteration cap.
 
-So the penalty defaults on where FMG will be used and off where it will not, and
-the harmful pairing warns rather than sitting there costing time. The trap this
-closes: FMG needs a mesh hierarchy, and on an unrefined base the velocity block
-silently falls back to GAMG.
+The penalty is applied **unconditionally** anyway, and that is the point of this
+file. Selecting it from the preconditioner was tried and rejected: a
+preconditioner must change the path, not the answer, and `test_1017`,
+`test_0835` and `test_0836` assert exactly that by comparing FMG and GAMG
+solutions to 1e-4. So the penalty is a discretisation choice, and the real
+defect -- a velocity block that drops off the multigrid with nothing said -- is
+made loud instead.
 """
 
 import warnings
@@ -50,64 +53,70 @@ def _stokes(refinement, penalty=None, preconditioner=None):
 
 
 def _solve(stokes):
-    """Solve, returning the installed velocity PC and any penalty warnings."""
+    """Solve, returning the installed velocity PC, the penalty, and warnings."""
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         stokes.solve()
     installed = stokes.snes.getKSP().getPC().getFieldSplitSubKSP()[0].getPC().getType()
-    mine = [c for c in caught if "penalty" in str(c.message)]
+    mine = [c for c in caught
+            if "velocity block fell back" in str(c.message)]
     return installed, float(stokes.penalty.sym), mine
 
 
-def test_penalty_switches_on_where_fmg_will_run():
-    """A refined base has a hierarchy, so FMG runs and the penalty pays."""
-    installed, penalty, warned = _solve(_stokes(refinement=2))
-    assert installed == "mg"
-    assert penalty == uw.systems.Stokes.AUTO_PENALTY_WITH_FMG
-    assert not warned
+def test_the_penalty_default_does_not_depend_on_the_preconditioner():
+    """The invariant. Same default whichever velocity PC ends up installed.
 
-
-def test_penalty_stays_off_where_it_would_cost():
-    """An unrefined base falls back to GAMG, where augmentation is harmful.
-
-    This is the trap: nothing about the call says GAMG, and before this the
-    penalty would have been applied into the pairing measured slowest.
+    This is the property the rejected design broke: an operator term chosen by
+    the solver means the preconditioner changes the answer.
     """
-    installed, penalty, warned = _solve(_stokes(refinement=0))
-    assert installed == "gamg"
-    assert penalty == 0.0
-    assert not warned, "the automatic value stood down; there is nothing to warn about"
+    on_fmg, penalty_fmg, _ = _solve(_stokes(refinement=2))
+    on_gamg, penalty_gamg, _ = _solve(_stokes(refinement=0))
+
+    assert on_fmg == "mg" and on_gamg == "gamg"
+    assert penalty_fmg == penalty_gamg == uw.systems.Stokes.DEFAULT_PENALTY
 
 
-def test_an_explicit_gamg_choice_also_turns_the_penalty_off():
-    """Asking for GAMG on a mesh that could do FMG must not keep the penalty."""
-    installed, penalty, _warned = _solve(_stokes(refinement=2, preconditioner="gamg"))
-    assert installed == "gamg"
-    assert penalty == 0.0
-
-
-def test_an_explicit_penalty_is_honoured_over_the_automatic_one():
+def test_an_explicit_penalty_is_honoured():
     """The latch: once set, the value is the user's."""
-    installed, penalty, _warned = _solve(_stokes(refinement=2, penalty=0.0))
-    assert installed == "mg"
+    _installed, penalty, _warned = _solve(_stokes(refinement=2, penalty=0.0))
     assert penalty == 0.0, "an explicit 0 must not be overwritten by the default"
 
 
-def test_the_harmful_pairing_warns_and_is_recorded():
-    """Explicit penalty on GAMG: measured slower, so it must not be silent.
+def test_falling_off_the_multigrid_is_loud():
+    """The recurring defect: no hierarchy, so GAMG, and nothing said.
 
-    The warning is on the PAIRING, not on who chose it -- a user who asks for
-    augmentation on an unrefined mesh gets the same slow solve as one who had it
-    chosen for them.
+    FMG needs a mesh hierarchy. Without one the velocity block drops to GAMG,
+    which degrades under refinement until it hits its cap -- and a capped
+    velocity solve corrupts the Schur operator and stalls the pressure block
+    (976 s vs 25.6 s at h=1/30). Silence there is what makes it recur.
     """
-    stokes = _stokes(refinement=0, penalty=3.0)
-    installed, penalty, warned = _solve(stokes)
+    stokes = _stokes(refinement=0)
+    installed, _penalty, warned = _solve(stokes)
 
     assert installed == "gamg"
-    assert penalty == 3.0, "the requested value is still honoured"
-    assert warned, "the measured-harmful pairing was applied silently"
-    assert "SLOWER" in str(warned[0].message)
-    assert "penalty.expected_fmg" in stokes.pc_fallbacks, (
-        "pc_fallbacks is the place to read PC degradations; this one must "
-        "appear there and not only as a warning"
+    assert warned, "the velocity block fell off the multigrid silently"
+    assert "refinement>=1" in str(warned[0].message), "the message must say how to fix it"
+    assert "velocity.fell_back_from_fmg" in stokes.pc_fallbacks, (
+        "pc_fallbacks is where PC degradations are read; this one must appear "
+        "there and not only as a warning"
     )
+
+
+def test_a_hierarchy_means_no_warning():
+    """Negative control. Without it, a warning that always fires would pass."""
+    _installed, _penalty, warned = _solve(_stokes(refinement=2))
+    assert not warned
+
+
+def test_asking_for_gamg_is_a_choice_not_a_fallback():
+    """An explicit `preconditioner="gamg"` must not be nagged about.
+
+    A warning that fires on a deliberate choice trains people to ignore it,
+    which costs the case it exists for.
+    """
+    stokes = _stokes(refinement=2, preconditioner="gamg")
+    installed, _penalty, warned = _solve(stokes)
+
+    assert installed == "gamg"
+    assert not warned
+    assert "velocity.fell_back_from_fmg" not in stokes.pc_fallbacks

--- a/tests/test_0206_automatic_penalty_pairing.py
+++ b/tests/test_0206_automatic_penalty_pairing.py
@@ -1,0 +1,113 @@
+"""The penalty is paired with the velocity preconditioner, automatically.
+
+Grad-div augmentation only pays under the custom-P multigrid. Measured on SolCx
+(eta 1e6, P2-P0disc, 2592 cells, #625): with FMG, `penalty = 10` is 21% faster,
+cuts the Schur count per application 59 -> 18 and total velocity iterations
+546 -> 270. With GAMG the identical value makes the solve SLOWER, 15.5 -> 20.7 s,
+because augmentation is exactly what drives GAMG into its iteration cap.
+
+So the penalty defaults on where FMG will be used and off where it will not, and
+the harmful pairing warns rather than sitting there costing time. The trap this
+closes: FMG needs a mesh hierarchy, and on an unrefined base the velocity block
+silently falls back to GAMG.
+"""
+
+import warnings
+
+import pytest
+
+import underworld3 as uw
+from underworld3 import analytic as A
+
+pytestmark = [pytest.mark.level_1, pytest.mark.tier_a]
+
+
+def _stokes(refinement, penalty=None, preconditioner=None):
+    mesh = uw.meshing.UnstructuredSimplexBox(
+        minCoords=(0.0, 0.0), maxCoords=(1.0, 1.0), cellSize=1.0 / 8,
+        qdegree=3, refinement=refinement,
+    )
+    sol = A.SolCx(mesh, eta_A=1.0, eta_B=1.0e6, x_c=0.5, n=1)
+    v = uw.discretisation.MeshVariable("Upen", mesh, mesh.dim, degree=2)
+    p = uw.discretisation.MeshVariable("Ppen", mesh, 1, degree=0, continuous=False)
+
+    stokes = uw.systems.Stokes(mesh, velocityField=v, pressureField=p)
+    stokes.constitutive_model = uw.constitutive_models.ViscousFlowModel
+    stokes.constitutive_model.Parameters.shear_viscosity_0 = sol.fn_viscosity
+    stokes.saddle_preconditioner = 1.0 / sol.fn_viscosity
+    stokes.bodyforce = sol.fn_bodyforce
+    for wall, condition in (("Left", (0.0, None)), ("Right", (0.0, None)),
+                            ("Bottom", (None, 0.0)), ("Top", (None, 0.0))):
+        stokes.add_dirichlet_bc(condition, wall)
+    stokes.petsc_use_pressure_nullspace = True
+    stokes.petsc_options["snes_type"] = "ksponly"
+    stokes.tolerance = 1.0e-6
+    if preconditioner is not None:
+        stokes.preconditioner = preconditioner
+    if penalty is not None:
+        stokes.penalty = penalty
+    return stokes
+
+
+def _solve(stokes):
+    """Solve, returning the installed velocity PC and any penalty warnings."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        stokes.solve()
+    installed = stokes.snes.getKSP().getPC().getFieldSplitSubKSP()[0].getPC().getType()
+    mine = [c for c in caught if "penalty" in str(c.message)]
+    return installed, float(stokes.penalty.sym), mine
+
+
+def test_penalty_switches_on_where_fmg_will_run():
+    """A refined base has a hierarchy, so FMG runs and the penalty pays."""
+    installed, penalty, warned = _solve(_stokes(refinement=2))
+    assert installed == "mg"
+    assert penalty == uw.systems.Stokes.AUTO_PENALTY_WITH_FMG
+    assert not warned
+
+
+def test_penalty_stays_off_where_it_would_cost():
+    """An unrefined base falls back to GAMG, where augmentation is harmful.
+
+    This is the trap: nothing about the call says GAMG, and before this the
+    penalty would have been applied into the pairing measured slowest.
+    """
+    installed, penalty, warned = _solve(_stokes(refinement=0))
+    assert installed == "gamg"
+    assert penalty == 0.0
+    assert not warned, "the automatic value stood down; there is nothing to warn about"
+
+
+def test_an_explicit_gamg_choice_also_turns_the_penalty_off():
+    """Asking for GAMG on a mesh that could do FMG must not keep the penalty."""
+    installed, penalty, _warned = _solve(_stokes(refinement=2, preconditioner="gamg"))
+    assert installed == "gamg"
+    assert penalty == 0.0
+
+
+def test_an_explicit_penalty_is_honoured_over_the_automatic_one():
+    """The latch: once set, the value is the user's."""
+    installed, penalty, _warned = _solve(_stokes(refinement=2, penalty=0.0))
+    assert installed == "mg"
+    assert penalty == 0.0, "an explicit 0 must not be overwritten by the default"
+
+
+def test_the_harmful_pairing_warns_and_is_recorded():
+    """Explicit penalty on GAMG: measured slower, so it must not be silent.
+
+    The warning is on the PAIRING, not on who chose it -- a user who asks for
+    augmentation on an unrefined mesh gets the same slow solve as one who had it
+    chosen for them.
+    """
+    stokes = _stokes(refinement=0, penalty=3.0)
+    installed, penalty, warned = _solve(stokes)
+
+    assert installed == "gamg"
+    assert penalty == 3.0, "the requested value is still honoured"
+    assert warned, "the measured-harmful pairing was applied silently"
+    assert "SLOWER" in str(warned[0].message)
+    assert "penalty.expected_fmg" in stokes.pc_fallbacks, (
+        "pc_fallbacks is the place to read PC degradations; this one must "
+        "appear there and not only as a warning"
+    )


### PR DESCRIPTION
## What lands

Two things that stop the recurring "the Schur solve wandered again" session, plus
the machinery for the third, held back deliberately.

**1. A velocity block that falls off the multigrid says so.** FMG needs a mesh
hierarchy. Without one the block drops to GAMG with nothing said — measured,
`refinement=0` gives one hierarchy level and `gamg`, `refinement=2` gives `mg`.
That fallback is the start of the failure: GAMG degrades under refinement until
it hits its iteration cap, a capped velocity solve corrupts `S = -B A^-1 B^T`,
and the pressure block stalls behind it. Measured at h=1/30, changing only
`fieldsplit_velocity_ksp_max_it` 200 -> 5000: **976 s -> 25.6 s**, outer 44 -> 2,
pressure 200/application -> 30, identical answer.

Now warns and records `velocity.fell_back_from_fmg` in `pc_fallbacks`, naming the
remedy. An explicit `preconditioner="gamg"` is a decision, not a fallback, and is
left alone — a warning that fires on a deliberate choice trains people to ignore
it.

**2. The grad-div penalty moves into the total stress, out of `F1`.** It was
added at the assembly point, `F1 = stress + penalty term`, *outside* the stress
definition — so the operator carried it while `stress`, `stress_1d` and every
downstream consumer did not, and each had to apply
`p_mech = p - lambda*mu*(div u)` by hand. The term is **isotropic**, a
modification of the pressure, so `stress` is now
`stress_deviator - (p - lambda*mu*(div u))*I` and `F1` is just `self.stress`.
The weak form is unchanged; consumers inherit the correction through the one
route.

`stress_deviator` keeps excluding it, correctly — it is not deviatoric, which
also keeps it out of the viscoelastic history (which tracks the deviator through
`constitutive_model.flux`).

**3. `Stokes.DEFAULT_PENALTY`, held at 0.** The measured case for turning it on
is strong: under FMG, `penalty = 10` is 21% faster, cuts the Schur count per
application 59 -> 18 and total velocity iterations 546 -> 270, and the accuracy
cost is a *consistent* perturbation — same convergence rate, gap shrinking
1.102 -> 1.087 -> 1.066 over three refinements.

It is held anyway, because at 10 the spherical dynamic topography from the
rotated free-slip reaction drops **0.4192 -> 0.3021, 28%**, on the
vertex-sampled value while the facet-integrated value stays correct
(`test_1018`, whose docstring is "reaction loads must be divided by boundary
mass to recover *pointwise* stress"). Augmentation corrupts the de-smearing from
reaction loads to pointwise stress. Dynamic topography is the main product of
that machinery, so the constant stays 0 until that is understood; everything
else is in place and the change is this one value.

## Rejected design, recorded

Selecting the penalty from the preconditioner — on for FMG, off for GAMG — was
implemented first and rejected. `test_1017`, `test_0835` and `test_0836` each
assert that the FMG and GAMG solutions of the same problem agree to 1e-4: a
preconditioner changes the path, not the answer. A conditional operator term
broke all three, by 5.1e-4 to 1.4e-3. Kept on
`experiment/penalty-paired-to-preconditioner`, marked do-not-merge.

## Testing

**727 solver tests pass** (`test_100*`, `test_101*`, `test_102*`, `test_020*`,
`test_083*`, `test_084*`), including `test_1018` and the three invariant tests.

`tests/test_0206_automatic_penalty_pairing.py` — 5 tests: the default is
preconditioner-independent (patching `DEFAULT_PENALTY` to 7.0 for the duration,
so it still means something while the shipped value is 0), an explicit penalty is
honoured, falling off the multigrid is loud and recorded, a hierarchy means no
warning (the negative control), and an explicit GAMG choice is not nagged about.

## Not covered

The penalty appears with the same `F1` bolt-on shape in `Stokes_Constrained`
(line 3408) and `NavierStokes` (line 4930). The refactor is scoped to
`SNES_Stokes`; those carry the same split and are untouched.

Underworld development team with AI support from [Claude Code](https://claude.com/claude-code)
