### PR TITLE
Destroy temporary PETSc field decompositions after reaction assembly

### DIFF
--- a/src/underworld3/cython/petsc_generic_snes_solvers.pyx
+++ b/src/underworld3/cython/petsc_generic_snes_solvers.pyx
@@ -3126,9 +3126,17 @@ class SolverBaseClass(uw_object):
                     gvec.restoreSubVector(self._subdict[name][0], sgvec)
             else:
                 _names, _iss, _subdms = self.dm.createFieldDecomposition()
-                sgvec = gvec.getSubVector(_iss[0])
-                _subdms[0].localToGlobal(self.Unknowns.u.vec, sgvec)
-                gvec.restoreSubVector(_iss[0], sgvec)
+                try:
+                    sgvec = gvec.getSubVector(_iss[0])
+                    try:
+                        _subdms[0].localToGlobal(self.Unknowns.u.vec, sgvec)
+                    finally:
+                        gvec.restoreSubVector(_iss[0], sgvec)
+                finally:
+                    for _is in _iss:
+                        _is.destroy()
+                    for _subdm in _subdms:
+                        _subdm.destroy()
 
             self.dm.globalToLocal(gvec, xlocal)
 


### PR DESCRIPTION
## Problem

`SolverBaseClass._assemble_volume_reaction()` creates a PETSc field decomposition for every single-field reaction assembly so that the unknown local vector is transferred through field 0's sub-DM. The subvector was restored, but the temporary PETSc `IS` and sub-DM objects were not destroyed.

Reaction-backed APIs such as `boundary_flux()`, `boundary_flux_integral()`, and `boundary_flux_field()` can run every timestep. In a 48-rank Zhong thermal-convection diagnostic this produced persistent aggregate RSS growth. This is shared single-field reaction infrastructure, not a SUPG-specific problem.

## Fix

Retain the sub-DM transfer required by vector semi-Lagrangian fields, but use nested `try/finally` blocks to:

1. always restore the borrowed subvector;
2. destroy every temporary PETSc index set;
3. destroy every temporary sub-DM;
4. perform cleanup when local-to-global transfer raises.

No solver formulation, boundary-flux calculation, or numerical tolerance changes.

## Memory validation

All memory values are aggregate RSS across MPI ranks.

| Test | UW3 | Resolution / ranks | Result |
| --- | --- | --- | --- |
| Coupled pre-fix gate | pre-fix | `1/32`, 48 ranks, 120 steps | late slope `344.109 MiB/step`; diagnostic median `66.709 MiB/step` |
| Repeated two-boundary integral | `2466adb2` | `1/16`, 16 ranks, 121 calls | post-warm-up `0.125 MiB/call`; final-20 `0.032 MiB/call`; final median delta `0` |
| Diagnostics-only, same production mesh | `2466adb2` | `1/32`, 48 ranks, 120 calls | late slope `0.263 MiB/step`; diagnostic median `0.270 MiB/step` |
| Coupled post-fix confirmation | `2466adb2` | `1/16`, 16 ranks, 40 steps | overall `4.584 MiB/step`; late `2.775 MiB/step`; peak `9.77 GiB` |

The same-resolution diagnostics-only test disables thermal and Stokes work and exercises the reaction-backed upper/lower flux diagnostics. Its early-to-late slope declines by 26%, with zero retained thermal, Stokes, and between-step increments.

## Correctness validation

Run on Gadi with Open MPI 4.1.7:

- serial `tests/test_1019_boundary_flux.py tests/test_1120_SLVectorCartesian.py`: **18 passed**;
- two-rank `tests/parallel/test_1065_boundary_flux_parallel.py tests/test_1120_SLVectorCartesian.py`: **7 passed on each rank**;
- the coupled run completed all steps with bounded temperature and unchanged finite heat-flux diagnostics.

The vector SLCN regression is included because it protects the field-0 sub-DM mapping that this patch deliberately retains. RSS is allocator- and platform-dependent, so the performance evidence is reported here rather than encoded as a brittle CI threshold.
